### PR TITLE
Feat: Monitoring summary in batch with form grouping

### DIFF
--- a/app/src/pages/FormData/FormDataDetails.js
+++ b/app/src/pages/FormData/FormDataDetails.js
@@ -12,7 +12,10 @@ import { QUESTION_TYPES } from '../../lib/constants';
 const ImageView = ({ label, uri, textTestID, imageTestID }) => {
   // get base path from http://example.com/api/v2/any/ to http://example.com
   const baseURL = api.getConfig().baseURL?.replace(/\/api\/v\d+\/.*$/, '');
-  const imageURL = !uri?.includes('file://') && !uri?.startsWith('http') ? `${baseURL}${uri}` : uri;
+  const imageURL =
+    !uri?.includes('file://') && !uri?.startsWith('http') && !uri.startsWith('data:image')
+      ? `${baseURL}${uri}`
+      : uri;
   return (
     <View style={styles.containerImage}>
       <Text style={styles.title} testID={textTestID}>

--- a/backend/api/v1/v1_approval/serializers.py
+++ b/backend/api/v1/v1_approval/serializers.py
@@ -514,6 +514,8 @@ class ListBatchSerializer(serializers.ModelSerializer):
 
 class ListBatchSummarySerializer(serializers.ModelSerializer):
     id = serializers.ReadOnlyField(source="question.id")
+    form = serializers.ReadOnlyField(source="question.form_id")
+    form_name = serializers.ReadOnlyField(source="question.form.name")
     question = serializers.ReadOnlyField(source="question.label")
     type = serializers.SerializerMethodField()
     value = serializers.SerializerMethodField()
@@ -557,7 +559,7 @@ class ListBatchSummarySerializer(serializers.ModelSerializer):
 
     class Meta:
         model = Answers
-        fields = ["id", "question", "type", "value"]
+        fields = ["id", "form", "form_name", "question", "type", "value"]
 
 
 class ListBatchCommentSerializer(serializers.ModelSerializer):
@@ -645,6 +647,10 @@ class CreateBatchSerializer(serializers.Serializer):
                         "Registration data must be included in the batch "
                         "if it is pending."
                     )
+            if item.form.parent and not item.parent:
+                raise ValidationError(
+                    "Monitoring data must have a parent registration data."
+                )
         return data
 
     def validate_files(self, files):

--- a/backend/api/v1/v1_approval/tests/tests_batch_details.py
+++ b/backend/api/v1/v1_approval/tests/tests_batch_details.py
@@ -88,6 +88,8 @@ class DataBatchDetailsTestCase(TestCase, ProfileTestHelperMixin):
             list(response_json[0]),
             [
                 "id",
+                "form",
+                "form_name",
                 "question",
                 "type",
                 "value",

--- a/backend/api/v1/v1_approval/tests/tests_create_batch.py
+++ b/backend/api/v1/v1_approval/tests/tests_create_batch.py
@@ -3,6 +3,7 @@ from django.test.utils import override_settings
 from django.core.management import call_command
 from io import StringIO
 from api.v1.v1_data.models import FormData
+from api.v1.v1_forms.models import Forms
 from api.v1.v1_profile.models import Administration
 from api.v1.v1_profile.tests.mixins import ProfileTestHelperMixin
 
@@ -277,3 +278,38 @@ class CreateDataBatchTestCase(TestCase, ProfileTestHelperMixin):
             HTTP_AUTHORIZATION=f"Bearer {self.token}",
         )
         self.assertEqual(response.status_code, 201)
+
+    def test_create_batch_with_monitoring_data_without_parent(self):
+        # Get a monitoring form (form with parent)
+        monitoring_form = Forms.objects.filter(
+            parent__isnull=False,
+        ).first()
+        self.assertIsNotNone(monitoring_form, "No monitoring form found")
+        # Create monitoring data without a parent registration data
+        orphan_data = FormData.objects.create(
+            name="Orphan Monitoring Data",
+            geo=[0, 0],
+            form=monitoring_form,
+            administration=self.data.administration,
+            created_by=self.submitter,
+            parent=None,
+            is_pending=True,
+        )
+        payload = {
+            "name": "Test Batch with Orphan Monitoring",
+            "comment": "This batch contains monitoring data without parent",
+            "data": [orphan_data.id],
+        }
+        response = self.client.post(
+            "/api/v1/batch",
+            payload,
+            content_type="application/json",
+            HTTP_AUTHORIZATION=f"Bearer {self.token}",
+        )
+        self.assertEqual(response.status_code, 400)
+        self.assertIn("detail", response.json())
+        error_data = response.json()["detail"]["data"]
+        self.assertIn(
+            "Monitoring data must have a parent registration data.",
+            error_data,
+        )

--- a/backend/api/v1/v1_approval/views.py
+++ b/backend/api/v1/v1_approval/views.py
@@ -37,7 +37,7 @@ from api.v1.v1_forms.constants import (
 )
 from api.v1.v1_forms.models import Questions
 from api.v1.v1_users.models import SystemUser
-from api.v1.v1_data.models import Answers
+from api.v1.v1_data.models import Answers, FormData
 from mis.settings import REST_FRAMEWORK
 from utils.custom_permissions import (
     IsSuperAdmin,
@@ -329,12 +329,17 @@ class BatchSummaryView(APIView):
     )
     def get(self, request, batch_id, version):
         batch = get_object_or_404(DataBatch, pk=batch_id)
-        # Get questions for option and multiple_option types
+        # Get form IDs from data in this batch
+        batch_form_ids = FormData.objects.filter(
+            data_batch_list__batch=batch
+        ).values_list("form_id", flat=True).distinct()
+        # Get questions scoped to batch forms
         questions = Questions.objects.filter(
+            form_id__in=batch_form_ids,
             type__in=[
                 QuestionTypes.option,
                 QuestionTypes.multiple_option,
-            ]
+            ],
         )
         # Get all answers for these questions in the batch
         answers = Answers.objects.filter(

--- a/backend/api/v1/v1_data/serializers.py
+++ b/backend/api/v1/v1_data/serializers.py
@@ -582,12 +582,12 @@ class ListPendingFormDataSerializer(serializers.ModelSerializer):
         if instance.parent:
             return ParentFormDataSerializer(instance=instance.parent).data
         if instance.form.parent and not instance.parent:
-            return ParentFormDataSerializer(
-                instance=FormData(
-                    id=None,
-                    name=None,
-                )
-            ).data
+            return {
+                "id": None,
+                "name": None,
+                "form": None,
+                "is_pending": None,
+            }
         return None
 
     class Meta:

--- a/backend/api/v1/v1_data/serializers.py
+++ b/backend/api/v1/v1_data/serializers.py
@@ -579,6 +579,13 @@ class ListPendingFormDataSerializer(serializers.ModelSerializer):
     def get_parent(self, instance: FormData):
         if instance.parent:
             return ParentFormDataSerializer(instance=instance.parent).data
+        if instance.form.parent and not instance.parent:
+            return ParentFormDataSerializer(
+                instance=FormData(
+                    id=None,
+                    name=None,
+                )
+            ).data
         return None
 
     class Meta:

--- a/frontend/src/lib/columns.js
+++ b/frontend/src/lib/columns.js
@@ -117,19 +117,22 @@ export const columnsPending = [
     title: "Type",
     dataIndex: "parent",
     key: "parent",
-    render: (parent) =>
-      parent?.id ? (
-        <Tag color="orange">Monitoring</Tag>
-      ) : (
-        <Tag color="purple">Registration</Tag>
-      ),
+    render: (parent) => {
+      if (parent === null) {
+        return <Tag color="purple">Registration</Tag>;
+      }
+      if (parent?.id) {
+        return <Tag color="orange">Monitoring</Tag>;
+      }
+      return <Tag color="red">INVALID</Tag>;
+    },
   },
   {
     title: "Name",
     dataIndex: "name",
     key: "name",
     render: (name, row) =>
-      row?.parent ? (
+      row?.parent?.id ? (
         row.parent.is_pending ? (
           <div>{row.parent.name}</div>
         ) : (

--- a/frontend/src/pages/submissions/UploadDetail.jsx
+++ b/frontend/src/pages/submissions/UploadDetail.jsx
@@ -21,51 +21,70 @@ import { getTimeDifferenceText } from "../../util/date";
 import UploadAttachmentModal from "./UploadAttachmentModal";
 const { TabPane } = Tabs;
 
-const getSummaryColumns = (data) => [
-  {
-    title: "Form",
-    dataIndex: "form_name",
-    key: "form_name",
-    width: "20%",
-    onCell: (record) => {
-      const formRows = data.filter((d) => d.form === record.form);
-      const firstRow = formRows[0];
-      if (record.key === firstRow.key) {
-        return {
-          rowSpan: formRows.length,
-          style: { verticalAlign: "top" },
-        };
+const getSummaryColumns = (data) => {
+  const uniqueForms = new Set(data.map((d) => d.form));
+  const hasMultipleForms = uniqueForms.size > 1;
+
+  const formColumn = [];
+  if (hasMultipleForms) {
+    // Precompute rowSpan map: { [key]: rowSpan } for first row of each form
+    const spanMap = {};
+    const formCount = {};
+    const formFirstKey = {};
+    data.forEach((d) => {
+      formCount[d.form] = (formCount[d.form] || 0) + 1;
+      if (!formFirstKey[d.form]) {
+        formFirstKey[d.form] = d.key;
       }
-      return { rowSpan: 0 };
+    });
+    Object.keys(formFirstKey).forEach((form) => {
+      spanMap[formFirstKey[form]] = formCount[form];
+    });
+    formColumn.push({
+      title: "Form",
+      dataIndex: "form_name",
+      key: "form_name",
+      width: "20%",
+      onCell: (record) => {
+        const rowSpan = spanMap[record.key];
+        if (rowSpan) {
+          return { rowSpan, style: { verticalAlign: "top" } };
+        }
+        return { rowSpan: 0 };
+      },
+    });
+  }
+
+  return [
+    ...formColumn,
+    {
+      title: "Question",
+      dataIndex: "question",
+      key: "question",
+      width: hasMultipleForms ? "30%" : "50%",
     },
-  },
-  {
-    title: "Question",
-    dataIndex: "question",
-    key: "question",
-    width: "30%",
-  },
-  {
-    title: "Value",
-    dataIndex: "value",
-    className: "blue",
-    render: (value, row) => {
-      if (row.type === "Option" || row.type === "Multiple_Option") {
-        const filtered = value
-          .filter((x) => x.total)
-          .map((val) => `${val.type} - (${val.total})`);
-        return (
-          <ul className="option-list">
-            {filtered.map((d, di) => (
-              <li key={di}>{d}</li>
-            ))}
-          </ul>
-        );
-      }
-      return value;
+    {
+      title: "Value",
+      dataIndex: "value",
+      className: "blue",
+      render: (value, row) => {
+        if (row.type === "Option" || row.type === "Multiple_Option") {
+          const filtered = value
+            .filter((x) => x.total)
+            .map((val) => `${val.type} - (${val.total})`);
+          return (
+            <ul className="option-list">
+              {filtered.map((d, di) => (
+                <li key={di}>{d}</li>
+              ))}
+            </ul>
+          );
+        }
+        return value;
+      },
     },
-  },
-];
+  ];
+};
 
 const UploadDetail = ({ record: batch, setReload }) => {
   const [values, setValues] = useState([]);

--- a/frontend/src/pages/submissions/UploadDetail.jsx
+++ b/frontend/src/pages/submissions/UploadDetail.jsx
@@ -21,12 +21,29 @@ import { getTimeDifferenceText } from "../../util/date";
 import UploadAttachmentModal from "./UploadAttachmentModal";
 const { TabPane } = Tabs;
 
-const summaryColumns = [
+const getSummaryColumns = (data) => [
+  {
+    title: "Form",
+    dataIndex: "form_name",
+    key: "form_name",
+    width: "20%",
+    onCell: (record) => {
+      const formRows = data.filter((d) => d.form === record.form);
+      const firstRow = formRows[0];
+      if (record.key === firstRow.key) {
+        return {
+          rowSpan: formRows.length,
+          style: { verticalAlign: "top" },
+        };
+      }
+      return { rowSpan: 0 };
+    },
+  },
   {
     title: "Question",
     dataIndex: "question",
     key: "question",
-    width: "50%",
+    width: "30%",
   },
   {
     title: "Value",
@@ -34,12 +51,12 @@ const summaryColumns = [
     className: "blue",
     render: (value, row) => {
       if (row.type === "Option" || row.type === "Multiple_Option") {
-        const data = value
+        const filtered = value
           .filter((x) => x.total)
           .map((val) => `${val.type} - (${val.total})`);
         return (
           <ul className="option-list">
-            {data.map((d, di) => (
+            {filtered.map((d, di) => (
               <li key={di}>{d}</li>
             ))}
           </ul>
@@ -53,7 +70,7 @@ const summaryColumns = [
 const UploadDetail = ({ record: batch, setReload }) => {
   const [values, setValues] = useState([]);
   const [rawValues, setRawValues] = useState([]);
-  const [columns, setColumns] = useState(summaryColumns);
+  const [columns, setColumns] = useState([]);
   const [loading, setLoading] = useState(true);
   const [dataLoading, setDataLoading] = useState(null);
   const [saving, setSaving] = useState(null);
@@ -151,7 +168,7 @@ const UploadDetail = ({ record: batch, setReload }) => {
       return;
     }
     if (e === "data-summary") {
-      setColumns(summaryColumns);
+      setColumns(getSummaryColumns(values));
     } else {
       setExpandedRowKeys([]);
       setColumns([...columnsRawData, Table.EXPAND_COLUMN]);
@@ -168,7 +185,7 @@ const UploadDetail = ({ record: batch, setReload }) => {
           const data = res.data.map((r, i) => {
             return { key: `Q-${i}`, ...r };
           });
-          setColumns(summaryColumns);
+          setColumns(getSummaryColumns(data));
           setValues(data);
           setLoading(false);
         })

--- a/frontend/src/pages/submissions/UploadDetail.jsx
+++ b/frontend/src/pages/submissions/UploadDetail.jsx
@@ -201,7 +201,8 @@ const UploadDetail = ({ record: batch, setReload }) => {
       api
         .get(`/batch/summary/${batch.id}`)
         .then((res) => {
-          const data = res.data.map((r, i) => {
+          const sorted = [...res.data].sort((a, b) => a.form - b.form);
+          const data = sorted.map((r, i) => {
             return { key: `Q-${i}`, ...r };
           });
           setColumns(getSummaryColumns(data));


### PR DESCRIPTION
## Problem

The batch summary API had two issues:
1. **Wrong question scope** — Questions were queried globally across all forms, not scoped to the forms in the batch. This meant monitoring form questions were missed.
2. **No form context** — The summary response didn't include which form each question belongs to, making it impossible to visually distinguish registration vs monitoring questions.
3. **Orphan monitoring data** — Monitoring data without a parent registration could be submitted in a batch without validation.

## Changes

### Backend: Scope batch summary to batch forms (`views.py`, `serializers.py`)
- Scope questions query to forms present in the batch data (`form_id__in=batch_form_ids`)
- Add `form` (ID) and `form_name` fields to `ListBatchSummarySerializer`
- Update test to include new fields in response assertion

### Backend: Monitoring data validation (`serializers.py`)
- Add validation in `CreateBatchSerializer`: reject monitoring data (form with parent) that has no parent registration data
- Handle orphan monitoring data in `ListPendingFormDataSerializer` by returning empty parent object

### Backend: Test coverage (`tests_create_batch.py`)
- Add `test_create_batch_with_monitoring_data_without_parent` — verifies 400 response with appropriate error message

### Frontend: Group summary by form name (`UploadDetail.jsx`)
- Replace static `summaryColumns` with `getSummaryColumns(data)` function
- Add "Form" column with `rowSpan`-based grouping to merge cells by form
- Apply `verticalAlign: top` on merged form cells
- Rename shadowed `data` variable to `filtered` in render

### Frontend: Invalid monitoring tag (`columns.js`)
- Fix parent checking logic to use `parent?.id` instead of truthy `parent`
- Show red "INVALID" tag for monitoring data without parent registration

## Files changed (7)

| File | What changed |
|------|-------------|
| `backend/api/v1/v1_approval/views.py` | Scope questions to batch form IDs |
| `backend/api/v1/v1_approval/serializers.py` | Add `form`/`form_name` fields, monitoring parent validation |
| `backend/api/v1/v1_data/serializers.py` | Handle orphan monitoring in pending data serializer |
| `backend/api/v1/v1_approval/tests/tests_batch_details.py` | Update expected response fields |
| `backend/api/v1/v1_approval/tests/tests_create_batch.py` | Add orphan monitoring validation test |
| `frontend/src/pages/submissions/UploadDetail.jsx` | Group summary questions by form with rowSpan |
| `frontend/src/lib/columns.js` | Fix parent check, add INVALID tag |

## Test plan

- [ ] Create batch with registration + monitoring data — summary shows questions grouped by form name
- [ ] Create batch with registration only — summary shows single form group
- [ ] Attempt to create batch with orphan monitoring data (no parent) — returns 400 error
- [ ] Verify INVALID tag displays for monitoring data without parent in submissions list
- [ ] Backend tests pass: `python manage.py test api.v1.v1_approval.tests`

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1213567280975745