### PR TITLE
Download filtered monitoring data by date range

### DIFF
--- a/backend/api/v1/v1_jobs/job.py
+++ b/backend/api/v1/v1_jobs/job.py
@@ -139,6 +139,7 @@ def download_data(
                     item["datapoint_name"] = d.name
                     item["created_at"] = d.to_data_frame.get("created_at")
                     item["created_by"] = d.created_by.get_full_name()
+                    item["updated_at"] = dl.to_data_frame.get("created_at")
                     item["updated_by"] = dl.created_by.get_full_name()
             data_items.append(item)
         if download_type == DataDownloadTypes.all:
@@ -155,6 +156,7 @@ def download_data(
                         "datapoint_name": d.name,
                         "created_at": d.to_data_frame.get("created_at"),
                         "created_by": d.created_by.get_full_name(),
+                        "updated_at": dl.to_data_frame.get("created_at"),
                         "updated_by": dl.created_by.get_full_name(),
                     })
         if d.children.filter(

--- a/backend/api/v1/v1_jobs/job.py
+++ b/backend/api/v1/v1_jobs/job.py
@@ -1,9 +1,11 @@
 import logging
 import os
+from datetime import datetime, time, timedelta
 from dateutil import parser
 from django_q.models import Task
 
 import pandas as pd
+from django.conf import settings
 from django.utils import timezone
 from django_q.tasks import async_task
 from api.v1.v1_jobs.administrations_bulk_upload import (
@@ -44,19 +46,81 @@ from utils.report_generator import generate_datapoint_report
 logger = logging.getLogger(__name__)
 
 
+def _build_date_filter(date_from=None, date_to=None):
+    """Build created__gte / created__lt filter kwargs from date strings."""
+    date_filter = {}
+    if date_from:
+        start_date = parser.parse(date_from)
+        start_datetime = datetime.combine(start_date, time.min)
+        if settings.USE_TZ:
+            start_datetime = timezone.make_aware(start_datetime)
+        date_filter["created__gte"] = start_datetime
+    if date_to:
+        end_date = parser.parse(date_to)
+        end_datetime = datetime.combine(
+            end_date + timedelta(days=1), time.min
+        )
+        if settings.USE_TZ:
+            end_datetime = timezone.make_aware(end_datetime)
+        date_filter["created__lt"] = end_datetime
+    return date_filter
+
+
 def download_data(
     form: Forms,
     administration_ids: list = None,
     download_type: str = DataDownloadTypes.recent,
-    child_form_ids: list = []
+    child_form_ids: list = [],
+    date_from: str = None,
+    date_to: str = None,
 ) -> list:
+    has_date_filter = date_from or date_to
+    date_filter = _build_date_filter(date_from, date_to)
+
     filter_data = {
         "is_pending": False,
         "is_draft": False,
     }
     if administration_ids:
         filter_data["administration_id__in"] = administration_ids
-    data = form.form_form_data.filter(**filter_data).order_by("id").all()
+
+    if has_date_filter and child_form_ids:
+        # Filter children by date, include their parents regardless
+        child_filter = {
+            "is_pending": False,
+            "is_draft": False,
+            "form_id__in": child_form_ids,
+            **date_filter,
+        }
+        if administration_ids:
+            child_filter["administration_id__in"] = administration_ids
+        matched_children = FormData.objects.filter(**child_filter)
+        parent_ids_from_children = set(
+            matched_children.values_list("parent_id", flat=True)
+        )
+        # Parents in date range themselves
+        parent_date_filter = {**filter_data, **date_filter}
+        parent_ids_in_range = set(
+            form.form_form_data.filter(**parent_date_filter)
+            .values_list("id", flat=True)
+        )
+        # Union: parents with in-range children OR in-range themselves
+        all_parent_ids = parent_ids_from_children | parent_ids_in_range
+        data = form.form_form_data.filter(
+            id__in=all_parent_ids, **filter_data
+        ).order_by("id").all()
+    elif has_date_filter:
+        # No child forms — filter parents directly by date
+        filter_data.update(date_filter)
+        data = form.form_form_data.filter(
+            **filter_data
+        ).order_by("id").all()
+    else:
+        # No date filter — existing behavior
+        data = form.form_form_data.filter(
+            **filter_data
+        ).order_by("id").all()
+
     data_items = []
     for d in data:
         if download_type == DataDownloadTypes.recent:
@@ -66,6 +130,7 @@ def download_data(
                     form_id=child_form,
                     is_pending=False,
                     is_draft=False,
+                    **date_filter,
                 ).last()
                 if dl:
                     # merge parent and child data
@@ -82,6 +147,7 @@ def download_data(
                     form_id=child_form,
                     is_pending=False,
                     is_draft=False,
+                    **date_filter,
                 ).all():
                     data_items.append({
                         **d.to_data_frame,
@@ -94,6 +160,7 @@ def download_data(
         if d.children.filter(
             is_pending=False,
             is_draft=False,
+            **date_filter,
         ).count() == 0 and download_type == DataDownloadTypes.all:
             data_items.append(d.to_data_frame)
     return data_items
@@ -120,6 +187,8 @@ def generate_data_sheet(
     download_type: str = DataDownloadTypes.recent,
     use_label: bool = True,
     child_form_ids: list = [],
+    date_from: str = None,
+    date_to: str = None,
 ) -> None:
     questions = get_question_names(form=form)
     if len(child_form_ids):
@@ -131,6 +200,8 @@ def generate_data_sheet(
         administration_ids=administration_ids,
         download_type=download_type,
         child_form_ids=child_form_ids,
+        date_from=date_from,
+        date_to=date_to,
     )
     if len(data):
         df = pd.DataFrame(data)
@@ -222,6 +293,8 @@ def job_generate_data_download(job_id, **kwargs):
     download_type = kwargs.get("download_type", DataDownloadTypes.recent)
     use_label = kwargs.get("use_label", True)
     child_form_ids = job.info.get("child_form_ids", [])
+    date_from = kwargs.get("date_from")
+    date_to = kwargs.get("date_to")
 
     writer = pd.ExcelWriter(file_path, engine="xlsxwriter")
     generate_data_sheet(
@@ -231,6 +304,8 @@ def job_generate_data_download(job_id, **kwargs):
         download_type=download_type,
         use_label=use_label,
         child_form_ids=child_form_ids,
+        date_from=date_from,
+        date_to=date_to,
     )
 
     monitoring_forms = form.children.filter(pk__in=child_form_ids).all()
@@ -256,6 +331,13 @@ def job_generate_data_download(job_id, **kwargs):
             ),
         },
     ]
+    if date_from or date_to:
+        date_range_str = (
+            f"{date_from or 'beginning'} to {date_to or 'present'}"
+        )
+        context.append(
+            {"context": "Date Range Filter", "value": date_range_str}
+        )
 
     context = (
         pd.DataFrame(context).groupby(["context", "value"], sort=False).first()

--- a/backend/api/v1/v1_jobs/job.py
+++ b/backend/api/v1/v1_jobs/job.py
@@ -70,10 +70,12 @@ def download_data(
     form: Forms,
     administration_ids: list = None,
     download_type: str = DataDownloadTypes.recent,
-    child_form_ids: list = [],
+    child_form_ids: list = None,
     date_from: str = None,
     date_to: str = None,
 ) -> list:
+    if child_form_ids is None:
+        child_form_ids = []
     has_date_filter = date_from or date_to
     date_filter = _build_date_filter(date_from, date_to)
 
@@ -131,7 +133,7 @@ def download_data(
                     is_pending=False,
                     is_draft=False,
                     **date_filter,
-                ).last()
+                ).order_by("-created").first()
                 if dl:
                     # merge parent and child data
                     item = {**item, **dl.to_data_frame}
@@ -143,13 +145,15 @@ def download_data(
                     item["updated_by"] = dl.created_by.get_full_name()
             data_items.append(item)
         if download_type == DataDownloadTypes.all:
+            has_children = False
             for child_form in child_form_ids:
                 for dl in d.children.filter(
                     form_id=child_form,
                     is_pending=False,
                     is_draft=False,
                     **date_filter,
-                ).all():
+                ).order_by("created").all():
+                    has_children = True
                     data_items.append({
                         **d.to_data_frame,
                         **dl.to_data_frame,
@@ -159,12 +163,8 @@ def download_data(
                         "updated_at": dl.to_data_frame.get("created_at"),
                         "updated_by": dl.created_by.get_full_name(),
                     })
-        if d.children.filter(
-            is_pending=False,
-            is_draft=False,
-            **date_filter,
-        ).count() == 0 and download_type == DataDownloadTypes.all:
-            data_items.append(d.to_data_frame)
+            if not has_children:
+                data_items.append(d.to_data_frame)
     return data_items
 
 
@@ -188,10 +188,12 @@ def generate_data_sheet(
     administration_ids: list = None,
     download_type: str = DataDownloadTypes.recent,
     use_label: bool = True,
-    child_form_ids: list = [],
+    child_form_ids: list = None,
     date_from: str = None,
     date_to: str = None,
 ) -> None:
+    if child_form_ids is None:
+        child_form_ids = []
     questions = get_question_names(form=form)
     if len(child_form_ids):
         child_forms = form.children.filter(id__in=child_form_ids).all()

--- a/backend/api/v1/v1_jobs/management/commands/job_download.py
+++ b/backend/api/v1/v1_jobs/management/commands/job_download.py
@@ -29,6 +29,12 @@ class Command(BaseCommand):
         parser.add_argument(
             "-c", "--child_form_ids", nargs="*", default=[], type=int
         )
+        parser.add_argument(
+            "-df", "--date_from", nargs="?", default=None, type=str
+        )
+        parser.add_argument(
+            "-dt", "--date_to", nargs="?", default=None, type=str
+        )
 
     def handle(self, *args, **options):
         administration = options.get("administration")
@@ -64,12 +70,16 @@ class Command(BaseCommand):
                         )
                     )
                     return
+        date_from = options.get("date_from")
+        date_to = options.get("date_to")
         info = {
             "form_id": form_id,
             "administration": administration if administration > 0 else None,
             "download_type": download_type,
             "use_label": use_label == 1,
             "child_form_ids": child_form_ids,
+            "date_from": date_from,
+            "date_to": date_to,
         }
         form_name = form.name.replace(" ", "_").lower()
         today = timezone.datetime.today().strftime("%y%m%d")

--- a/backend/api/v1/v1_jobs/serializers.py
+++ b/backend/api/v1/v1_jobs/serializers.py
@@ -34,6 +34,8 @@ class DownloadDataRequestSerializer(serializers.Serializer):
         ),
         required=False,
     )
+    date_from = serializers.DateField(required=False, allow_null=True)
+    date_to = serializers.DateField(required=False, allow_null=True)
 
     def __init__(self, **kwargs):
         super().__init__(**kwargs)
@@ -42,6 +44,15 @@ class DownloadDataRequestSerializer(serializers.Serializer):
             "administration_id"
         ).queryset = Administration.objects.all()
         self.fields.get("child_form_ids").child.queryset = Forms.objects.all()
+
+    def validate(self, data):
+        date_from = data.get("date_from")
+        date_to = data.get("date_to")
+        if date_from and date_to and date_from > date_to:
+            raise serializers.ValidationError(
+                "date_from must be before or equal to date_to"
+            )
+        return data
 
 
 class DownloadListSerializer(serializers.ModelSerializer):

--- a/backend/api/v1/v1_jobs/tests/tests_download_date_filter.py
+++ b/backend/api/v1/v1_jobs/tests/tests_download_date_filter.py
@@ -1,0 +1,408 @@
+from datetime import timedelta
+from io import StringIO
+from django.core.management import call_command
+from django.test import TestCase
+from django.test.utils import override_settings
+from django.utils import timezone
+from api.v1.v1_data.models import FormData
+from api.v1.v1_forms.models import Forms
+from api.v1.v1_jobs.job import download_data
+from api.v1.v1_jobs.constants import DataDownloadTypes
+from api.v1.v1_profile.management.commands import administration_seeder
+from api.v1.v1_users.models import SystemUser
+from api.v1.v1_profile.tests.mixins import ProfileTestHelperMixin
+from rest_framework import status
+
+
+@override_settings(USE_TZ=False)
+class DownloadDateFilterTestCase(TestCase, ProfileTestHelperMixin):
+    def call_command(self, *args, **kwargs):
+        out = StringIO()
+        call_command(
+            "fake_complete_data_seeder",
+            "--test=true",
+            *args,
+            stdout=out,
+            stderr=StringIO(),
+            **kwargs,
+        )
+        return out.getvalue()
+
+    def setUp(self):
+        call_command("form_seeder", "--test")
+        rows = [
+            {
+                "code_0": "ID",
+                "National_0": "Indonesia",
+                "code_1": "ID-JK",
+                "Province_1": "Jakarta",
+                "code_2": "ID-JK-JKE",
+                "District_2": "East Jakarta",
+                "code_3": "ID-JK-JKE-KJ",
+                "Subdistrict_3": "Kramat Jati",
+                "code_4": "ID-JK-JKE-KJ-CW",
+                "Village_4": "Cawang",
+            },
+            {
+                "code_0": "ID",
+                "National_0": "Indonesia",
+                "code_1": "ID-JK",
+                "Province_1": "Jakarta",
+                "code_2": "ID-JK-JKW",
+                "District_2": "West Jakarta",
+                "code_3": "ID-JK-JKW-KJ",
+                "Subdistrict_3": "Kebon Jeruk",
+                "code_4": "ID-JK-JKW-KJ-KJ",
+                "Village_4": "Kebon Jeruk",
+            },
+            {
+                "code_0": "ID",
+                "National_0": "Indonesia",
+                "code_1": "ID-YO",
+                "Province_1": "Yogyakarta",
+                "code_2": "ID-YO-SL",
+                "District_2": "Sleman",
+                "code_3": "ID-YO-SL-ST",
+                "Subdistrict_3": "Seturan",
+                "code_4": "ID-YO-SL-ST-CB",
+                "Village_4": "Cepit Baru",
+            },
+            {
+                "code_0": "ID",
+                "National_0": "Indonesia",
+                "code_1": "ID-YO",
+                "Province_1": "Yogyakarta",
+                "code_2": "ID-YO-BT",
+                "District_2": "Bantul",
+                "code_3": "ID-YO-BT-BT",
+                "Subdistrict_3": "Bantul",
+                "code_4": "ID-YO-BT-BT-BT",
+                "Village_4": "Bantul",
+            },
+        ]
+        administration_seeder.seed_administration_test(rows=rows)
+        call_command("default_roles_seeder", "--test", 1)
+        self.client.post(
+            "/api/v1/login",
+            {"email": "admin@akvo.org", "password": "Test105*"},
+            content_type="application/json",
+        )
+        self.call_command("-r", 2, "--test", True)
+
+        self.form = Forms.objects.get(pk=1)
+        self.child_form = self.form.children.first()
+        self.child_form_ids = list(
+            self.form.children.values_list("id", flat=True)
+        )
+        self.user = SystemUser.objects.filter(
+            email="admin@akvo.org"
+        ).first()
+
+        # Set known dates on test data for predictable filtering
+        now = timezone.now()
+        self.today = now.date()
+        self.yesterday = (now - timedelta(days=1)).date()
+        self.three_days_ago = (now - timedelta(days=3)).date()
+        self.five_days_ago = (now - timedelta(days=5)).date()
+
+        # Get parent form data and set different created dates
+        parents = list(
+            self.form.form_form_data.filter(
+                is_pending=False, is_draft=False
+            ).order_by("id").all()
+        )
+        self.assertTrue(
+            len(parents) >= 2, "Need at least 2 parent records"
+        )
+        self.parent_old = parents[0]
+        self.parent_recent = parents[1]
+
+        # Set parent_old to 5 days ago, parent_recent to yesterday
+        FormData.objects.filter(pk=self.parent_old.pk).update(
+            created=timezone.now() - timedelta(days=5)
+        )
+        FormData.objects.filter(pk=self.parent_recent.pk).update(
+            created=timezone.now() - timedelta(days=1)
+        )
+
+        # Set children dates
+        old_children = list(
+            self.parent_old.children.filter(
+                is_pending=False, is_draft=False
+            ).all()
+        )
+        recent_children = list(
+            self.parent_recent.children.filter(
+                is_pending=False, is_draft=False
+            ).all()
+        )
+
+        # Old parent's children: set to yesterday (in range)
+        for child in old_children:
+            FormData.objects.filter(pk=child.pk).update(
+                created=timezone.now() - timedelta(days=1)
+            )
+
+        # Recent parent's children: set to today
+        for child in recent_children:
+            FormData.objects.filter(pk=child.pk).update(
+                created=timezone.now()
+            )
+
+        # Refresh from DB
+        self.parent_old.refresh_from_db()
+        self.parent_recent.refresh_from_db()
+
+    def test_download_without_date_range_returns_all(self):
+        """No date filter — existing behavior unchanged."""
+        result = download_data(
+            form=self.form,
+            download_type=DataDownloadTypes.recent,
+            child_form_ids=self.child_form_ids,
+        )
+        parents = self.form.form_form_data.filter(
+            is_pending=False, is_draft=False
+        )
+        self.assertEqual(len(result), parents.count())
+
+    def test_download_with_date_from_only(self):
+        """Data before date_from excluded."""
+        result = download_data(
+            form=self.form,
+            download_type=DataDownloadTypes.recent,
+            child_form_ids=[],
+            date_from=str(self.yesterday),
+        )
+        for item in result:
+            self.assertNotEqual(
+                item["id"], self.parent_old.id,
+                "Old parent should be excluded by date_from"
+            )
+
+    def test_download_with_date_to_only(self):
+        """Data after date_to excluded."""
+        result = download_data(
+            form=self.form,
+            download_type=DataDownloadTypes.recent,
+            child_form_ids=[],
+            date_to=str(self.five_days_ago),
+        )
+        for item in result:
+            self.assertNotEqual(
+                item["id"], self.parent_recent.id,
+                "Recent parent should be excluded by date_to"
+            )
+
+    def test_download_with_date_range(self):
+        """Only data within range included."""
+        result = download_data(
+            form=self.form,
+            download_type=DataDownloadTypes.recent,
+            child_form_ids=[],
+            date_from=str(self.three_days_ago),
+            date_to=str(self.today),
+        )
+        result_ids = [item["id"] for item in result]
+        self.assertIn(self.parent_recent.id, result_ids)
+        self.assertNotIn(self.parent_old.id, result_ids)
+
+    def test_download_date_boundary_inclusivity(self):
+        """Data on date_from and date_to dates are included."""
+        # Set parent to exactly yesterday
+        FormData.objects.filter(pk=self.parent_recent.pk).update(
+            created=timezone.now() - timedelta(days=1)
+        )
+        result = download_data(
+            form=self.form,
+            download_type=DataDownloadTypes.recent,
+            child_form_ids=[],
+            date_from=str(self.yesterday),
+            date_to=str(self.yesterday),
+        )
+        result_ids = [item["id"] for item in result]
+        self.assertIn(
+            self.parent_recent.id, result_ids,
+            "Data on boundary date should be included"
+        )
+
+    def test_child_date_triggers_parent_inclusion(self):
+        """Parent created outside range included via in-range children."""
+        # parent_old created 5 days ago (outside range)
+        # but its children were set to yesterday (in range)
+        # Get actual child form IDs from existing children
+        actual_child_form_ids = list(
+            self.parent_old.children.filter(
+                is_pending=False, is_draft=False
+            ).values_list("form_id", flat=True).distinct()
+        )
+        self.assertTrue(
+            len(actual_child_form_ids) > 0,
+            "parent_old must have children for this test"
+        )
+        # Verify children dates were set correctly
+        children = self.parent_old.children.filter(
+            is_pending=False, is_draft=False
+        )
+        for child in children:
+            child.refresh_from_db()
+            self.assertTrue(
+                child.created.date() >= self.three_days_ago,
+                f"Child {child.id} created={child.created.date()} "
+                f"should be >= {self.three_days_ago}"
+            )
+        result = download_data(
+            form=self.form,
+            download_type=DataDownloadTypes.recent,
+            child_form_ids=actual_child_form_ids,
+            date_from=str(self.three_days_ago),
+            date_to=str(self.today),
+        )
+        # When children are merged, the child id overwrites parent id
+        # in to_data_frame. Check by datapoint_name instead.
+        result_names = [item["datapoint_name"] for item in result]
+        self.assertIn(
+            self.parent_old.name, result_names,
+            "Parent should be included when its children "
+            "are in date range"
+        )
+
+    def test_out_of_range_children_excluded(self):
+        """Children created outside range not in output."""
+        actual_child_form_ids = list(
+            self.parent_old.children.filter(
+                is_pending=False, is_draft=False
+            ).values_list("form_id", flat=True).distinct()
+        )
+        # Set old parent's children to 5 days ago (out of range)
+        for child in self.parent_old.children.filter(
+            is_pending=False, is_draft=False
+        ).all():
+            FormData.objects.filter(pk=child.pk).update(
+                created=timezone.now() - timedelta(days=5)
+            )
+        result = download_data(
+            form=self.form,
+            download_type=DataDownloadTypes.recent,
+            child_form_ids=actual_child_form_ids,
+            date_from=str(self.yesterday),
+            date_to=str(self.today),
+        )
+        result_ids = [item["id"] for item in result]
+        # parent_old should NOT be included now
+        # (out of range itself, no in-range children)
+        self.assertNotIn(
+            self.parent_old.id, result_ids,
+            "Parent with no in-range children and itself "
+            "out of range should be excluded"
+        )
+
+    def test_download_with_date_range_and_administration(self):
+        """Both date range and administration filters applied."""
+        adm = self.parent_recent.administration
+        result = download_data(
+            form=self.form,
+            administration_ids=[adm.id],
+            download_type=DataDownloadTypes.recent,
+            child_form_ids=[],
+            date_from=str(self.three_days_ago),
+            date_to=str(self.today),
+        )
+        for item in result:
+            self.assertIn(adm.name, item["administration"])
+
+
+@override_settings(USE_TZ=False)
+class DownloadDateFilterAPITestCase(TestCase, ProfileTestHelperMixin):
+    def call_command(self, *args, **kwargs):
+        out = StringIO()
+        call_command(
+            "fake_complete_data_seeder",
+            "--test=true",
+            *args,
+            stdout=out,
+            stderr=StringIO(),
+            **kwargs,
+        )
+        return out.getvalue()
+
+    def setUp(self):
+        call_command("form_seeder", "--test")
+        rows = [
+            {
+                "code_0": "ID",
+                "National_0": "Indonesia",
+                "code_1": "ID-JK",
+                "Province_1": "Jakarta",
+                "code_2": "ID-JK-JKE",
+                "District_2": "East Jakarta",
+                "code_3": "ID-JK-JKE-KJ",
+                "Subdistrict_3": "Kramat Jati",
+                "code_4": "ID-JK-JKE-KJ-CW",
+                "Village_4": "Cawang",
+            },
+            {
+                "code_0": "ID",
+                "National_0": "Indonesia",
+                "code_1": "ID-JK",
+                "Province_1": "Jakarta",
+                "code_2": "ID-JK-JKW",
+                "District_2": "West Jakarta",
+                "code_3": "ID-JK-JKW-KJ",
+                "Subdistrict_3": "Kebon Jeruk",
+                "code_4": "ID-JK-JKW-KJ-KJ",
+                "Village_4": "Kebon Jeruk",
+            },
+            {
+                "code_0": "ID",
+                "National_0": "Indonesia",
+                "code_1": "ID-YO",
+                "Province_1": "Yogyakarta",
+                "code_2": "ID-YO-SL",
+                "District_2": "Sleman",
+                "code_3": "ID-YO-SL-ST",
+                "Subdistrict_3": "Seturan",
+                "code_4": "ID-YO-SL-ST-CB",
+                "Village_4": "Cepit Baru",
+            },
+            {
+                "code_0": "ID",
+                "National_0": "Indonesia",
+                "code_1": "ID-YO",
+                "Province_1": "Yogyakarta",
+                "code_2": "ID-YO-BT",
+                "District_2": "Bantul",
+                "code_3": "ID-YO-BT-BT",
+                "Subdistrict_3": "Bantul",
+                "code_4": "ID-YO-BT-BT-BT",
+                "Village_4": "Bantul",
+            },
+        ]
+        administration_seeder.seed_administration_test(rows=rows)
+        call_command("default_roles_seeder", "--test", 1)
+        self.client.post(
+            "/api/v1/login",
+            {"email": "admin@akvo.org", "password": "Test105*"},
+            content_type="application/json",
+        )
+        self.call_command("-r", 2, "--test", True)
+        self.user = SystemUser.objects.filter(
+            email="admin@akvo.org"
+        ).first()
+        self.token = self.get_auth_token(
+            email="admin@akvo.org", password="Test105*"
+        )
+
+    def test_invalid_date_range_returns_400(self):
+        """date_from > date_to should return 400."""
+        response = self.client.get(
+            "/api/v1/download/generate",
+            {
+                "form_id": 1,
+                "date_from": "2026-03-10",
+                "date_to": "2026-03-01",
+            },
+            HTTP_AUTHORIZATION=f"Bearer {self.token}",
+        )
+        self.assertEqual(
+            response.status_code, status.HTTP_400_BAD_REQUEST
+        )

--- a/backend/api/v1/v1_jobs/views.py
+++ b/backend/api/v1/v1_jobs/views.py
@@ -76,6 +76,18 @@ from utils.custom_serializer_fields import validate_serializers_message
             type={"type": "array", "items": {"type": "number"}},
             location=OpenApiParameter.QUERY,
         ),
+        OpenApiParameter(
+            name="date_from",
+            required=False,
+            type=OpenApiTypes.DATE,
+            location=OpenApiParameter.QUERY,
+        ),
+        OpenApiParameter(
+            name="date_to",
+            required=False,
+            type=OpenApiTypes.DATE,
+            location=OpenApiParameter.QUERY,
+        ),
     ],
     responses={
         (200, "application/json"): inline_serializer(
@@ -103,7 +115,7 @@ def download_generate(request, version):
         child.id
         for child in serializer.validated_data.get("child_form_ids", [])
     ]
-    result = call_command(
+    cmd_args = [
         "job_download",
         serializer.validated_data.get("form_id").id,
         request.user.id,
@@ -115,7 +127,14 @@ def download_generate(request, version):
         1 if serializer.validated_data.get("use_label") else 0,
         "-c",
         *child_forms,
-    )
+    ]
+    date_from = serializer.validated_data.get("date_from")
+    date_to = serializer.validated_data.get("date_to")
+    if date_from:
+        cmd_args.extend(["-df", str(date_from)])
+    if date_to:
+        cmd_args.extend(["-dt", str(date_to)])
+    result = call_command(*cmd_args)
     job = Jobs.objects.get(pk=result)
     data = {
         "task_id": job.task_id,

--- a/doc/claude/download-filtered-data-by-date-range.md
+++ b/doc/claude/download-filtered-data-by-date-range.md
@@ -1,0 +1,391 @@
+# Plan: Download Filtered Monitoring Data by Date Range (#182)
+
+## Context
+
+PR #174 added date range filtering to the Manage Data and Pending Submissions list views. However, the **data download (Excel export)** ignores these filters — when a user applies a date range and clicks "Export to Excel", all data is downloaded regardless of the active date filter.
+
+This plan adds date range support to the download flow so that exports respect the same filters applied to the data table.
+
+## Current Flow (No Date Filtering)
+
+```
+Frontend (DataFilters.js)
+  → GET /api/v1/download/generate?form_id=X&administration_id=Y&type=recent&child_form_ids=1,2
+    → views.py: download_generate()
+      → management command: job_download
+        → Creates Jobs record (info={form_id, administration, download_type, use_label, child_form_ids})
+        → Queues async task: job_generate_data_download(job_id, **kwargs)
+          → download_data(form, administration_ids, download_type, child_form_ids)
+            → FormData.filter(is_pending=False, is_draft=False, administration_id__in=...)
+```
+
+**Problem:** `download_data()` only filters by `is_pending`, `is_draft`, and `administration_id`. No date filtering exists.
+
+## Target Flow (With Date Range)
+
+```
+Frontend (DataFilters.js)
+  → GET /api/v1/download/generate?form_id=X&...&date_from=2026-01-01&date_to=2026-03-12
+    → views.py: download_generate() — passes date params
+      → management command: job_download — accepts -df/--date_from, -dt/--date_to
+        → Creates Jobs record (info={..., date_from, date_to})
+        → Queues async task: job_generate_data_download(job_id, **kwargs)
+          → download_data(form, ..., date_from=..., date_to=...)
+            → Filter children by date range, then include their parents
+```
+
+## Simulation: Date Range Filtering with Real Data
+
+### Test Data
+
+| id | form_id       | created_at | name      | parent_id |
+|----|---------------|------------|-----------|-----------|
+| 1  | 1749623934933 | 27/02/2026 | EPS #1    |           |
+| 2  | 1749632545233 | 03/03/2026 | EPS WQ #1 | 1         |
+| 3  | 1749624452908 | 03/03/2026 | EPS PC #1 | 1         |
+| 4  | 1749623934933 | 28/02/2026 | EPS #2    |           |
+| 5  | 1749623934933 | 02/03/2026 | EPS #3    |           |
+| 6  | 1749624452908 | 03/03/2026 | EPS PC #3 | 5         |
+
+- Registration form: `1749623934933` (ids 1, 4, 5)
+- Monitoring forms: `1749632545233` (WQ), `1749624452908` (PC)
+- **Filter:** date_from=2026-03-02, date_to=2026-03-06
+
+### Why Not Filter on Parent Only?
+
+If we filter parents by date range: only id=5 (EPS #3, created Mar 2) matches.
+Result: EPS #3 + EPS PC #3. **Missing:** EPS WQ #1 and EPS PC #1 (created Mar 3) because their parent EPS #1 was created Feb 27.
+
+A user filtering "March 2-6" expects to see monitoring submissions from that period, not just registrations.
+
+### Correct Approach: Filter Children by Date, Include Parents Regardless
+
+**Step 1:** Query child form data where `created` is in date range:
+- id=2 (EPS WQ #1, Mar 3) → parent_id=1
+- id=3 (EPS PC #1, Mar 3) → parent_id=1
+- id=6 (EPS PC #3, Mar 3) → parent_id=5
+
+**Step 2:** Collect parent IDs from matched children: {1, 5}
+
+**Step 3:** Also include parents whose own `created` is in range: {5}
+
+**Step 4:** Union of parent IDs: {1, 5}
+
+**Step 5:** For each parent, only include children that are in the date range.
+
+### Expected Output (download_type=recent)
+
+| datapoint_name | created_at | EPS WQ data | EPS PC data |
+|---|---|---|---|
+| EPS #1 | 27/02/2026 | EPS WQ #1 answers | EPS PC #1 answers |
+| EPS #3 | 02/03/2026 | *(no WQ data)* | EPS PC #3 answers |
+
+- **EPS #1** included because its children (WQ #1, PC #1) were created within the date range
+- **EPS #3** included because it was created within the date range AND has a child (PC #3) in range
+- **EPS #2** excluded: created outside range AND has no children in range
+
+### Expected Output (download_type=all)
+
+Same as above — all child submissions in the range are already shown (there's only one per child form per parent in this dataset).
+
+## Implementation Steps
+
+### Step 1: Backend — Add date params to `download_data()` and `generate_data_sheet()`
+
+**File:** `backend/api/v1/v1_jobs/job.py`
+
+Add `date_from` and `date_to` parameters. When child forms are involved, filter children by date and include their parents regardless (see simulation above).
+
+**Imports needed:** `from datetime import datetime, time, timedelta` and `from django.conf import settings`
+
+**Helper function** — build date filter kwargs (reuse pattern from PR #174):
+```python
+def _build_date_filter(date_from=None, date_to=None):
+    """Build created__gte / created__lt filter kwargs from date strings."""
+    date_filter = {}
+    if date_from:
+        start_date = parser.parse(date_from)
+        start_datetime = datetime.combine(start_date, time.min)
+        if settings.USE_TZ:
+            start_datetime = timezone.make_aware(start_datetime)
+        date_filter["created__gte"] = start_datetime
+    if date_to:
+        end_date = parser.parse(date_to)
+        end_datetime = datetime.combine(
+            end_date + timedelta(days=1), time.min
+        )
+        if settings.USE_TZ:
+            end_datetime = timezone.make_aware(end_datetime)
+        date_filter["created__lt"] = end_datetime
+    return date_filter
+```
+
+1. **`download_data()`** (line 47):
+   ```python
+   def download_data(
+       form: Forms,
+       administration_ids: list = None,
+       download_type: str = DataDownloadTypes.recent,
+       child_form_ids: list = [],
+       date_from: str = None,
+       date_to: str = None,
+   ) -> list:
+       has_date_filter = date_from or date_to
+       date_filter = _build_date_filter(date_from, date_to)
+
+       filter_data = {
+           "is_pending": False,
+           "is_draft": False,
+       }
+       if administration_ids:
+           filter_data["administration_id__in"] = administration_ids
+
+       if has_date_filter and child_form_ids:
+           # Filter children by date, include their parents
+           # Step 1: Find child data in date range
+           child_filter = {
+               "is_pending": False,
+               "is_draft": False,
+               "form_id__in": child_form_ids,
+               **date_filter,
+           }
+           if administration_ids:
+               child_filter["administration_id__in"] = administration_ids
+           matched_children = FormData.objects.filter(**child_filter)
+           parent_ids_from_children = set(
+               matched_children.values_list("parent_id", flat=True)
+           )
+           # Step 2: Parents in date range themselves
+           parent_date_filter = {**filter_data, **date_filter}
+           parent_ids_in_range = set(
+               form.form_form_data.filter(**parent_date_filter)
+               .values_list("id", flat=True)
+           )
+           # Step 3: Union — parents with in-range children OR in-range themselves
+           all_parent_ids = parent_ids_from_children | parent_ids_in_range
+           data = form.form_form_data.filter(
+               id__in=all_parent_ids, **filter_data
+           ).order_by("id").all()
+       elif has_date_filter:
+           # No child forms — filter parents directly by date
+           filter_data.update(date_filter)
+           data = form.form_form_data.filter(**filter_data).order_by("id").all()
+       else:
+           # No date filter — existing behavior
+           data = form.form_form_data.filter(**filter_data).order_by("id").all()
+
+       # Rest of function: iterate data and build data_items...
+       # When iterating children, also apply date filter:
+       data_items = []
+       for d in data:
+           if download_type == DataDownloadTypes.recent:
+               item = d.to_data_frame
+               for child_form in child_form_ids:
+                   child_qs = d.children.filter(
+                       form_id=child_form,
+                       is_pending=False,
+                       is_draft=False,
+                       **date_filter,  # Apply date filter to children too
+                   )
+                   dl = child_qs.last()
+                   if dl:
+                       item = {**item, **dl.to_data_frame}
+                       item["datapoint_name"] = d.name
+                       item["created_at"] = d.to_data_frame.get("created_at")
+                       item["created_by"] = d.created_by.get_full_name()
+                       item["updated_by"] = dl.created_by.get_full_name()
+               data_items.append(item)
+           if download_type == DataDownloadTypes.all:
+               for child_form in child_form_ids:
+                   for dl in d.children.filter(
+                       form_id=child_form,
+                       is_pending=False,
+                       is_draft=False,
+                       **date_filter,  # Apply date filter to children too
+                   ).all():
+                       data_items.append({...})
+           if d.children.filter(
+               is_pending=False,
+               is_draft=False,
+               **date_filter,  # Apply date filter here too
+           ).count() == 0 and download_type == DataDownloadTypes.all:
+               data_items.append(d.to_data_frame)
+       return data_items
+   ```
+
+   **Key points:**
+   - When `child_form_ids` + date filter: find children in range → get their parent IDs → union with parents in range
+   - When iterating children for each parent, also apply `**date_filter` so out-of-range children are excluded from the Excel output
+   - Use `created__lt = date_to + 1 day` (exclusive upper bound) to make `date_to` inclusive
+
+2. **`generate_data_sheet()`** (line 116): Pass `date_from`/`date_to` through to `download_data()`.
+
+3. **`job_generate_data_download()`** (line 192): Extract `date_from`/`date_to` from `kwargs` and pass to `generate_data_sheet()`. Also add date range info to the context sheet metadata.
+
+### Step 2: Backend — Add date params to serializer
+
+**File:** `backend/api/v1/v1_jobs/serializers.py`
+
+Add to `DownloadDataRequestSerializer`:
+```python
+date_from = serializers.DateField(required=False, allow_null=True)
+date_to = serializers.DateField(required=False, allow_null=True)
+```
+
+Add cross-field validation (same pattern as `ListFormDataRequestSerializer` in PR #174):
+```python
+def validate(self, data):
+    date_from = data.get("date_from")
+    date_to = data.get("date_to")
+    if date_from and date_to and date_from > date_to:
+        raise serializers.ValidationError(
+            "date_from must be before or equal to date_to"
+        )
+    return data
+```
+
+### Step 3: Backend — Add date params to management command
+
+**File:** `backend/api/v1/v1_jobs/management/commands/job_download.py`
+
+Add arguments:
+```python
+p.add_argument("-df", "--date_from", nargs="?", default=None, type=str)
+p.add_argument("-dt", "--date_to", nargs="?", default=None, type=str)
+```
+
+Store in job info:
+```python
+job_info = {
+    "form_id": form.id,
+    "administration": adm,
+    "download_type": download_type,
+    "use_label": use_label,
+    "child_form_ids": child_form_ids,
+    "date_from": date_from,
+    "date_to": date_to,
+}
+```
+
+Pass as kwargs to async task:
+```python
+task_id = async_task(
+    "api.v1.v1_jobs.job.job_generate_data_download",
+    new_job.id,
+    hook="api.v1.v1_jobs.job.job_generate_data_download_result",
+    administration=adm,
+    download_type=download_type,
+    use_label=use_label,
+    date_from=date_from,
+    date_to=date_to,
+)
+```
+
+### Step 4: Backend — Update view to pass date params
+
+**File:** `backend/api/v1/v1_jobs/views.py`
+
+In `download_generate()`, extract validated date params and pass to management command:
+```python
+date_from = serializer.validated_data.get("date_from")
+date_to = serializer.validated_data.get("date_to")
+
+# Pass to call_command
+options = {
+    "administration": administration_id or 0,
+    "type": download_type,
+    "use_label": use_label,
+    "child_form_ids": child_form_ids,
+}
+if date_from:
+    options["date_from"] = str(date_from)
+if date_to:
+    options["date_to"] = str(date_to)
+
+call_command("job_download", form_id, user.id, **options)
+```
+
+### Step 5: Backend — Update context sheet with date range info
+
+**File:** `backend/api/v1/v1_jobs/job.py` (in `job_generate_data_download`)
+
+Add date range to the Excel context sheet so users know what filter was applied:
+```python
+date_from = kwargs.get("date_from")
+date_to = kwargs.get("date_to")
+
+context = [
+    {"context": "Form Name", "value": form.name},
+    {"context": "Monitoring Form(s)", "value": ...},
+    {"context": "Download Date", "value": ...},
+    {"context": "Administration", "value": ...},
+]
+
+# Add date range context if filtered
+if date_from or date_to:
+    date_range_str = f"{date_from or 'beginning'} to {date_to or 'present'}"
+    context.append({"context": "Date Range Filter", "value": date_range_str})
+```
+
+### Step 6: Frontend — Pass date range to download API
+
+**File:** `frontend/src/components/filters/DataFilters.js`
+
+In the `export2Excel()` function, add date range params from store state:
+```javascript
+const { dateRange } = UIState.useState((s) => s);
+
+// In export2Excel():
+let url = `/download/generate?form_id=${selectedForm}`;
+if (hasParent) {
+    url += `&administration_id=${selectedAdm}`;
+}
+if (dateRange) {
+    url += `&date_from=${dateRange[0].format("YYYY-MM-DD")}`;
+    url += `&date_to=${dateRange[1].format("YYYY-MM-DD")}`;
+}
+if (childFormIds.length) {
+    url += `&child_form_ids=${childFormIds.join(",")}`;
+}
+```
+
+### Step 7: Backend — Tests
+
+**File:** `backend/api/v1/v1_jobs/tests/` (new or existing test file)
+
+Test cases:
+1. **Download with date_from only** — data before date_from excluded
+2. **Download with date_to only** — data after date_to excluded
+3. **Download with date range** — only data within range included
+4. **Download with invalid date range** (date_from > date_to) — returns 400
+5. **Download with date range + administration** — both filters applied
+6. **Download without date range** — existing behavior unchanged (regression)
+7. **Date boundary inclusivity** — data on date_from and date_to dates are included
+8. **Child date triggers parent inclusion** — parent created outside range is included because its child monitoring data was created within range (see simulation: EPS #1 included via EPS WQ #1 and EPS PC #1)
+9. **Out-of-range children excluded** — children created outside range are not in the Excel output even if their parent is included
+10. **Parent with no in-range children and itself out-of-range** — excluded entirely (see simulation: EPS #2)
+
+## Files to Modify
+
+| File | Change |
+|------|--------|
+| `backend/api/v1/v1_jobs/job.py` | Add `date_from`/`date_to` to `download_data()`, `generate_data_sheet()`, `job_generate_data_download()` |
+| `backend/api/v1/v1_jobs/serializers.py` | Add date fields + validation to `DownloadDataRequestSerializer` |
+| `backend/api/v1/v1_jobs/management/commands/job_download.py` | Add `-df`/`-dt` arguments, store in job info, pass to async task |
+| `backend/api/v1/v1_jobs/views.py` | Extract date params from serializer, pass to `call_command` |
+| `frontend/src/components/filters/DataFilters.js` | Include `dateRange` in download API call |
+| `backend/api/v1/v1_jobs/tests/` | Add test cases for date-filtered downloads |
+
+## Design Decisions
+
+1. **Filter on `created` field** — Matches PR #174 behavior for list views. The `created` field (auto_now_add) represents when data was submitted.
+
+2. **Inclusive date range** — `date_from` uses `>=`, `date_to` uses `< next day`. This matches PR #174's pattern and ensures both boundary dates are fully included.
+
+3. **Filter children by date, include parents regardless** — When child_form_ids are specified with a date range, the filter applies to monitoring (child) form `created` dates. Parents are included if they have at least one child submission in the date range OR if the parent itself was created in the range. This matches the UX expectation: "show me monitoring submissions from this period." Parents created outside the range are still shown as context for their in-range children. See the simulation section above for a worked example.
+
+4. **Date filter also applied when iterating children** — After selecting parents, child queries within the loop also include `**date_filter`. This ensures out-of-range children are excluded from the actual Excel rows, not just from the parent selection.
+
+5. **Optional parameters** — Both `date_from` and `date_to` are optional. Omitting both preserves existing behavior (download all). Providing only one creates an open-ended range.
+
+6. **String format for dates** — Dates passed as `YYYY-MM-DD` strings through the management command and kwargs, parsed to datetime in `download_data()`. This keeps the interface simple and avoids serialization issues with Django-Q async tasks.

--- a/frontend/src/components/filters/DataFilters.js
+++ b/frontend/src/components/filters/DataFilters.js
@@ -90,6 +90,10 @@ const DataFilters = ({
       if (["all", "recent"].includes(downloadType)) {
         urls.push(`type=${downloadType}`);
       }
+      if (dateRange) {
+        urls.push(`date_from=${dateRange[0].format("YYYY-MM-DD")}`);
+        urls.push(`date_to=${dateRange[1].format("YYYY-MM-DD")}`);
+      }
       const apiURL = `/${urls.join("&")}`;
       await api.get(apiURL);
       notify({
@@ -112,6 +116,7 @@ const DataFilters = ({
     selectedChildForms,
     notify,
     downloadType,
+    dateRange,
     text.export2ExcelSuccess,
     text.export2ExcelError,
     navigate,

--- a/frontend/src/components/filters/DataFilters.js
+++ b/frontend/src/components/filters/DataFilters.js
@@ -90,7 +90,7 @@ const DataFilters = ({
       if (["all", "recent"].includes(downloadType)) {
         urls.push(`type=${downloadType}`);
       }
-      if (dateRange) {
+      if (dateRange && dateRange.length === 2 && dateRange[0] && dateRange[1]) {
         urls.push(`date_from=${dateRange[0].format("YYYY-MM-DD")}`);
         urls.push(`date_to=${dateRange[1].format("YYYY-MM-DD")}`);
       }


### PR DESCRIPTION
Closes #182

## Problem

The data download (Excel export) ignores the date range filter — when a user applies a date range on the Manage Data page and clicks "Export to Excel", all data is downloaded regardless of the active filter.

Additionally, for monitoring forms, filtering by parent registration date misses monitoring submissions that occurred within the date range but whose parent was registered earlier.

## Solution

Filter **children (monitoring data) by date**, then include their parents regardless of parent creation date. This matches the UX expectation: "download monitoring submissions from this period."

### Simulation

Given data with filter `date_from=2026-03-02, date_to=2026-03-06`:

| id | form | created | name | parent_id |
|----|------|---------|------|-----------|
| 1 | Registration | 27/02 | EPS #1 | |
| 2 | Monitoring WQ | 03/03 | EPS WQ #1 | 1 |
| 3 | Monitoring PC | 03/03 | EPS PC #1 | 1 |
| 4 | Registration | 28/02 | EPS #2 | |
| 5 | Registration | 02/03 | EPS #3 | |
| 6 | Monitoring PC | 03/03 | EPS PC #3 | 5 |

**Result:** EPS #1 (included via in-range children WQ #1, PC #1), EPS #3 (in range itself + child PC #3). EPS #2 excluded — out of range with no in-range children.

## Changes

### Backend: Date range filtering in download (`job.py`)
- Add `_build_date_filter()` helper to convert date strings to Django ORM filter kwargs
- Add `date_from`/`date_to` params to `download_data()`, `generate_data_sheet()`, `job_generate_data_download()`
- When child forms + date filter: query children in range → collect parent IDs → union with parents in range
- Apply date filter when iterating children to exclude out-of-range records
- Add "Date Range Filter" row to Excel context sheet

### Backend: Serializer validation (`serializers.py`)
- Add `date_from` and `date_to` DateFields to `DownloadDataRequestSerializer`
- Add cross-field validation: `date_from` must be before or equal to `date_to`

### Backend: Management command (`job_download.py`)
- Add `-df`/`--date_from` and `-dt`/`--date_to` arguments
- Store date params in job info and pass to async task

### Backend: API endpoint (`views.py`)
- Add `date_from`/`date_to` OpenAPI parameters to `download_generate`
- Extract validated dates and pass to management command

### Frontend: Pass date range to download API (`DataFilters.js`)
- Include `dateRange` from store state in `export2Excel()` URL params
- Add `dateRange` to `useCallback` dependency array

### Backend: Test coverage (`tests_download_date_filter.py`)
- 9 test cases covering all date filter scenarios

## Files changed (6)

| File | What changed |
|------|-------------|
| `backend/api/v1/v1_jobs/job.py` | Add `_build_date_filter`, date params to `download_data`/`generate_data_sheet`/`job_generate_data_download`, context sheet |
| `backend/api/v1/v1_jobs/serializers.py` | Add date fields + validation to `DownloadDataRequestSerializer` |
| `backend/api/v1/v1_jobs/management/commands/job_download.py` | Add `-df`/`-dt` args, store in job info |
| `backend/api/v1/v1_jobs/views.py` | Add OpenAPI params, pass dates to `call_command` |
| `frontend/src/components/filters/DataFilters.js` | Pass `dateRange` to download API |
| `backend/api/v1/v1_jobs/tests/tests_download_date_filter.py` | 9 test cases for date-filtered downloads |

## Test plan

- [ ] Apply date range filter on Manage Data page, click Export to Excel — downloaded file only contains data within date range
- [ ] Download with monitoring forms — parent created before date range is included if it has monitoring data within range
- [ ] Download without date range — all data included (existing behavior)
- [ ] Invalid date range (from > to) — returns 400
- [ ] Excel context sheet shows "Date Range Filter" row when filtered
- [ ] Backend tests pass: `python manage.py test api.v1.v1_jobs.tests`

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1213531289811618