### PR TITLE
[#184] Split Registration Monitoring in Export Excel functionality 

### DIFF
--- a/backend/api/v1/v1_jobs/job.py
+++ b/backend/api/v1/v1_jobs/job.py
@@ -75,9 +75,36 @@ def download_data(
     child_form_ids: list = None,
     date_from: str = None,
     date_to: str = None,
+    selection_ids: list = None,
 ) -> list:
     if child_form_ids is None:
         child_form_ids = []
+
+    if selection_ids:
+        data = form.form_form_data.filter(
+            id__in=selection_ids,
+            is_pending=False,
+            is_draft=False,
+        ).order_by("id").all()
+        data_items = []
+        for d in data:
+            item = d.to_data_frame
+            for child_form in child_form_ids:
+                dl = d.children.filter(
+                    form_id=child_form,
+                    is_pending=False,
+                    is_draft=False,
+                ).order_by("-created").first()
+                if dl:
+                    item = {**item, **dl.to_data_frame}
+                    item["datapoint_name"] = d.name
+                    item["created_at"] = d.to_data_frame.get("created_at")
+                    item["created_by"] = d.created_by.get_full_name()
+                    item["updated_at"] = dl.to_data_frame.get("created_at")
+                    item["updated_by"] = dl.created_by.get_full_name()
+            data_items.append(item)
+        return data_items
+
     has_date_filter = date_from or date_to
     date_filter = _build_date_filter(date_from, date_to)
 
@@ -193,6 +220,7 @@ def generate_data_sheet(
     child_form_ids: list = None,
     date_from: str = None,
     date_to: str = None,
+    selection_ids: list = None,
 ) -> None:
     if child_form_ids is None:
         child_form_ids = []
@@ -208,6 +236,7 @@ def generate_data_sheet(
         child_form_ids=child_form_ids,
         date_from=date_from,
         date_to=date_to,
+        selection_ids=selection_ids,
     )
     if len(data):
         df = pd.DataFrame(data)
@@ -273,6 +302,7 @@ def download_monitoring_data(
     download_type: str = DataDownloadTypes.recent,
     date_from: str = None,
     date_to: str = None,
+    selection_ids: list = None,
 ) -> list:
     date_filter = _build_date_filter(date_from, date_to)
     filter_data = {
@@ -282,6 +312,8 @@ def download_monitoring_data(
         "is_pending": False,
         "is_draft": False,
     }
+    if selection_ids:
+        filter_data["parent_id__in"] = selection_ids
     if administration_ids:
         filter_data["parent__administration_id__in"] = administration_ids
     filter_data.update(date_filter)
@@ -324,6 +356,7 @@ def generate_monitoring_data_sheet(
     use_label: bool = True,
     date_from: str = None,
     date_to: str = None,
+    selection_ids: list = None,
 ) -> None:
     questions = get_question_names(form=child_form)
     data = download_monitoring_data(
@@ -333,6 +366,7 @@ def generate_monitoring_data_sheet(
         download_type=download_type,
         date_from=date_from,
         date_to=date_to,
+        selection_ids=selection_ids,
     )
     if len(data):
         df = pd.DataFrame(data)
@@ -495,6 +529,7 @@ def _generate_excel_download(job, **kwargs):
     download_type = kwargs.get("download_type", DataDownloadTypes.recent)
     use_label = kwargs.get("use_label", True)
     child_form_ids = job.info.get("child_form_ids", [])
+    selection_ids = job.info.get("selection_ids", [])
     date_from = kwargs.get("date_from")
     date_to = kwargs.get("date_to")
 
@@ -508,6 +543,7 @@ def _generate_excel_download(job, **kwargs):
         child_form_ids=child_form_ids,
         date_from=date_from,
         date_to=date_to,
+        selection_ids=selection_ids or None,
     )
     monitoring_forms = form.children.filter(pk__in=child_form_ids).all()
     _write_context_sheet(
@@ -529,6 +565,7 @@ def _generate_zip_download(job, **kwargs):
     use_label = kwargs.get("use_label", True)
     child_form_ids = job.info.get("child_form_ids", [])
     child_forms = form.children.filter(pk__in=child_form_ids).all()
+    selection_ids = job.info.get("selection_ids", [])
     date_from = kwargs.get("date_from")
     date_to = kwargs.get("date_to")
 
@@ -549,6 +586,7 @@ def _generate_zip_download(job, **kwargs):
                 child_form_ids=[],
                 date_from=date_from,
                 date_to=date_to,
+                selection_ids=selection_ids or None,
             )
             _write_context_sheet(
                 reg_writer, form, child_forms, job,
@@ -576,6 +614,7 @@ def _generate_zip_download(job, **kwargs):
                     use_label=use_label,
                     date_from=date_from,
                     date_to=date_to,
+                    selection_ids=selection_ids or None,
                 )
                 child_writer.save()
                 zf.write(child_path, f"{child_name}.xlsx")

--- a/backend/api/v1/v1_jobs/job.py
+++ b/backend/api/v1/v1_jobs/job.py
@@ -1,5 +1,6 @@
 import logging
 import os
+import zipfile
 from datetime import datetime, time, timedelta
 from dateutil import parser
 from django_q.models import Task
@@ -37,6 +38,7 @@ from utils.export_form import (
     get_question_names,
     blank_data_template,
     meta_columns,
+    monitoring_meta_columns,
 )
 from utils.functions import update_date_time_format
 from utils.storage import upload
@@ -264,56 +266,141 @@ def generate_data_sheet(
         blank_data_template(form=form, writer=writer)
 
 
-def job_generate_data_download(job_id, **kwargs):
-    job = Jobs.objects.get(pk=job_id)
-    file_path = "./tmp/{0}".format(job.result)
-    if os.path.exists(file_path):
-        os.remove(file_path)
-    administration_ids = False
-    administration_name = "All Administration Level"
-    if kwargs.get("administration"):
-        administration = Administration.objects.get(
-            pk=kwargs.get("administration")
-        )
-        if administration.path:
-            filter_path = "{0}{1}.".format(
-                administration.path, administration.id
-            )
-        else:
-            filter_path = f"{administration.id}."
-        administration_ids = list(
-            Administration.objects.filter(
-                path__startswith=filter_path
-            ).values_list("id", flat=True)
-        )
-        administration_ids.append(administration.id)
+def download_monitoring_data(
+    parent_form: Forms,
+    child_form: Forms,
+    administration_ids: list = None,
+    download_type: str = DataDownloadTypes.recent,
+    date_from: str = None,
+    date_to: str = None,
+) -> list:
+    date_filter = _build_date_filter(date_from, date_to)
+    filter_data = {
+        "form": child_form,
+        "parent__form": parent_form,
+        "parent__isnull": False,
+        "is_pending": False,
+        "is_draft": False,
+    }
+    if administration_ids:
+        filter_data["parent__administration_id__in"] = administration_ids
+    filter_data.update(date_filter)
 
-        administration_name = list(
-            Administration.objects.filter(
-                path__startswith=filter_path
-            ).values_list("name", flat=True)
-        )
-    form = Forms.objects.get(pk=job.info.get("form_id"))
-    download_type = kwargs.get("download_type", DataDownloadTypes.recent)
-    use_label = kwargs.get("use_label", True)
-    child_form_ids = job.info.get("child_form_ids", [])
-    date_from = kwargs.get("date_from")
-    date_to = kwargs.get("date_to")
+    queryset = FormData.objects.filter(
+        **filter_data
+    ).select_related("parent", "parent__administration", "created_by")
 
-    writer = pd.ExcelWriter(file_path, engine="xlsxwriter")
-    generate_data_sheet(
-        writer=writer,
-        form=form,
+    if download_type == DataDownloadTypes.recent:
+        # Get latest monitoring submission per parent
+        seen_parents = {}
+        for fd in queryset.order_by("parent_id", "-created"):
+            if fd.parent_id not in seen_parents:
+                seen_parents[fd.parent_id] = fd
+        monitoring_records = list(seen_parents.values())
+    else:
+        monitoring_records = list(
+            queryset.order_by("parent_id", "created").all()
+        )
+
+    data_items = []
+    for fd in monitoring_records:
+        item = fd.to_data_frame
+        item["parent_id"] = fd.parent_id
+        item["datapoint_name"] = fd.parent.name
+        parent_admin = fd.parent.administration
+        item["administration"] = (
+            parent_admin.administration_column if parent_admin else None
+        )
+        data_items.append(item)
+    return data_items
+
+
+def generate_monitoring_data_sheet(
+    writer: pd.ExcelWriter,
+    parent_form: Forms,
+    child_form: Forms,
+    administration_ids: list = None,
+    download_type: str = DataDownloadTypes.recent,
+    use_label: bool = True,
+    date_from: str = None,
+    date_to: str = None,
+) -> None:
+    questions = get_question_names(form=child_form)
+    data = download_monitoring_data(
+        parent_form=parent_form,
+        child_form=child_form,
         administration_ids=administration_ids,
         download_type=download_type,
-        use_label=use_label,
-        child_form_ids=child_form_ids,
         date_from=date_from,
         date_to=date_to,
     )
+    if len(data):
+        df = pd.DataFrame(data)
+        question_map = {}
+        for question in questions:
+            question_id, question_name, question_type = question
+            question_map[question_name] = {
+                'id': question_id,
+                'type': question_type,
+                'name': question_name
+            }
+        actual_columns = [
+            col for col in df.columns
+            if col not in monitoring_meta_columns
+        ]
+        for question in questions:
+            question_id, question_name, question_type = question
+            if question_name not in df:
+                df[question_name] = None
 
-    monitoring_forms = form.children.filter(pk__in=child_form_ids).all()
+        new_columns = {}
+        if use_label:
+            for col_name in actual_columns:
+                base_question_name = (
+                    col_name.split('_')[0]
+                    if '_' in col_name else col_name
+                )
+                if base_question_name in question_map:
+                    question_info = question_map[base_question_name]
+                    if question_info['type'] in [
+                        QuestionTypes.option,
+                        QuestionTypes.multiple_option,
+                    ]:
+                        new_columns[col_name] = df[col_name].apply(
+                            lambda x: get_answer_label(
+                                x, question_info['id']
+                            )
+                        )
+        if use_label and new_columns:
+            new_df = pd.DataFrame(new_columns)
+            df.drop(columns=list(new_columns.keys()), inplace=True)
+            df = pd.concat([df, new_df], axis=1)
 
+        available_question_columns = [
+            col for col in df.columns
+            if col not in monitoring_meta_columns
+        ]
+        final_columns = monitoring_meta_columns + available_question_columns
+        # Only include columns that exist in the dataframe
+        final_columns = [c for c in final_columns if c in df.columns]
+        df = df[final_columns]
+        df.to_excel(writer, sheet_name="data", index=False)
+        generate_definition_sheet(
+            writer=writer,
+            form=child_form,
+        )
+    else:
+        blank_data_template(form=child_form, writer=writer)
+
+
+def _sanitize_form_name(name: str) -> str:
+    return name.replace(" ", "_").lower()
+
+
+def _write_context_sheet(
+    writer, form, monitoring_forms, job,
+    administration_name, date_from, date_to,
+):
     context = [
         {"context": "Form Name", "value": form.name},
         {
@@ -342,22 +429,23 @@ def job_generate_data_download(job_id, **kwargs):
         context.append(
             {"context": "Date Range Filter", "value": date_range_str}
         )
-
     context = (
-        pd.DataFrame(context).groupby(["context", "value"], sort=False).first()
+        pd.DataFrame(context)
+        .groupby(["context", "value"], sort=False)
+        .first()
     )
     context.to_excel(writer, sheet_name="context", startrow=0, header=False)
     workbook = writer.book
     worksheet = writer.sheets["context"]
-    f = workbook.add_format(
+    fmt = workbook.add_format(
         {
             "align": "left",
             "bold": False,
             "border": 0,
         }
     )
-    worksheet.set_column("A:A", 20, f)
-    worksheet.set_column("B:B", 30, f)
+    worksheet.set_column("A:A", 20, fmt)
+    worksheet.set_column("B:B", 30, fmt)
     merge_format = workbook.add_format(
         {
             "bold": True,
@@ -369,9 +457,144 @@ def job_generate_data_download(job_id, **kwargs):
         }
     )
     worksheet.merge_range("A1:B1", "Context", merge_format)
+
+
+def _resolve_administration(kwargs):
+    administration_ids = False
+    administration_name = "All Administration Level"
+    if kwargs.get("administration"):
+        administration = Administration.objects.get(
+            pk=kwargs.get("administration")
+        )
+        if administration.path:
+            filter_path = "{0}{1}.".format(
+                administration.path, administration.id
+            )
+        else:
+            filter_path = f"{administration.id}."
+        administration_ids = list(
+            Administration.objects.filter(
+                path__startswith=filter_path
+            ).values_list("id", flat=True)
+        )
+        administration_ids.append(administration.id)
+        administration_name = list(
+            Administration.objects.filter(
+                path__startswith=filter_path
+            ).values_list("name", flat=True)
+        )
+    return administration_ids, administration_name
+
+
+def _generate_excel_download(job, **kwargs):
+    file_path = "./tmp/{0}".format(job.result)
+    if os.path.exists(file_path):
+        os.remove(file_path)
+    administration_ids, administration_name = _resolve_administration(kwargs)
+    form = Forms.objects.get(pk=job.info.get("form_id"))
+    download_type = kwargs.get("download_type", DataDownloadTypes.recent)
+    use_label = kwargs.get("use_label", True)
+    child_form_ids = job.info.get("child_form_ids", [])
+    date_from = kwargs.get("date_from")
+    date_to = kwargs.get("date_to")
+
+    writer = pd.ExcelWriter(file_path, engine="xlsxwriter")
+    generate_data_sheet(
+        writer=writer,
+        form=form,
+        administration_ids=administration_ids,
+        download_type=download_type,
+        use_label=use_label,
+        child_form_ids=child_form_ids,
+        date_from=date_from,
+        date_to=date_to,
+    )
+    monitoring_forms = form.children.filter(pk__in=child_form_ids).all()
+    _write_context_sheet(
+        writer, form, monitoring_forms, job,
+        administration_name, date_from, date_to,
+    )
     writer.save()
     url = upload(file=file_path, folder="download")
     return url
+
+
+def _generate_zip_download(job, **kwargs):
+    zip_path = "./tmp/{0}".format(job.result)
+    if os.path.exists(zip_path):
+        os.remove(zip_path)
+    administration_ids, administration_name = _resolve_administration(kwargs)
+    form = Forms.objects.get(pk=job.info.get("form_id"))
+    download_type = kwargs.get("download_type", DataDownloadTypes.recent)
+    use_label = kwargs.get("use_label", True)
+    child_form_ids = job.info.get("child_form_ids", [])
+    child_forms = form.children.filter(pk__in=child_form_ids).all()
+    date_from = kwargs.get("date_from")
+    date_to = kwargs.get("date_to")
+
+    tmp_files = []
+    try:
+        with zipfile.ZipFile(zip_path, 'w', zipfile.ZIP_DEFLATED) as zf:
+            # Registration Excel
+            reg_name = _sanitize_form_name(form.name)
+            reg_path = f"./tmp/reg_{job.id}.xlsx"
+            tmp_files.append(reg_path)
+            reg_writer = pd.ExcelWriter(reg_path, engine="xlsxwriter")
+            generate_data_sheet(
+                writer=reg_writer,
+                form=form,
+                administration_ids=administration_ids,
+                download_type=download_type,
+                use_label=use_label,
+                child_form_ids=[],
+                date_from=date_from,
+                date_to=date_to,
+            )
+            _write_context_sheet(
+                reg_writer, form, child_forms, job,
+                administration_name, date_from, date_to,
+            )
+            reg_writer.save()
+            zf.write(reg_path, f"{reg_name}.xlsx")
+
+            # One Excel per monitoring form
+            for child_form in child_forms:
+                child_name = _sanitize_form_name(child_form.name)
+                child_path = (
+                    f"./tmp/child_{child_form.id}_{job.id}.xlsx"
+                )
+                tmp_files.append(child_path)
+                child_writer = pd.ExcelWriter(
+                    child_path, engine="xlsxwriter"
+                )
+                generate_monitoring_data_sheet(
+                    writer=child_writer,
+                    parent_form=form,
+                    child_form=child_form,
+                    administration_ids=administration_ids,
+                    download_type=download_type,
+                    use_label=use_label,
+                    date_from=date_from,
+                    date_to=date_to,
+                )
+                child_writer.save()
+                zf.write(child_path, f"{child_name}.xlsx")
+
+        url = upload(file=zip_path, folder="download")
+        return url
+    finally:
+        for f in tmp_files:
+            if os.path.exists(f):
+                os.remove(f)
+
+
+def job_generate_data_download(job_id, **kwargs):
+    job = Jobs.objects.get(pk=job_id)
+    child_form_ids = job.info.get("child_form_ids", [])
+    if child_form_ids:
+        return _generate_zip_download(job, **kwargs)
+    else:
+        return _generate_excel_download(job, **kwargs)
 
 
 def transform_form_data_for_report(

--- a/backend/api/v1/v1_jobs/job.py
+++ b/backend/api/v1/v1_jobs/job.py
@@ -1,5 +1,6 @@
 import logging
 import os
+import re
 import zipfile
 from datetime import datetime, time, timedelta
 from dateutil import parser
@@ -427,8 +428,12 @@ def generate_monitoring_data_sheet(
         blank_data_template(form=child_form, writer=writer)
 
 
-def _sanitize_form_name(name: str) -> str:
-    return name.replace(" ", "_").lower()
+def _sanitize_form_name(name: str, form_id: int = None) -> str:
+    safe = re.sub(r'[^a-z0-9_-]', '_', name.lower())
+    safe = re.sub(r'_+', '_', safe).strip('_')
+    if form_id is not None:
+        safe = f"{safe}_{form_id}"
+    return safe
 
 
 def _write_context_sheet(
@@ -533,24 +538,23 @@ def _generate_excel_download(job, **kwargs):
     date_from = kwargs.get("date_from")
     date_to = kwargs.get("date_to")
 
-    writer = pd.ExcelWriter(file_path, engine="xlsxwriter")
-    generate_data_sheet(
-        writer=writer,
-        form=form,
-        administration_ids=administration_ids,
-        download_type=download_type,
-        use_label=use_label,
-        child_form_ids=child_form_ids,
-        date_from=date_from,
-        date_to=date_to,
-        selection_ids=selection_ids or None,
-    )
-    monitoring_forms = form.children.filter(pk__in=child_form_ids).all()
-    _write_context_sheet(
-        writer, form, monitoring_forms, job,
-        administration_name, date_from, date_to,
-    )
-    writer.save()
+    with pd.ExcelWriter(file_path, engine="xlsxwriter") as writer:
+        generate_data_sheet(
+            writer=writer,
+            form=form,
+            administration_ids=administration_ids,
+            download_type=download_type,
+            use_label=use_label,
+            child_form_ids=child_form_ids,
+            date_from=date_from,
+            date_to=date_to,
+            selection_ids=selection_ids or None,
+        )
+        monitoring_forms = form.children.filter(pk__in=child_form_ids).all()
+        _write_context_sheet(
+            writer, form, monitoring_forms, job,
+            administration_name, date_from, date_to,
+        )
     url = upload(file=file_path, folder="download")
     return url
 
@@ -576,47 +580,47 @@ def _generate_zip_download(job, **kwargs):
             reg_name = _sanitize_form_name(form.name)
             reg_path = f"./tmp/reg_{job.id}.xlsx"
             tmp_files.append(reg_path)
-            reg_writer = pd.ExcelWriter(reg_path, engine="xlsxwriter")
-            generate_data_sheet(
-                writer=reg_writer,
-                form=form,
-                administration_ids=administration_ids,
-                download_type=download_type,
-                use_label=use_label,
-                child_form_ids=[],
-                date_from=date_from,
-                date_to=date_to,
-                selection_ids=selection_ids or None,
-            )
-            _write_context_sheet(
-                reg_writer, form, child_forms, job,
-                administration_name, date_from, date_to,
-            )
-            reg_writer.save()
-            zf.write(reg_path, f"{reg_name}.xlsx")
-
-            # One Excel per monitoring form
-            for child_form in child_forms:
-                child_name = _sanitize_form_name(child_form.name)
-                child_path = (
-                    f"./tmp/child_{child_form.id}_{job.id}.xlsx"
-                )
-                tmp_files.append(child_path)
-                child_writer = pd.ExcelWriter(
-                    child_path, engine="xlsxwriter"
-                )
-                generate_monitoring_data_sheet(
-                    writer=child_writer,
-                    parent_form=form,
-                    child_form=child_form,
+            with pd.ExcelWriter(reg_path, engine="xlsxwriter") as rw:
+                generate_data_sheet(
+                    writer=rw,
+                    form=form,
                     administration_ids=administration_ids,
                     download_type=download_type,
                     use_label=use_label,
+                    child_form_ids=[],
                     date_from=date_from,
                     date_to=date_to,
                     selection_ids=selection_ids or None,
                 )
-                child_writer.save()
+                _write_context_sheet(
+                    rw, form, child_forms, job,
+                    administration_name, date_from, date_to,
+                )
+            zf.write(reg_path, f"{reg_name}.xlsx")
+
+            # One Excel per monitoring form
+            for child_form in child_forms:
+                child_name = _sanitize_form_name(
+                    child_form.name, form_id=child_form.id
+                )
+                child_path = (
+                    f"./tmp/child_{child_form.id}_{job.id}.xlsx"
+                )
+                tmp_files.append(child_path)
+                with pd.ExcelWriter(
+                    child_path, engine="xlsxwriter"
+                ) as cw:
+                    generate_monitoring_data_sheet(
+                        writer=cw,
+                        parent_form=form,
+                        child_form=child_form,
+                        administration_ids=administration_ids,
+                        download_type=download_type,
+                        use_label=use_label,
+                        date_from=date_from,
+                        date_to=date_to,
+                        selection_ids=selection_ids or None,
+                    )
                 zf.write(child_path, f"{child_name}.xlsx")
 
         url = upload(file=zip_path, folder="download")

--- a/backend/api/v1/v1_jobs/management/commands/job_download.py
+++ b/backend/api/v1/v1_jobs/management/commands/job_download.py
@@ -30,6 +30,9 @@ class Command(BaseCommand):
             "-c", "--child_form_ids", nargs="*", default=[], type=int
         )
         parser.add_argument(
+            "-s", "--selection_ids", nargs="*", default=[], type=int
+        )
+        parser.add_argument(
             "-df", "--date_from", nargs="?", default=None, type=str
         )
         parser.add_argument(
@@ -70,6 +73,7 @@ class Command(BaseCommand):
                         )
                     )
                     return
+        selection_ids = options.get("selection_ids", [])
         date_from = options.get("date_from")
         date_to = options.get("date_to")
         info = {
@@ -78,6 +82,7 @@ class Command(BaseCommand):
             "download_type": download_type,
             "use_label": use_label == 1,
             "child_form_ids": child_form_ids,
+            "selection_ids": selection_ids,
             "date_from": date_from,
             "date_to": date_to,
         }

--- a/backend/api/v1/v1_jobs/management/commands/job_download.py
+++ b/backend/api/v1/v1_jobs/management/commands/job_download.py
@@ -83,8 +83,9 @@ class Command(BaseCommand):
         }
         form_name = form.name.replace(" ", "_").lower()
         today = timezone.datetime.today().strftime("%y%m%d")
-        out_file = "download-{0}-{1}-{2}.xlsx".format(
-            form_name, today, uuid.uuid4()
+        ext = "zip" if child_form_ids else "xlsx"
+        out_file = "download-{0}-{1}-{2}.{3}".format(
+            form_name, today, uuid.uuid4(), ext
         )
         job = Jobs.objects.create(
             type=JobTypes.download,

--- a/backend/api/v1/v1_jobs/serializers.py
+++ b/backend/api/v1/v1_jobs/serializers.py
@@ -36,6 +36,12 @@ class DownloadDataRequestSerializer(serializers.Serializer):
     )
     date_from = serializers.DateField(required=False, allow_null=True)
     date_to = serializers.DateField(required=False, allow_null=True)
+    selection_ids = CustomListField(
+        child=CustomPrimaryKeyRelatedField(
+            queryset=FormData.objects.none()
+        ),
+        required=False,
+    )
 
     def __init__(self, **kwargs):
         super().__init__(**kwargs)
@@ -44,6 +50,11 @@ class DownloadDataRequestSerializer(serializers.Serializer):
             "administration_id"
         ).queryset = Administration.objects.all()
         self.fields.get("child_form_ids").child.queryset = Forms.objects.all()
+        self.fields.get(
+            "selection_ids"
+        ).child.queryset = FormData.objects.filter(
+            form__parent__isnull=True
+        ).all()
 
     def validate(self, data):
         date_from = data.get("date_from")
@@ -135,18 +146,27 @@ class DownloadListSerializer(serializers.ModelSerializer):
                 )
                 return list(fd)
         if instance.type == JobTypes.download:
+            selection_ids = instance.info.get("selection_ids", [])
+            if selection_ids:
+                fd = FormData.objects.filter(
+                    pk__in=selection_ids
+                ).values("id", "name", "form_id")
+                return list(fd)
+            items = []
             child_form_ids = instance.info.get("child_form_ids")
             if child_form_ids:
-                forms = Forms.objects.filter(pk__in=child_form_ids).values(
-                    "id", "name"
-                )
-                forms = [f for f in forms]
-                return forms
+                forms = Forms.objects.filter(
+                    pk__in=child_form_ids
+                ).values("id", "name")
+                items.extend(list(forms))
+            return items
 
         return instance.info.get("attributes")
 
     @extend_schema_field(OpenApiTypes.STR)
     def get_download_type(self, instance):
+        if instance.info.get("selection_ids"):
+            return None
         return instance.info.get("download_type")
 
     class Meta:

--- a/backend/api/v1/v1_jobs/serializers.py
+++ b/backend/api/v1/v1_jobs/serializers.py
@@ -63,6 +63,16 @@ class DownloadDataRequestSerializer(serializers.Serializer):
             raise serializers.ValidationError(
                 "date_from must be before or equal to date_to"
             )
+        selection_ids = data.get("selection_ids", [])
+        form_id = data.get("form_id")
+        if selection_ids and form_id:
+            invalid = [
+                fd for fd in selection_ids if fd.form_id != form_id.id
+            ]
+            if invalid:
+                raise serializers.ValidationError(
+                    "selection_ids must belong to the requested form_id"
+                )
         return data
 
 
@@ -138,18 +148,21 @@ class DownloadListSerializer(serializers.ModelSerializer):
             attributes = [a for a in attributes]
             return attributes
         if instance.type == JobTypes.download_datapoint_report:
-            # Get a list of selected datapoint IDs
             selection_ids = instance.info.get("selection_ids", [])
+            form_id = instance.info.get("form_id")
             if selection_ids:
-                fd = FormData.objects.filter(pk__in=selection_ids).values(
-                    "id", "name", "form_id",
-                )
+                fd = FormData.objects.filter(
+                    pk__in=selection_ids,
+                    form_id=form_id,
+                ).values("id", "name", "form_id")
                 return list(fd)
         if instance.type == JobTypes.download:
             selection_ids = instance.info.get("selection_ids", [])
+            form_id = instance.info.get("form_id")
             if selection_ids:
                 fd = FormData.objects.filter(
-                    pk__in=selection_ids
+                    pk__in=selection_ids,
+                    form_id=form_id,
                 ).values("id", "name", "form_id")
                 return list(fd)
             items = []

--- a/backend/api/v1/v1_jobs/tests/tests_split_monitoring_export.py
+++ b/backend/api/v1/v1_jobs/tests/tests_split_monitoring_export.py
@@ -1,0 +1,366 @@
+from datetime import timedelta
+from io import StringIO
+from django.core.management import call_command
+from django.test import TestCase
+from django.test.utils import override_settings
+from django.utils import timezone
+from api.v1.v1_data.models import FormData
+from api.v1.v1_forms.models import Forms
+from api.v1.v1_jobs.job import download_monitoring_data
+from api.v1.v1_jobs.constants import DataDownloadTypes
+from api.v1.v1_profile.management.commands import administration_seeder
+from api.v1.v1_profile.tests.mixins import ProfileTestHelperMixin
+
+
+@override_settings(USE_TZ=False)
+class DownloadMonitoringDataTestCase(TestCase, ProfileTestHelperMixin):
+    def call_command(self, *args, **kwargs):
+        out = StringIO()
+        call_command(
+            "fake_complete_data_seeder",
+            "--test=true",
+            *args,
+            stdout=out,
+            stderr=StringIO(),
+            **kwargs,
+        )
+        return out.getvalue()
+
+    def setUp(self):
+        call_command("form_seeder", "--test")
+        rows = [
+            {
+                "code_0": "ID",
+                "National_0": "Indonesia",
+                "code_1": "ID-JK",
+                "Province_1": "Jakarta",
+                "code_2": "ID-JK-JKE",
+                "District_2": "East Jakarta",
+                "code_3": "ID-JK-JKE-KJ",
+                "Subdistrict_3": "Kramat Jati",
+                "code_4": "ID-JK-JKE-KJ-CW",
+                "Village_4": "Cawang",
+            },
+            {
+                "code_0": "ID",
+                "National_0": "Indonesia",
+                "code_1": "ID-JK",
+                "Province_1": "Jakarta",
+                "code_2": "ID-JK-JKW",
+                "District_2": "West Jakarta",
+                "code_3": "ID-JK-JKW-KJ",
+                "Subdistrict_3": "Kebon Jeruk",
+                "code_4": "ID-JK-JKW-KJ-KJ",
+                "Village_4": "Kebon Jeruk",
+            },
+            {
+                "code_0": "ID",
+                "National_0": "Indonesia",
+                "code_1": "ID-YO",
+                "Province_1": "Yogyakarta",
+                "code_2": "ID-YO-SL",
+                "District_2": "Sleman",
+                "code_3": "ID-YO-SL-ST",
+                "Subdistrict_3": "Seturan",
+                "code_4": "ID-YO-SL-ST-CB",
+                "Village_4": "Cepit Baru",
+            },
+            {
+                "code_0": "ID",
+                "National_0": "Indonesia",
+                "code_1": "ID-YO",
+                "Province_1": "Yogyakarta",
+                "code_2": "ID-YO-BT",
+                "District_2": "Bantul",
+                "code_3": "ID-YO-BT-BT",
+                "Subdistrict_3": "Bantul",
+                "code_4": "ID-YO-BT-BT-BT",
+                "Village_4": "Bantul",
+            },
+        ]
+        administration_seeder.seed_administration_test(rows=rows)
+        call_command("default_roles_seeder", "--test", 1)
+        self.client.post(
+            "/api/v1/login",
+            {"email": "admin@akvo.org", "password": "Test105*"},
+            content_type="application/json",
+        )
+        self.call_command("-r", 2, "--test", True)
+
+        self.form = Forms.objects.get(pk=1)
+        self.child_form = self.form.children.first()
+
+        now = timezone.now()
+        self.today = now.date()
+        self.yesterday = (now - timedelta(days=1)).date()
+        self.three_days_ago = (now - timedelta(days=3)).date()
+        self.five_days_ago = (now - timedelta(days=5)).date()
+
+    def test_returns_child_ids_not_parent_ids(self):
+        result = download_monitoring_data(
+            parent_form=self.form,
+            child_form=self.child_form,
+        )
+        self.assertTrue(len(result) > 0)
+        parent_ids = set(
+            self.form.form_form_data.filter(
+                is_pending=False, is_draft=False
+            ).values_list("id", flat=True)
+        )
+        for row in result:
+            self.assertIn("parent_id", row)
+            self.assertIn(row["parent_id"], parent_ids)
+            # id should be the monitoring record's own id
+            self.assertNotEqual(row["id"], row["parent_id"])
+
+    def test_recent_one_per_parent(self):
+        result = download_monitoring_data(
+            parent_form=self.form,
+            child_form=self.child_form,
+            download_type=DataDownloadTypes.recent,
+        )
+        parent_ids = [row["parent_id"] for row in result]
+        self.assertEqual(len(parent_ids), len(set(parent_ids)))
+
+    def test_all_multiple_per_parent(self):
+        result = download_monitoring_data(
+            parent_form=self.form,
+            child_form=self.child_form,
+            download_type=DataDownloadTypes.all,
+        )
+        parent_ids = [row["parent_id"] for row in result]
+        unique_parents = set(parent_ids)
+        self.assertGreaterEqual(len(result), len(unique_parents))
+
+    def test_with_administration_filter(self):
+        parents = list(
+            self.form.form_form_data.filter(
+                is_pending=False, is_draft=False
+            ).all()
+        )
+        adm = parents[0].administration
+        adm_ids = [adm.id]
+        result = download_monitoring_data(
+            parent_form=self.form,
+            child_form=self.child_form,
+            administration_ids=adm_ids,
+        )
+        for row in result:
+            parent = FormData.objects.get(pk=row["parent_id"])
+            self.assertEqual(parent.administration_id, adm.id)
+
+    def test_with_date_from(self):
+        # Set monitoring records: some old, some recent
+        children = list(
+            FormData.objects.filter(
+                form=self.child_form,
+                is_pending=False,
+                is_draft=False,
+            ).all()
+        )
+        self.assertTrue(len(children) >= 2)
+        # Make first child old
+        FormData.objects.filter(pk=children[0].pk).update(
+            created=timezone.now() - timedelta(days=5)
+        )
+        # Make second child recent
+        FormData.objects.filter(pk=children[1].pk).update(
+            created=timezone.now() - timedelta(days=1)
+        )
+        result = download_monitoring_data(
+            parent_form=self.form,
+            child_form=self.child_form,
+            date_from=str(self.three_days_ago),
+        )
+        result_ids = [row["id"] for row in result]
+        self.assertNotIn(children[0].id, result_ids)
+        self.assertIn(children[1].id, result_ids)
+
+    def test_with_date_to(self):
+        children = list(
+            FormData.objects.filter(
+                form=self.child_form,
+                is_pending=False,
+                is_draft=False,
+            ).all()
+        )
+        self.assertTrue(len(children) >= 2)
+        FormData.objects.filter(pk=children[0].pk).update(
+            created=timezone.now() - timedelta(days=5)
+        )
+        FormData.objects.filter(pk=children[1].pk).update(
+            created=timezone.now()
+        )
+        result = download_monitoring_data(
+            parent_form=self.form,
+            child_form=self.child_form,
+            date_to=str(self.three_days_ago),
+        )
+        result_ids = [row["id"] for row in result]
+        self.assertIn(children[0].id, result_ids)
+        self.assertNotIn(children[1].id, result_ids)
+
+    def test_with_date_range(self):
+        children = list(
+            FormData.objects.filter(
+                form=self.child_form,
+                is_pending=False,
+                is_draft=False,
+            ).all()
+        )
+        self.assertTrue(len(children) >= 2)
+        FormData.objects.filter(pk=children[0].pk).update(
+            created=timezone.now() - timedelta(days=5)
+        )
+        FormData.objects.filter(pk=children[1].pk).update(
+            created=timezone.now() - timedelta(days=1)
+        )
+        result = download_monitoring_data(
+            parent_form=self.form,
+            child_form=self.child_form,
+            date_from=str(self.three_days_ago),
+            date_to=str(self.today),
+        )
+        result_ids = [row["id"] for row in result]
+        self.assertNotIn(children[0].id, result_ids)
+        self.assertIn(children[1].id, result_ids)
+
+    def test_date_boundary_inclusivity(self):
+        children = list(
+            FormData.objects.filter(
+                form=self.child_form,
+                is_pending=False,
+                is_draft=False,
+            ).all()
+        )
+        self.assertTrue(len(children) >= 1)
+        FormData.objects.filter(pk=children[0].pk).update(
+            created=timezone.now() - timedelta(days=1)
+        )
+        result = download_monitoring_data(
+            parent_form=self.form,
+            child_form=self.child_form,
+            date_from=str(self.yesterday),
+            date_to=str(self.yesterday),
+        )
+        result_ids = [row["id"] for row in result]
+        self.assertIn(children[0].id, result_ids)
+
+    def test_empty_result_with_out_of_range_dates(self):
+        far_future = str(
+            (timezone.now() + timedelta(days=365)).date()
+        )
+        result = download_monitoring_data(
+            parent_form=self.form,
+            child_form=self.child_form,
+            date_from=far_future,
+        )
+        self.assertEqual(len(result), 0)
+
+    def test_with_date_and_administration(self):
+        parents = list(
+            self.form.form_form_data.filter(
+                is_pending=False, is_draft=False
+            ).all()
+        )
+        adm = parents[0].administration
+        children = list(
+            FormData.objects.filter(
+                form=self.child_form,
+                parent=parents[0],
+                is_pending=False,
+                is_draft=False,
+            ).all()
+        )
+        if children:
+            FormData.objects.filter(pk=children[0].pk).update(
+                created=timezone.now() - timedelta(days=1)
+            )
+        result = download_monitoring_data(
+            parent_form=self.form,
+            child_form=self.child_form,
+            administration_ids=[adm.id],
+            date_from=str(self.three_days_ago),
+            date_to=str(self.today),
+        )
+        for row in result:
+            parent = FormData.objects.get(pk=row["parent_id"])
+            self.assertEqual(parent.administration_id, adm.id)
+
+    def test_monitoring_date_filter_independent_from_parent(self):
+        """Parent created outside range, monitoring in range."""
+        parents = list(
+            self.form.form_form_data.filter(
+                is_pending=False, is_draft=False
+            ).order_by("id").all()
+        )
+        parent = parents[0]
+        # Parent: 5 days ago (outside range)
+        FormData.objects.filter(pk=parent.pk).update(
+            created=timezone.now() - timedelta(days=5)
+        )
+        # Child: yesterday (in range)
+        children = list(
+            parent.children.filter(
+                form=self.child_form,
+                is_pending=False,
+                is_draft=False,
+            ).all()
+        )
+        if children:
+            FormData.objects.filter(pk=children[0].pk).update(
+                created=timezone.now() - timedelta(days=1)
+            )
+            result = download_monitoring_data(
+                parent_form=self.form,
+                child_form=self.child_form,
+                date_from=str(self.three_days_ago),
+                date_to=str(self.today),
+            )
+            result_ids = [row["id"] for row in result]
+            self.assertIn(children[0].id, result_ids)
+            matching = [r for r in result if r["id"] == children[0].id]
+            self.assertEqual(matching[0]["parent_id"], parent.id)
+
+    def test_monitoring_excludes_out_of_range_even_if_parent_in_range(self):
+        """Parent in range, monitoring out of range."""
+        parents = list(
+            self.form.form_form_data.filter(
+                is_pending=False, is_draft=False
+            ).order_by("id").all()
+        )
+        parent = parents[0]
+        # Parent: yesterday (in range)
+        FormData.objects.filter(pk=parent.pk).update(
+            created=timezone.now() - timedelta(days=1)
+        )
+        # Child: 5 days ago (out of range)
+        children = list(
+            parent.children.filter(
+                form=self.child_form,
+                is_pending=False,
+                is_draft=False,
+            ).all()
+        )
+        for child in children:
+            FormData.objects.filter(pk=child.pk).update(
+                created=timezone.now() - timedelta(days=5)
+            )
+        result = download_monitoring_data(
+            parent_form=self.form,
+            child_form=self.child_form,
+            date_from=str(self.three_days_ago),
+            date_to=str(self.today),
+        )
+        result_ids = [row["id"] for row in result]
+        for child in children:
+            self.assertNotIn(child.id, result_ids)
+
+    def test_datapoint_name_from_parent(self):
+        result = download_monitoring_data(
+            parent_form=self.form,
+            child_form=self.child_form,
+        )
+        for row in result:
+            parent = FormData.objects.get(pk=row["parent_id"])
+            self.assertEqual(row["datapoint_name"], parent.name)

--- a/backend/api/v1/v1_jobs/tests/tests_zip_download.py
+++ b/backend/api/v1/v1_jobs/tests/tests_zip_download.py
@@ -1,0 +1,489 @@
+import os
+import zipfile
+from datetime import timedelta
+from io import StringIO
+import pandas as pd
+from django.core.management import call_command
+from django.test import TestCase
+from django.test.utils import override_settings
+from django.utils import timezone
+from api.v1.v1_data.models import FormData
+from api.v1.v1_forms.models import Forms
+from api.v1.v1_jobs.models import Jobs
+from api.v1.v1_jobs.job import job_generate_data_download
+from api.v1.v1_jobs.constants import (
+    DataDownloadTypes,
+    JobStatus,
+    JobTypes,
+)
+from api.v1.v1_profile.management.commands import administration_seeder
+from api.v1.v1_profile.models import Administration
+from api.v1.v1_profile.tests.mixins import ProfileTestHelperMixin
+from api.v1.v1_users.models import SystemUser
+from rest_framework import status
+from utils import storage
+
+
+@override_settings(USE_TZ=False)
+class ZipDownloadTestCase(TestCase, ProfileTestHelperMixin):
+    def call_command(self, *args, **kwargs):
+        out = StringIO()
+        call_command(
+            "fake_complete_data_seeder",
+            "--test=true",
+            *args,
+            stdout=out,
+            stderr=StringIO(),
+            **kwargs,
+        )
+        return out.getvalue()
+
+    def setUp(self):
+        call_command("form_seeder", "--test")
+        rows = [
+            {
+                "code_0": "ID",
+                "National_0": "Indonesia",
+                "code_1": "ID-JK",
+                "Province_1": "Jakarta",
+                "code_2": "ID-JK-JKE",
+                "District_2": "East Jakarta",
+                "code_3": "ID-JK-JKE-KJ",
+                "Subdistrict_3": "Kramat Jati",
+                "code_4": "ID-JK-JKE-KJ-CW",
+                "Village_4": "Cawang",
+            },
+            {
+                "code_0": "ID",
+                "National_0": "Indonesia",
+                "code_1": "ID-JK",
+                "Province_1": "Jakarta",
+                "code_2": "ID-JK-JKW",
+                "District_2": "West Jakarta",
+                "code_3": "ID-JK-JKW-KJ",
+                "Subdistrict_3": "Kebon Jeruk",
+                "code_4": "ID-JK-JKW-KJ-KJ",
+                "Village_4": "Kebon Jeruk",
+            },
+            {
+                "code_0": "ID",
+                "National_0": "Indonesia",
+                "code_1": "ID-YO",
+                "Province_1": "Yogyakarta",
+                "code_2": "ID-YO-SL",
+                "District_2": "Sleman",
+                "code_3": "ID-YO-SL-ST",
+                "Subdistrict_3": "Seturan",
+                "code_4": "ID-YO-SL-ST-CB",
+                "Village_4": "Cepit Baru",
+            },
+            {
+                "code_0": "ID",
+                "National_0": "Indonesia",
+                "code_1": "ID-YO",
+                "Province_1": "Yogyakarta",
+                "code_2": "ID-YO-BT",
+                "District_2": "Bantul",
+                "code_3": "ID-YO-BT-BT",
+                "Subdistrict_3": "Bantul",
+                "code_4": "ID-YO-BT-BT-BT",
+                "Village_4": "Bantul",
+            },
+        ]
+        administration_seeder.seed_administration_test(rows=rows)
+        call_command("default_roles_seeder", "--test", 1)
+        self.client.post(
+            "/api/v1/login",
+            {"email": "admin@akvo.org", "password": "Test105*"},
+            content_type="application/json",
+        )
+        self.call_command("-r", 2, "--test", True)
+
+        self.form = Forms.objects.get(pk=1)
+        self.child_form = self.form.children.first()
+        self.child_form_ids = list(
+            self.form.children.values_list("id", flat=True)
+        )
+        self.user = SystemUser.objects.filter(
+            email="admin@akvo.org"
+        ).first()
+
+    def _create_zip_job(self, **extra_info):
+        info = {
+            "form_id": self.form.id,
+            "administration": None,
+            "download_type": DataDownloadTypes.recent,
+            "use_label": True,
+            "child_form_ids": self.child_form_ids,
+            "date_from": None,
+            "date_to": None,
+        }
+        info.update(extra_info)
+        job = Jobs.objects.create(
+            type=JobTypes.download,
+            user=self.user,
+            status=JobStatus.on_progress,
+            info=info,
+            result="placeholder.zip",
+        )
+        job.result = f"download-test-{job.id}.zip"
+        job.save()
+        return job
+
+    def _create_xlsx_job(self):
+        info = {
+            "form_id": self.form.id,
+            "administration": None,
+            "download_type": DataDownloadTypes.recent,
+            "use_label": True,
+            "child_form_ids": [],
+            "date_from": None,
+            "date_to": None,
+        }
+        job = Jobs.objects.create(
+            type=JobTypes.download,
+            user=self.user,
+            status=JobStatus.on_progress,
+            info=info,
+            result="placeholder.xlsx",
+        )
+        job.result = f"download-test-{job.id}.xlsx"
+        job.save()
+        return job
+
+    def test_zip_download_produces_zip_file(self):
+        job = self._create_zip_job()
+        url = job_generate_data_download(job_id=job.id, **job.info)
+        self.assertIn(".zip", url)
+        # Cleanup
+        storage.delete(url=f"download/{job.result}")
+
+    def test_zip_contains_correct_number_of_files(self):
+        job = self._create_zip_job()
+        job_generate_data_download(job_id=job.id, **job.info)
+        zip_path = f"./tmp/{job.result}"
+        storage.download(f"download/{job.result}")
+        with zipfile.ZipFile(zip_path, 'r') as zf:
+            names = zf.namelist()
+            # 1 registration + N monitoring forms
+            expected = 1 + len(self.child_form_ids)
+            self.assertEqual(len(names), expected)
+        if os.path.exists(zip_path):
+            os.remove(zip_path)
+        storage.delete(url=f"download/{job.result}")
+
+    def test_zip_registration_excel_has_no_parent_id(self):
+        job = self._create_zip_job()
+        job_generate_data_download(job_id=job.id, **job.info)
+        storage.download(f"download/{job.result}")
+        zip_path = f"./tmp/{job.result}"
+        with zipfile.ZipFile(zip_path, 'r') as zf:
+            reg_name = self.form.name.replace(" ", "_").lower() + ".xlsx"
+            self.assertIn(reg_name, zf.namelist())
+            zf.extract(reg_name, "./tmp/zip_extract/")
+            df = pd.read_excel(
+                f"./tmp/zip_extract/{reg_name}", sheet_name="data"
+            )
+            self.assertNotIn("parent_id", df.columns)
+        # Cleanup
+        import shutil
+        if os.path.exists("./tmp/zip_extract"):
+            shutil.rmtree("./tmp/zip_extract")
+        if os.path.exists(zip_path):
+            os.remove(zip_path)
+        storage.delete(url=f"download/{job.result}")
+
+    def test_zip_monitoring_excel_has_parent_id(self):
+        job = self._create_zip_job()
+        job_generate_data_download(job_id=job.id, **job.info)
+        storage.download(f"download/{job.result}")
+        zip_path = f"./tmp/{job.result}"
+        with zipfile.ZipFile(zip_path, 'r') as zf:
+            child_name = (
+                self.child_form.name.replace(" ", "_").lower() + ".xlsx"
+            )
+            self.assertIn(child_name, zf.namelist())
+            zf.extract(child_name, "./tmp/zip_extract/")
+            df = pd.read_excel(
+                f"./tmp/zip_extract/{child_name}", sheet_name="data"
+            )
+            self.assertIn("parent_id", df.columns)
+            self.assertIn("id", df.columns)
+            # Verify parent_id references valid registration data
+            reg_ids = set(
+                self.form.form_form_data.filter(
+                    is_pending=False, is_draft=False
+                ).values_list("id", flat=True)
+            )
+            for pid in df["parent_id"].dropna():
+                self.assertIn(int(pid), reg_ids)
+        import shutil
+        if os.path.exists("./tmp/zip_extract"):
+            shutil.rmtree("./tmp/zip_extract")
+        if os.path.exists(zip_path):
+            os.remove(zip_path)
+        storage.delete(url=f"download/{job.result}")
+
+    def test_without_child_forms_produces_xlsx(self):
+        job = self._create_xlsx_job()
+        url = job_generate_data_download(job_id=job.id, **job.info)
+        self.assertIn(".xlsx", url)
+        self.assertNotIn(".zip", url)
+        storage.delete(url=f"download/{job.result}")
+
+    def test_zip_monitoring_recent_mode(self):
+        job = self._create_zip_job(
+            download_type=DataDownloadTypes.recent
+        )
+        job_generate_data_download(job_id=job.id, **job.info)
+        storage.download(f"download/{job.result}")
+        zip_path = f"./tmp/{job.result}"
+        with zipfile.ZipFile(zip_path, 'r') as zf:
+            child_name = (
+                self.child_form.name.replace(" ", "_").lower() + ".xlsx"
+            )
+            zf.extract(child_name, "./tmp/zip_extract/")
+            df = pd.read_excel(
+                f"./tmp/zip_extract/{child_name}", sheet_name="data"
+            )
+            if len(df) > 0:
+                parent_ids = df["parent_id"].tolist()
+                self.assertEqual(
+                    len(parent_ids), len(set(parent_ids)),
+                    "Recent mode should have one row per parent"
+                )
+        import shutil
+        if os.path.exists("./tmp/zip_extract"):
+            shutil.rmtree("./tmp/zip_extract")
+        if os.path.exists(zip_path):
+            os.remove(zip_path)
+        storage.delete(url=f"download/{job.result}")
+
+    def test_zip_monitoring_all_mode(self):
+        job = self._create_zip_job(
+            download_type=DataDownloadTypes.all
+        )
+        job_generate_data_download(job_id=job.id, **job.info)
+        storage.download(f"download/{job.result}")
+        zip_path = f"./tmp/{job.result}"
+        with zipfile.ZipFile(zip_path, 'r') as zf:
+            child_name = (
+                self.child_form.name.replace(" ", "_").lower() + ".xlsx"
+            )
+            zf.extract(child_name, "./tmp/zip_extract/")
+            df = pd.read_excel(
+                f"./tmp/zip_extract/{child_name}", sheet_name="data"
+            )
+            if len(df) > 0:
+                parent_ids = df["parent_id"].tolist()
+                unique_parents = set(parent_ids)
+                self.assertGreaterEqual(len(parent_ids), len(unique_parents))
+        import shutil
+        if os.path.exists("./tmp/zip_extract"):
+            shutil.rmtree("./tmp/zip_extract")
+        if os.path.exists(zip_path):
+            os.remove(zip_path)
+        storage.delete(url=f"download/{job.result}")
+
+    def test_zip_download_with_date_filter(self):
+        now = timezone.now()
+        today = now.date()
+        three_days_ago = (now - timedelta(days=3)).date()
+
+        # Set known dates
+        children = list(
+            FormData.objects.filter(
+                form=self.child_form,
+                is_pending=False,
+                is_draft=False,
+            ).all()
+        )
+        if len(children) >= 2:
+            FormData.objects.filter(pk=children[0].pk).update(
+                created=timezone.now() - timedelta(days=5)
+            )
+            FormData.objects.filter(pk=children[1].pk).update(
+                created=timezone.now() - timedelta(days=1)
+            )
+        job = self._create_zip_job(
+            date_from=str(three_days_ago),
+            date_to=str(today),
+        )
+        job_generate_data_download(job_id=job.id, **job.info)
+        storage.download(f"download/{job.result}")
+        zip_path = f"./tmp/{job.result}"
+        with zipfile.ZipFile(zip_path, 'r') as zf:
+            child_name = (
+                self.child_form.name.replace(" ", "_").lower() + ".xlsx"
+            )
+            zf.extract(child_name, "./tmp/zip_extract/")
+            df = pd.read_excel(
+                f"./tmp/zip_extract/{child_name}", sheet_name="data"
+            )
+            if len(children) >= 2 and len(df) > 0:
+                result_ids = df["id"].tolist()
+                self.assertNotIn(children[0].id, result_ids)
+                self.assertIn(children[1].id, result_ids)
+        import shutil
+        if os.path.exists("./tmp/zip_extract"):
+            shutil.rmtree("./tmp/zip_extract")
+        if os.path.exists(zip_path):
+            os.remove(zip_path)
+        storage.delete(url=f"download/{job.result}")
+
+    def test_zip_definition_sheet_per_form(self):
+        job = self._create_zip_job()
+        job_generate_data_download(job_id=job.id, **job.info)
+        storage.download(f"download/{job.result}")
+        zip_path = f"./tmp/{job.result}"
+        with zipfile.ZipFile(zip_path, 'r') as zf:
+            for name in zf.namelist():
+                zf.extract(name, "./tmp/zip_extract/")
+                xlsx = pd.ExcelFile(f"./tmp/zip_extract/{name}")
+                self.assertIn(
+                    "questions", xlsx.sheet_names,
+                    f"Missing 'questions' sheet in {name}"
+                )
+        import shutil
+        if os.path.exists("./tmp/zip_extract"):
+            shutil.rmtree("./tmp/zip_extract")
+        if os.path.exists(zip_path):
+            os.remove(zip_path)
+        storage.delete(url=f"download/{job.result}")
+
+    def test_zip_context_sheet_in_registration_only(self):
+        job = self._create_zip_job()
+        job_generate_data_download(job_id=job.id, **job.info)
+        storage.download(f"download/{job.result}")
+        zip_path = f"./tmp/{job.result}"
+        reg_name = self.form.name.replace(" ", "_").lower() + ".xlsx"
+        child_name = (
+            self.child_form.name.replace(" ", "_").lower() + ".xlsx"
+        )
+        with zipfile.ZipFile(zip_path, 'r') as zf:
+            zf.extractall("./tmp/zip_extract/")
+            # Registration has context sheet
+            reg_xlsx = pd.ExcelFile(f"./tmp/zip_extract/{reg_name}")
+            self.assertIn("context", reg_xlsx.sheet_names)
+            # Monitoring does NOT have context sheet
+            child_xlsx = pd.ExcelFile(f"./tmp/zip_extract/{child_name}")
+            self.assertNotIn("context", child_xlsx.sheet_names)
+        import shutil
+        if os.path.exists("./tmp/zip_extract"):
+            shutil.rmtree("./tmp/zip_extract")
+        if os.path.exists(zip_path):
+            os.remove(zip_path)
+        storage.delete(url=f"download/{job.result}")
+
+
+@override_settings(USE_TZ=False)
+class ZipDownloadCommandTestCase(TestCase, ProfileTestHelperMixin):
+    def setUp(self):
+        call_command("form_seeder", "--test")
+        call_command("administration_seeder", "--test")
+        call_command("default_roles_seeder", "--test", 1)
+        self.client.post(
+            '/api/v1/login',
+            {"email": "admin@akvo.org", "password": "Test105*"},
+            content_type='application/json',
+        )
+
+    def call_command(self, *args, **kwargs):
+        out = StringIO()
+        call_command(
+            "job_download",
+            *args,
+            stdout=out,
+            stderr=StringIO(),
+            **kwargs,
+        )
+        return out.getvalue()
+
+    def test_command_produces_zip_filename_with_child_forms(self):
+        form = Forms.objects.get(pk=1)
+        child_forms = form.children.all()[:1]
+        admin = SystemUser.objects.first()
+        result = self.call_command(
+            form.id,
+            admin.id,
+            "-a",
+            0,
+            "-c",
+            *child_forms.values_list("id", flat=True),
+        )
+        self.assertTrue(result)
+        job = Jobs.objects.get(pk=result)
+        self.assertTrue(
+            job.result.endswith(".zip"),
+            f"Expected .zip extension, got: {job.result}"
+        )
+
+    def test_command_produces_xlsx_filename_without_child_forms(self):
+        form = Forms.objects.get(pk=1)
+        admin = SystemUser.objects.first()
+        result = self.call_command(
+            form.id,
+            admin.id,
+            "-a",
+            0,
+        )
+        self.assertTrue(result)
+        job = Jobs.objects.get(pk=result)
+        self.assertTrue(
+            job.result.endswith(".xlsx"),
+            f"Expected .xlsx extension, got: {job.result}"
+        )
+
+
+@override_settings(USE_TZ=False, TEST_ENV=True)
+class ZipDownloadFileEndpointTestCase(TestCase, ProfileTestHelperMixin):
+    def setUp(self):
+        call_command("administration_seeder", "--test", 1)
+        call_command("default_roles_seeder", "--test", 1)
+        call_command("form_seeder", "--test", 1)
+
+        self.form = Forms.objects.get(pk=1)
+        self.administration = Administration.objects.filter(
+            level__level=1
+        ).order_by("?").first()
+        self.user = self.create_user(
+            email="admin@akvo.org",
+            password="Test105*",
+            role_level=self.IS_ADMIN,
+            administration=self.administration,
+            form=self.form
+        )
+        self.token = self.get_auth_token(
+            email=self.user.email,
+            password="Test105*"
+        )
+
+    def test_successful_zip_file_download(self):
+        filename = "download-test_form.zip"
+        # Create a test zip file
+        zip_path = f"./{filename}"
+        with zipfile.ZipFile(zip_path, 'w') as zf:
+            zf.writestr("test.txt", "test content")
+        storage.upload(file=zip_path, folder="download")
+        job = Jobs.objects.create(
+            type=JobTypes.download,
+            user=self.user,
+            status=JobStatus.done,
+            info={
+                "form_id": self.form.id,
+                "child_form_ids": [10001],
+            },
+            result=filename,
+        )
+        response = self.client.get(
+            f"/api/v1/download/file/{job.result}",
+            HTTP_AUTHORIZATION=f"Bearer {self.token}",
+        )
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(
+            response["Content-Type"], "application/zip"
+        )
+        self.assertIn(filename, response["Content-Disposition"])
+        # Cleanup
+        os.remove(zip_path)
+        storage.delete(url=f"download/{filename}")

--- a/backend/api/v1/v1_jobs/tests/tests_zip_download.py
+++ b/backend/api/v1/v1_jobs/tests/tests_zip_download.py
@@ -10,7 +10,7 @@ from django.utils import timezone
 from api.v1.v1_data.models import FormData
 from api.v1.v1_forms.models import Forms
 from api.v1.v1_jobs.models import Jobs
-from api.v1.v1_jobs.job import job_generate_data_download
+from api.v1.v1_jobs.job import job_generate_data_download, _sanitize_form_name
 from api.v1.v1_jobs.constants import (
     DataDownloadTypes,
     JobStatus,
@@ -178,7 +178,7 @@ class ZipDownloadTestCase(TestCase, ProfileTestHelperMixin):
         storage.download(f"download/{job.result}")
         zip_path = f"./tmp/{job.result}"
         with zipfile.ZipFile(zip_path, 'r') as zf:
-            reg_name = self.form.name.replace(" ", "_").lower() + ".xlsx"
+            reg_name = _sanitize_form_name(self.form.name) + ".xlsx"
             self.assertIn(reg_name, zf.namelist())
             zf.extract(reg_name, "./tmp/zip_extract/")
             df = pd.read_excel(
@@ -200,7 +200,10 @@ class ZipDownloadTestCase(TestCase, ProfileTestHelperMixin):
         zip_path = f"./tmp/{job.result}"
         with zipfile.ZipFile(zip_path, 'r') as zf:
             child_name = (
-                self.child_form.name.replace(" ", "_").lower() + ".xlsx"
+                _sanitize_form_name(
+                    self.child_form.name,
+                    form_id=self.child_form.id
+                ) + ".xlsx"
             )
             self.assertIn(child_name, zf.namelist())
             zf.extract(child_name, "./tmp/zip_extract/")
@@ -240,7 +243,10 @@ class ZipDownloadTestCase(TestCase, ProfileTestHelperMixin):
         zip_path = f"./tmp/{job.result}"
         with zipfile.ZipFile(zip_path, 'r') as zf:
             child_name = (
-                self.child_form.name.replace(" ", "_").lower() + ".xlsx"
+                _sanitize_form_name(
+                    self.child_form.name,
+                    form_id=self.child_form.id
+                ) + ".xlsx"
             )
             zf.extract(child_name, "./tmp/zip_extract/")
             df = pd.read_excel(
@@ -268,7 +274,10 @@ class ZipDownloadTestCase(TestCase, ProfileTestHelperMixin):
         zip_path = f"./tmp/{job.result}"
         with zipfile.ZipFile(zip_path, 'r') as zf:
             child_name = (
-                self.child_form.name.replace(" ", "_").lower() + ".xlsx"
+                _sanitize_form_name(
+                    self.child_form.name,
+                    form_id=self.child_form.id
+                ) + ".xlsx"
             )
             zf.extract(child_name, "./tmp/zip_extract/")
             df = pd.read_excel(
@@ -314,7 +323,10 @@ class ZipDownloadTestCase(TestCase, ProfileTestHelperMixin):
         zip_path = f"./tmp/{job.result}"
         with zipfile.ZipFile(zip_path, 'r') as zf:
             child_name = (
-                self.child_form.name.replace(" ", "_").lower() + ".xlsx"
+                _sanitize_form_name(
+                    self.child_form.name,
+                    form_id=self.child_form.id
+                ) + ".xlsx"
             )
             zf.extract(child_name, "./tmp/zip_extract/")
             df = pd.read_excel(
@@ -356,9 +368,12 @@ class ZipDownloadTestCase(TestCase, ProfileTestHelperMixin):
         job_generate_data_download(job_id=job.id, **job.info)
         storage.download(f"download/{job.result}")
         zip_path = f"./tmp/{job.result}"
-        reg_name = self.form.name.replace(" ", "_").lower() + ".xlsx"
+        reg_name = _sanitize_form_name(self.form.name) + ".xlsx"
         child_name = (
-            self.child_form.name.replace(" ", "_").lower() + ".xlsx"
+            _sanitize_form_name(
+                self.child_form.name,
+                form_id=self.child_form.id
+            ) + ".xlsx"
         )
         with zipfile.ZipFile(zip_path, 'r') as zf:
             zf.extractall("./tmp/zip_extract/")

--- a/backend/api/v1/v1_jobs/tests/tests_zip_download_with_selection_ids.py
+++ b/backend/api/v1/v1_jobs/tests/tests_zip_download_with_selection_ids.py
@@ -1,0 +1,425 @@
+import os
+import shutil
+import zipfile
+from io import StringIO
+
+import pandas as pd
+from django.core.management import call_command
+from django.test import TestCase
+from django.test.utils import override_settings
+from rest_framework import status
+
+from api.v1.v1_data.models import FormData
+from api.v1.v1_forms.models import Forms
+from api.v1.v1_jobs.constants import (
+    DataDownloadTypes,
+    JobStatus,
+    JobTypes,
+)
+from api.v1.v1_jobs.job import job_generate_data_download
+from api.v1.v1_jobs.models import Jobs
+from api.v1.v1_profile.management.commands import administration_seeder
+from api.v1.v1_profile.models import Administration
+from api.v1.v1_profile.tests.mixins import ProfileTestHelperMixin
+from api.v1.v1_users.models import SystemUser
+from utils import storage
+
+
+ADMIN_ROWS = [
+    {
+        "code_0": "ID",
+        "National_0": "Indonesia",
+        "code_1": "ID-JK",
+        "Province_1": "Jakarta",
+        "code_2": "ID-JK-JKE",
+        "District_2": "East Jakarta",
+        "code_3": "ID-JK-JKE-KJ",
+        "Subdistrict_3": "Kramat Jati",
+        "code_4": "ID-JK-JKE-KJ-CW",
+        "Village_4": "Cawang",
+    },
+    {
+        "code_0": "ID",
+        "National_0": "Indonesia",
+        "code_1": "ID-JK",
+        "Province_1": "Jakarta",
+        "code_2": "ID-JK-JKW",
+        "District_2": "West Jakarta",
+        "code_3": "ID-JK-JKW-KJ",
+        "Subdistrict_3": "Kebon Jeruk",
+        "code_4": "ID-JK-JKW-KJ-KJ",
+        "Village_4": "Kebon Jeruk",
+    },
+    {
+        "code_0": "ID",
+        "National_0": "Indonesia",
+        "code_1": "ID-YO",
+        "Province_1": "Yogyakarta",
+        "code_2": "ID-YO-SL",
+        "District_2": "Sleman",
+        "code_3": "ID-YO-SL-ST",
+        "Subdistrict_3": "Seturan",
+        "code_4": "ID-YO-SL-ST-CB",
+        "Village_4": "Cepit Baru",
+    },
+    {
+        "code_0": "ID",
+        "National_0": "Indonesia",
+        "code_1": "ID-YO",
+        "Province_1": "Yogyakarta",
+        "code_2": "ID-YO-BT",
+        "District_2": "Bantul",
+        "code_3": "ID-YO-BT-BT",
+        "Subdistrict_3": "Bantul",
+        "code_4": "ID-YO-BT-BT-BT",
+        "Village_4": "Bantul",
+    },
+]
+
+
+def _cleanup_zip(zip_path: str, job_result: str) -> None:
+    """Remove local files and remote storage after a test."""
+    if os.path.exists("./tmp/zip_extract"):
+        shutil.rmtree("./tmp/zip_extract")
+    if os.path.exists(zip_path):
+        os.remove(zip_path)
+    storage.delete(url=f"download/{job_result}")
+
+
+@override_settings(USE_TZ=False)
+class ZipDownloadWithSelectionIdsTestCase(TestCase, ProfileTestHelperMixin):
+    """Tests for the selection_ids feature in download/generate."""
+
+    def call_command(self, *args, **kwargs):
+        out = StringIO()
+        call_command(
+            "fake_complete_data_seeder",
+            "--test=true",
+            *args,
+            stdout=out,
+            stderr=StringIO(),
+            **kwargs,
+        )
+        return out.getvalue()
+
+    def setUp(self):
+        call_command("form_seeder", "--test")
+        administration_seeder.seed_administration_test(rows=ADMIN_ROWS)
+        call_command("default_roles_seeder", "--test", 1)
+        self.client.post(
+            "/api/v1/login",
+            {"email": "admin@akvo.org", "password": "Test105*"},
+            content_type="application/json",
+        )
+        self.call_command("-r", 2, "--test", True)
+
+        self.form = Forms.objects.get(pk=1)
+        self.child_form = self.form.children.first()
+        self.child_form_ids = list(
+            self.form.children.values_list("id", flat=True)
+        )
+        self.user = SystemUser.objects.filter(
+            email="admin@akvo.org"
+        ).first()
+
+        # Collect all registration FormData ids
+        self.all_reg_ids = list(
+            FormData.objects.filter(
+                form=self.form,
+                is_pending=False,
+                is_draft=False,
+            )
+            .order_by("id")
+            .values_list("id", flat=True)
+        )
+
+    def _create_zip_job(self, **extra_info):
+        info = {
+            "form_id": self.form.id,
+            "administration": None,
+            "download_type": DataDownloadTypes.recent,
+            "use_label": True,
+            "child_form_ids": self.child_form_ids,
+            "date_from": None,
+            "date_to": None,
+        }
+        info.update(extra_info)
+        job = Jobs.objects.create(
+            type=JobTypes.download,
+            user=self.user,
+            status=JobStatus.on_progress,
+            info=info,
+            result="placeholder.zip",
+        )
+        job.result = f"download-test-{job.id}.zip"
+        job.save()
+        return job
+
+    def _create_xlsx_job(self, **extra_info):
+        info = {
+            "form_id": self.form.id,
+            "administration": None,
+            "download_type": DataDownloadTypes.recent,
+            "use_label": True,
+            "child_form_ids": [],
+            "date_from": None,
+            "date_to": None,
+        }
+        info.update(extra_info)
+        job = Jobs.objects.create(
+            type=JobTypes.download,
+            user=self.user,
+            status=JobStatus.on_progress,
+            info=info,
+            result="placeholder.xlsx",
+        )
+        job.result = f"download-test-{job.id}.xlsx"
+        job.save()
+        return job
+
+    def test_selection_ids_filters_registration_data(self):
+        """Zip job with selection_ids produces registration Excel
+        containing only the selected FormData rows."""
+        self.assertGreaterEqual(
+            len(self.all_reg_ids), 2,
+            "Seeder must create at least 2 registration rows",
+        )
+        selected = [self.all_reg_ids[0]]
+
+        job = self._create_zip_job(selection_ids=selected)
+        job_generate_data_download(job_id=job.id, **job.info)
+
+        storage.download(f"download/{job.result}")
+        zip_path = f"./tmp/{job.result}"
+        reg_name = self.form.name.replace(" ", "_").lower() + ".xlsx"
+
+        with zipfile.ZipFile(zip_path, "r") as zf:
+            self.assertIn(reg_name, zf.namelist())
+            zf.extract(reg_name, "./tmp/zip_extract/")
+            df = pd.read_excel(
+                f"./tmp/zip_extract/{reg_name}", sheet_name="data"
+            )
+            self.assertEqual(
+                len(df), len(selected),
+                "Registration Excel should only contain selected rows",
+            )
+            self.assertIn("id", df.columns)
+            result_ids = df["id"].tolist()
+            self.assertEqual(result_ids, selected)
+
+        _cleanup_zip(zip_path, job.result)
+
+    def test_selection_ids_filters_monitoring_data(self):
+        """Zip job with selection_ids and child_form_ids produces
+        monitoring Excel containing only children whose parent_id
+        is in the selection_ids."""
+        self.assertGreaterEqual(
+            len(self.all_reg_ids), 2,
+            "Seeder must create at least 2 registration rows",
+        )
+        selected = [self.all_reg_ids[0]]
+
+        job = self._create_zip_job(selection_ids=selected)
+        job_generate_data_download(job_id=job.id, **job.info)
+
+        storage.download(f"download/{job.result}")
+        zip_path = f"./tmp/{job.result}"
+        child_name = (
+            self.child_form.name.replace(" ", "_").lower() + ".xlsx"
+        )
+
+        with zipfile.ZipFile(zip_path, "r") as zf:
+            self.assertIn(child_name, zf.namelist())
+            zf.extract(child_name, "./tmp/zip_extract/")
+            df = pd.read_excel(
+                f"./tmp/zip_extract/{child_name}", sheet_name="data"
+            )
+            if len(df) > 0:
+                self.assertIn("parent_id", df.columns)
+                for pid in df["parent_id"].dropna():
+                    self.assertIn(
+                        int(pid), selected,
+                        "Monitoring rows must belong to selected parents",
+                    )
+
+        _cleanup_zip(zip_path, job.result)
+
+    def test_empty_selection_ids_uses_normal_behavior(self):
+        """Zip job with selection_ids=[] should produce the same
+        number of registration rows as a job without selection_ids."""
+        # Job without selection_ids
+        job_normal = self._create_zip_job()
+        job_generate_data_download(
+            job_id=job_normal.id, **job_normal.info
+        )
+        storage.download(f"download/{job_normal.result}")
+        zip_normal = f"./tmp/{job_normal.result}"
+        reg_name = self.form.name.replace(" ", "_").lower() + ".xlsx"
+
+        with zipfile.ZipFile(zip_normal, "r") as zf:
+            zf.extract(reg_name, "./tmp/zip_extract/")
+            df_normal = pd.read_excel(
+                f"./tmp/zip_extract/{reg_name}", sheet_name="data"
+            )
+        normal_count = len(df_normal)
+        _cleanup_zip(zip_normal, job_normal.result)
+
+        # Job with empty selection_ids
+        job_empty = self._create_zip_job(selection_ids=[])
+        job_generate_data_download(
+            job_id=job_empty.id, **job_empty.info
+        )
+        storage.download(f"download/{job_empty.result}")
+        zip_empty = f"./tmp/{job_empty.result}"
+
+        with zipfile.ZipFile(zip_empty, "r") as zf:
+            zf.extract(reg_name, "./tmp/zip_extract/")
+            df_empty = pd.read_excel(
+                f"./tmp/zip_extract/{reg_name}", sheet_name="data"
+            )
+        empty_count = len(df_empty)
+        _cleanup_zip(zip_empty, job_empty.result)
+
+        self.assertEqual(
+            normal_count, empty_count,
+            "Empty selection_ids should behave the same as no selection_ids",
+        )
+
+    def test_xlsx_with_selection_ids(self):
+        """XLSX job (no child_form_ids) with selection_ids produces
+        an .xlsx file containing only the selected rows."""
+        self.assertGreaterEqual(
+            len(self.all_reg_ids), 2,
+            "Seeder must create at least 2 registration rows",
+        )
+        selected = [self.all_reg_ids[0]]
+
+        job = self._create_xlsx_job(selection_ids=selected)
+        url = job_generate_data_download(job_id=job.id, **job.info)
+
+        self.assertIn(".xlsx", url)
+        self.assertNotIn(".zip", url)
+
+        storage.download(f"download/{job.result}")
+        xlsx_path = f"./tmp/{job.result}"
+        df = pd.read_excel(xlsx_path, sheet_name="data")
+
+        self.assertEqual(
+            len(df), len(selected),
+            "XLSX should only contain selected rows",
+        )
+        self.assertIn("id", df.columns)
+        result_ids = df["id"].tolist()
+        self.assertEqual(result_ids, selected)
+
+        if os.path.exists(xlsx_path):
+            os.remove(xlsx_path)
+        storage.delete(url=f"download/{job.result}")
+
+
+@override_settings(USE_TZ=False)
+class ZipDownloadCommandWithSelectionIdsTestCase(
+    TestCase, ProfileTestHelperMixin
+):
+    """Tests for the management command with -s (selection_ids) flag."""
+
+    def setUp(self):
+        call_command("form_seeder", "--test")
+        call_command("administration_seeder", "--test")
+        call_command("default_roles_seeder", "--test", 1)
+        self.client.post(
+            "/api/v1/login",
+            {"email": "admin@akvo.org", "password": "Test105*"},
+            content_type="application/json",
+        )
+
+    def call_command(self, *args, **kwargs):
+        out = StringIO()
+        call_command(
+            "job_download",
+            *args,
+            stdout=out,
+            stderr=StringIO(),
+            **kwargs,
+        )
+        return out.getvalue()
+
+    def test_command_accepts_selection_ids_argument(self):
+        """Management command with -s flag stores selection_ids
+        in the job info dictionary."""
+        form = Forms.objects.get(pk=1)
+        admin = SystemUser.objects.first()
+
+        fake_ids = [100, 200]
+        result = self.call_command(
+            form.id,
+            admin.id,
+            "-a", 0,
+            "-s", *fake_ids,
+        )
+        self.assertTrue(result)
+        job = Jobs.objects.get(pk=result)
+        self.assertIn("selection_ids", job.info)
+        self.assertEqual(job.info["selection_ids"], fake_ids)
+
+
+@override_settings(USE_TZ=False, TEST_ENV=True)
+class ZipDownloadApiWithSelectionIdsTestCase(
+    TestCase, ProfileTestHelperMixin
+):
+    """Tests for the download/generate API endpoint with selection_ids."""
+
+    def setUp(self):
+        call_command("administration_seeder", "--test", 1)
+        call_command("default_roles_seeder", "--test", 1)
+        call_command("form_seeder", "--test", 1)
+
+        self.form = Forms.objects.get(pk=1)
+        self.administration = Administration.objects.filter(
+            level__level=1
+        ).order_by("?").first()
+        self.user = self.create_user(
+            email="admin@akvo.org",
+            password="Test105*",
+            role_level=self.IS_ADMIN,
+            administration=self.administration,
+            form=self.form,
+        )
+        self.token = self.get_auth_token(
+            email=self.user.email,
+            password="Test105*",
+        )
+        self.url = "/api/v1/download/generate"
+
+    def test_api_endpoint_accepts_selection_ids(self):
+        """GET /api/v1/download/generate with selection_ids query
+        params returns HTTP 200."""
+        # Seed data so FormData objects exist for the serializer
+        out = StringIO()
+        call_command(
+            "fake_complete_data_seeder",
+            "--test=true",
+            "-r", 2,
+            "--test", True,
+            stdout=out,
+            stderr=StringIO(),
+        )
+
+        reg_ids = list(
+            FormData.objects.filter(
+                form=self.form,
+                is_pending=False,
+                is_draft=False,
+            ).values_list("id", flat=True)[:1]
+        )
+        self.assertGreaterEqual(len(reg_ids), 1)
+
+        query = (
+            f"{self.url}?form_id={self.form.id}"
+            f"&selection_ids={reg_ids[0]}"
+        )
+        response = self.client.get(
+            query,
+            HTTP_AUTHORIZATION=f"Bearer {self.token}",
+        )
+        self.assertEqual(response.status_code, status.HTTP_200_OK)

--- a/backend/api/v1/v1_jobs/tests/tests_zip_download_with_selection_ids.py
+++ b/backend/api/v1/v1_jobs/tests/tests_zip_download_with_selection_ids.py
@@ -16,7 +16,7 @@ from api.v1.v1_jobs.constants import (
     JobStatus,
     JobTypes,
 )
-from api.v1.v1_jobs.job import job_generate_data_download
+from api.v1.v1_jobs.job import job_generate_data_download, _sanitize_form_name
 from api.v1.v1_jobs.models import Jobs
 from api.v1.v1_profile.management.commands import administration_seeder
 from api.v1.v1_profile.models import Administration
@@ -191,7 +191,7 @@ class ZipDownloadWithSelectionIdsTestCase(TestCase, ProfileTestHelperMixin):
 
         storage.download(f"download/{job.result}")
         zip_path = f"./tmp/{job.result}"
-        reg_name = self.form.name.replace(" ", "_").lower() + ".xlsx"
+        reg_name = _sanitize_form_name(self.form.name) + ".xlsx"
 
         with zipfile.ZipFile(zip_path, "r") as zf:
             self.assertIn(reg_name, zf.namelist())
@@ -225,7 +225,10 @@ class ZipDownloadWithSelectionIdsTestCase(TestCase, ProfileTestHelperMixin):
         storage.download(f"download/{job.result}")
         zip_path = f"./tmp/{job.result}"
         child_name = (
-            self.child_form.name.replace(" ", "_").lower() + ".xlsx"
+            _sanitize_form_name(
+                self.child_form.name,
+                form_id=self.child_form.id
+            ) + ".xlsx"
         )
 
         with zipfile.ZipFile(zip_path, "r") as zf:
@@ -254,7 +257,7 @@ class ZipDownloadWithSelectionIdsTestCase(TestCase, ProfileTestHelperMixin):
         )
         storage.download(f"download/{job_normal.result}")
         zip_normal = f"./tmp/{job_normal.result}"
-        reg_name = self.form.name.replace(" ", "_").lower() + ".xlsx"
+        reg_name = _sanitize_form_name(self.form.name) + ".xlsx"
 
         with zipfile.ZipFile(zip_normal, "r") as zf:
             zf.extract(reg_name, "./tmp/zip_extract/")

--- a/backend/api/v1/v1_jobs/views.py
+++ b/backend/api/v1/v1_jobs/views.py
@@ -190,7 +190,9 @@ def download_file(request, version, file_name):
     filename = job.result
     zip_file = open(filepath, "rb")
     # Set content type based on file extension
-    if filename.endswith('.docx'):
+    if filename.endswith('.zip'):
+        content_type = "application/zip"
+    elif filename.endswith('.docx'):
         content_type = (
             "application/vnd.openxmlformats-officedocument"
             ".wordprocessingml.document"

--- a/backend/api/v1/v1_jobs/views.py
+++ b/backend/api/v1/v1_jobs/views.py
@@ -115,6 +115,10 @@ def download_generate(request, version):
         child.id
         for child in serializer.validated_data.get("child_form_ids", [])
     ]
+    selection_ids = [
+        fd.id
+        for fd in serializer.validated_data.get("selection_ids", [])
+    ]
     cmd_args = [
         "job_download",
         serializer.validated_data.get("form_id").id,
@@ -128,6 +132,8 @@ def download_generate(request, version):
         "-c",
         *child_forms,
     ]
+    if selection_ids:
+        cmd_args.extend(["-s", *selection_ids])
     date_from = serializer.validated_data.get("date_from")
     date_to = serializer.validated_data.get("date_to")
     if date_from:

--- a/backend/api/v1/v1_jobs/views.py
+++ b/backend/api/v1/v1_jobs/views.py
@@ -88,6 +88,13 @@ from utils.custom_serializer_fields import validate_serializers_message
             type=OpenApiTypes.DATE,
             location=OpenApiParameter.QUERY,
         ),
+        OpenApiParameter(
+            name="selection_ids",
+            required=False,
+            type={"type": "array", "items": {"type": "number"}},
+            location=OpenApiParameter.QUERY,
+            description="Registration FormData IDs to download",
+        ),
     ],
     responses={
         (200, "application/json"): inline_serializer(

--- a/backend/utils/export_form.py
+++ b/backend/utils/export_form.py
@@ -14,6 +14,16 @@ meta_columns = [
     "geolocation",
 ]
 
+monitoring_meta_columns = [
+    "id",
+    "parent_id",
+    "datapoint_name",
+    "administration",
+    "geolocation",
+    "created_at",
+    "created_by",
+]
+
 
 def get_question_names(form: Forms):
     questions = []

--- a/doc/claude/selection-aware-excel-download.md
+++ b/doc/claude/selection-aware-excel-download.md
@@ -1,0 +1,90 @@
+# Selection-Aware Excel Download
+
+## Problem
+
+The Manage Data page had two download buttons:
+1. **Download Report** (DOCX) — used `selectedRowKeys` to filter specific datapoints
+2. **Download** (Excel) — ignored `selectedRowKeys`, only offered "All data" / "Latest data" radio
+
+Both buttons also shared a single `selectedChildForms` state and `childFormMenuItems` memo, causing child form selections in one dropdown to affect the other.
+
+## Solution
+
+When rows are selected, the Excel download now exports only those rows (via `selection_ids`). When no rows are selected, behavior is unchanged. Each dropdown has independent child form state.
+
+---
+
+## Changes
+
+### Backend
+
+#### `serializers.py` — `DownloadDataRequestSerializer`
+- Added `selection_ids` field (`CustomListField` of `FormData` PKs, required=False)
+- Queryset restricted to registration data only: `FormData.objects.filter(form__parent__isnull=True)`
+
+#### `serializers.py` — `DownloadListSerializer`
+- `get_attributes()`: When `selection_ids` is present on a `download` job, returns the selected `FormData` rows as `[{id, name, form_id}]` (rendered as clickable links in DownloadTable). When absent, returns child forms as `[{id, name}]` (plain text). Keeps the flat array format the frontend expects.
+- `get_download_type()`: Returns `None` when `selection_ids` is present (hides the "recent Data -" / "all Data -" label).
+
+#### `views.py` — `download_generate()`
+- Extracts `selection_ids` from validated data and passes as `-s` flag to the `job_download` management command.
+
+#### `management/commands/job_download.py`
+- Added `-s`/`--selection_ids` argument (`nargs="*"`, `default=[]`, `type=int`)
+- Stored in `job.info["selection_ids"]`
+
+#### `job.py` — `download_data()`
+- New `selection_ids` parameter. When provided, filters `FormData` by `id__in=selection_ids` directly, bypassing download_type/administration/date logic. Still merges latest child data per `child_form_ids`.
+
+#### `job.py` — `download_monitoring_data()`
+- New `selection_ids` parameter. When provided, adds `parent_id__in=selection_ids` filter. Other filters (administration, date) still apply.
+
+#### `job.py` — Passthrough in:
+- `generate_data_sheet()` — passes `selection_ids` to `download_data()`
+- `generate_monitoring_data_sheet()` — passes `selection_ids` to `download_monitoring_data()`
+- `_generate_excel_download()` — extracts from `job.info`, passes to `generate_data_sheet()`
+- `_generate_zip_download()` — extracts from `job.info`, passes to both `generate_data_sheet()` and `generate_monitoring_data_sheet()`
+
+### Frontend
+
+#### `DataFilters.js`
+- **Separate state**: Split `selectedChildForms` into `excelChildForms` and `docxChildForms` with independent `useState` hooks.
+- **Reusable checkbox builder**: `buildCheckboxItems(selected, setSelected)` — a `useCallback` that generates checkbox menu items for any state/setter pair.
+- **Split menus**: `excelMenuItems` and `docxMenuItems` each call `buildCheckboxItems` with their own state.
+- **Conditional radio**: `excelMenuItems` hides the "All data" / "Latest data" radio group when `selectedRowKeys.length > 0`.
+- **`export2Excel()`**: When `selectedRowKeys` is present, appends `selection_ids` params and skips the `type` param.
+- **Badge**: Excel download button wrapped in `<Badge count={selectedRowKeys.length}>`.
+- **Icons**: Excel menu footer uses `<DownloadOutlined />`, DOCX menu footer uses `<FileWordOutlined />`.
+
+#### `ManageDataTable.jsx`
+- Added `useEffect` that resets `selectedRowKeys` to `[]` when `administration` changes.
+
+### Tests
+
+#### `tests_zip_download_with_selection_ids.py`
+
+**`ZipDownloadWithSelectionIdsTestCase`** (4 tests):
+- `test_selection_ids_filters_registration_data` — only selected rows in registration Excel
+- `test_selection_ids_filters_monitoring_data` — monitoring Excel only has children of selected parents
+- `test_empty_selection_ids_uses_normal_behavior` — same row count as without selection_ids
+- `test_xlsx_with_selection_ids` — xlsx (no child forms) with selection_ids filters correctly
+
+**`ZipDownloadCommandWithSelectionIdsTestCase`** (1 test):
+- `test_command_accepts_selection_ids_argument` — `-s` flag stores in job info
+
+**`ZipDownloadApiWithSelectionIdsTestCase`** (1 test):
+- `test_api_endpoint_accepts_selection_ids` — GET with `selection_ids` returns HTTP 200
+
+---
+
+## File Summary
+
+| File | Change |
+|---|---|
+| `backend/api/v1/v1_jobs/serializers.py` | `selection_ids` in request serializer; attributes/download_type in list serializer |
+| `backend/api/v1/v1_jobs/views.py` | Pass `selection_ids` to command |
+| `backend/api/v1/v1_jobs/management/commands/job_download.py` | `-s` argument, store in info |
+| `backend/api/v1/v1_jobs/job.py` | `selection_ids` in download_data, download_monitoring_data, and all generators |
+| `backend/api/v1/v1_jobs/tests/tests_zip_download_with_selection_ids.py` | 6 dedicated tests |
+| `frontend/src/components/filters/DataFilters.js` | Independent state, split menus, selection_ids in API, badge |
+| `frontend/src/pages/manage-data/components/ManageDataTable.jsx` | Reset selectedRowKeys on administration change |

--- a/doc/claude/split-reg-monitoring-export.md
+++ b/doc/claude/split-reg-monitoring-export.md
@@ -1,0 +1,597 @@
+# Plan: Split Registration & Monitoring Data Export (.zip)
+
+## Problem Statement
+
+Currently, `job_generate_data_download()` produces a **single Excel file** that merges parent (registration) and child (monitoring) form data as additional columns in the same sheet. This causes:
+
+1. **Horizontal complexity**: Monitoring questions are appended as columns alongside registration columns, making the spreadsheet very wide and hard to read (e.g. 60+ columns when 2 monitoring forms are included)
+2. **Identity loss**: Monitoring records use the parent's `id` — the `to_data_frame` merge overwrites the child's own id with the parent's
+3. **Ambiguous metadata**: `updated_at`/`updated_by` are overloaded to represent child submission time, while `created_at`/`created_by` always refer to the parent
+4. **Complex merging logic**: `download_data()` has intricate branching for `recent` vs `all` modes with child forms, date filters, and administration filters all interacting
+
+### Example
+
+Form: **EPS Inspection** (`1749623934933`, type=1 registration) has 2 monitoring forms:
+- **EPS Projects Construction - Monitoring** (`1749624452908`, type=2) — 40+ questions
+- **EPS Water Quality Testing - Monitoring** (`1749632545233`, type=2) — 15+ questions
+
+Current export: 1 Excel with all columns merged horizontally.
+
+### Desired Output
+
+A `.zip` file containing separate Excel files:
+```
+download-eps_inspection-260320-<uuid>.zip
+├── eps_inspection.xlsx                              (registration data only)
+├── eps_projects_construction_-_monitoring.xlsx       (monitoring data with parent_id)
+└── eps_water_quality_testing_-_monitoring.xlsx       (monitoring data with parent_id)
+```
+
+Each monitoring Excel has its own `id` column (the monitoring FormData.id) plus a `parent_id` column referencing the registration FormData.id.
+
+---
+
+## Design Decisions
+
+### D1: .zip format only when child forms are selected
+
+- **When `child_form_ids` is non-empty**: produce `.zip` with separate files
+- **When `child_form_ids` is empty** (registration-only export): keep current single `.xlsx` behavior — no breaking change
+
+### D2: Monitoring sheet meta columns
+
+Each monitoring Excel will have these meta columns:
+
+```python
+monitoring_meta_columns = [
+    "id",              # monitoring FormData.id (was parent id before)
+    "parent_id",       # registration FormData.id (NEW)
+    "datapoint_name",  # inherited from parent
+    "administration",  # inherited from parent
+    "geolocation",     # from monitoring record if available, else parent
+    "created_at",      # monitoring submission timestamp
+    "created_by",      # monitoring submitter
+]
+```
+
+Registration sheet keeps current `meta_columns` unchanged (no `parent_id`, no `uuid` in meta — `uuid` comes from `to_data_frame` as a question column).
+
+### D3: Download type behavior in split mode
+
+- **`recent`**: Each monitoring sheet contains only the **latest** submission per parent datapoint
+- **`all`**: Each monitoring sheet contains **all** submissions per parent datapoint (multiple rows per `parent_id`)
+
+### D4: Date filtering — independent per sheet (no regression)
+
+**Critical**: Current behavior couples parent inclusion to child date ranges (parent included if ANY child is in range). The split approach simplifies this without regression:
+
+- **Registration sheet**: Filter by parent's `created` date directly. No cross-form dependency needed because registration data stands alone.
+- **Monitoring sheets**: Filter by each monitoring record's `created` date directly. The `parent_id` column always references the parent regardless of whether the parent falls in the date range — this is a foreign key reference, not a filter.
+
+**Regression guard**: The current `download_data()` function is NOT deleted. It remains available for any other callers. The new zip path uses new functions that handle each form independently.
+
+### D5: Context sheet and definition sheets
+
+- **Registration Excel**: Gets context sheet (form name, download date, administration, date range) + definition sheet (questions + options for registration form only)
+- **Each monitoring Excel**: Gets its own definition sheet (questions + options for that monitoring form only). No context sheet duplication — context is in the registration file.
+
+### D6: File naming
+
+- Job `result` field stores `.zip` filename when child forms present
+- Individual Excel files inside zip use sanitized form names (lowercase, spaces → underscores)
+
+---
+
+## Implementation Plan
+
+### Phase 1: Add `monitoring_meta_columns` to `export_form.py`
+
+**File**: `backend/utils/export_form.py`
+
+```python
+monitoring_meta_columns = [
+    "id",
+    "parent_id",
+    "datapoint_name",
+    "administration",
+    "geolocation",
+    "created_at",
+    "created_by",
+]
+```
+
+No changes to existing `meta_columns`.
+
+### Phase 2: New function `download_monitoring_data()`
+
+**File**: `backend/api/v1/v1_jobs/job.py`
+
+```python
+def download_monitoring_data(
+    parent_form: Forms,
+    child_form: Forms,
+    administration_ids: list = None,
+    download_type: str = DataDownloadTypes.recent,
+    date_from: str = None,
+    date_to: str = None,
+) -> list:
+    """
+    Query monitoring FormData for a single child form.
+    Returns list of dicts with monitoring's own id + parent_id reference.
+    """
+```
+
+Key logic:
+1. Base filter: `FormData.objects.filter(form=child_form, parent__form=parent_form, parent__isnull=False, is_pending=False, is_draft=False)`
+2. Administration filter: `parent__administration_id__in=administration_ids` (monitoring inherits parent's administration context)
+3. Date filter: Apply `_build_date_filter()` directly on monitoring `created` field
+4. For `recent`: group by `parent_id`, take latest per group (`.order_by('parent_id', '-created').distinct('parent_id')` on PostgreSQL, or manual grouping fallback)
+5. For `all`: return all matching records ordered by `parent_id, created`
+6. Build each row:
+   ```python
+   row = child_fd.to_data_frame  # gets monitoring's own id and answers
+   row["parent_id"] = child_fd.parent_id
+   row["datapoint_name"] = child_fd.parent.name
+   row["administration"] = child_fd.parent.administration.administration_column
+   ```
+
+**Note**: `to_data_frame` already returns the FormData's own `id`, so no override needed. The `parent_id` is added as a new column.
+
+### Phase 3: New function `generate_monitoring_data_sheet()`
+
+**File**: `backend/api/v1/v1_jobs/job.py`
+
+```python
+def generate_monitoring_data_sheet(
+    writer: pd.ExcelWriter,
+    parent_form: Forms,
+    child_form: Forms,
+    administration_ids: list = None,
+    download_type: str = DataDownloadTypes.recent,
+    use_label: bool = True,
+    date_from: str = None,
+    date_to: str = None,
+) -> None:
+    """
+    Write one monitoring form's data to an Excel writer.
+    Similar to generate_data_sheet but uses monitoring_meta_columns
+    and generates definition sheet scoped to this child form only.
+    """
+```
+
+Logic mirrors `generate_data_sheet()` but:
+- Uses `download_monitoring_data()` instead of `download_data()`
+- Uses `monitoring_meta_columns` for column ordering
+- Uses `get_question_names(form=child_form)` — only child form questions
+- Generates `generate_definition_sheet(writer, form=child_form)` — no `child_form_ids` param
+- Same label conversion logic (option values → labels)
+
+### Phase 4: Refactor `job_generate_data_download()` — zip/excel split
+
+**File**: `backend/api/v1/v1_jobs/job.py`
+
+```python
+def job_generate_data_download(job_id, **kwargs):
+    job = Jobs.objects.get(pk=job_id)
+    child_form_ids = job.info.get("child_form_ids", [])
+
+    if child_form_ids:
+        return _generate_zip_download(job, **kwargs)
+    else:
+        return _generate_excel_download(job, **kwargs)
+```
+
+**`_generate_excel_download()`**: Extract current single-Excel logic from `job_generate_data_download()`. This handles registration-only exports. Calls existing `generate_data_sheet()` with `child_form_ids=[]` (no merging). **Existing behavior preserved exactly.**
+
+**`_generate_zip_download()`**:
+```python
+import zipfile
+
+def _generate_zip_download(job, **kwargs):
+    zip_path = f"./tmp/{job.result}"  # .zip filename
+    form = Forms.objects.get(pk=job.info.get("form_id"))
+    child_form_ids = job.info.get("child_form_ids", [])
+    child_forms = form.children.filter(pk__in=child_form_ids).all()
+    # ... extract administration_ids, download_type, use_label, dates ...
+
+    tmp_files = []
+    try:
+        with zipfile.ZipFile(zip_path, 'w', zipfile.ZIP_DEFLATED) as zf:
+            # 1. Registration Excel
+            reg_name = _sanitize_form_name(form.name)
+            reg_path = f"./tmp/reg_{job.id}.xlsx"
+            tmp_files.append(reg_path)
+            reg_writer = pd.ExcelWriter(reg_path, engine="xlsxwriter")
+            generate_data_sheet(
+                writer=reg_writer, form=form,
+                administration_ids=administration_ids,
+                download_type=download_type,
+                use_label=use_label,
+                child_form_ids=[],  # registration only
+                date_from=date_from, date_to=date_to,
+            )
+            _write_context_sheet(reg_writer, form, child_forms, job, ...)
+            reg_writer.save()
+            zf.write(reg_path, f"{reg_name}.xlsx")
+
+            # 2. One Excel per monitoring form
+            for child_form in child_forms:
+                child_name = _sanitize_form_name(child_form.name)
+                child_path = f"./tmp/child_{child_form.id}_{job.id}.xlsx"
+                tmp_files.append(child_path)
+                child_writer = pd.ExcelWriter(child_path, engine="xlsxwriter")
+                generate_monitoring_data_sheet(
+                    writer=child_writer,
+                    parent_form=form,
+                    child_form=child_form,
+                    administration_ids=administration_ids,
+                    download_type=download_type,
+                    use_label=use_label,
+                    date_from=date_from, date_to=date_to,
+                )
+                child_writer.save()
+                zf.write(child_path, f"{child_name}.xlsx")
+
+        url = upload(file=zip_path, folder="download")
+        return url
+    finally:
+        # Cleanup temp files
+        for f in tmp_files:
+            if os.path.exists(f):
+                os.remove(f)
+```
+
+### Phase 5: Extract context sheet helper
+
+**File**: `backend/api/v1/v1_jobs/job.py`
+
+Extract the context sheet generation from `job_generate_data_download()` into:
+
+```python
+def _write_context_sheet(writer, form, monitoring_forms, job,
+                         administration_name, date_from, date_to):
+    """Write the context/metadata sheet to an Excel writer."""
+```
+
+Used by both `_generate_excel_download()` and `_generate_zip_download()` (in the registration Excel only).
+
+### Phase 6: Update `job_download.py` command — .zip filename
+
+**File**: `backend/api/v1/v1_jobs/management/commands/job_download.py`
+
+Change filename generation:
+
+```python
+if child_form_ids:
+    out_file = "download-{0}-{1}-{2}.zip".format(
+        form_name, today, uuid.uuid4()
+    )
+else:
+    out_file = "download-{0}-{1}-{2}.xlsx".format(
+        form_name, today, uuid.uuid4()
+    )
+```
+
+### Phase 7: Update download file endpoint
+
+**File**: `backend/api/v1/v1_jobs/views.py`
+
+Update `download_file()` to handle `.zip` content type:
+
+```python
+if filename.endswith(".zip"):
+    content_type = "application/zip"
+elif filename.endswith(".docx"):
+    content_type = "application/vnd.openxmlformats-officedocument.wordprocessingml.document"
+else:
+    content_type = "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet"
+```
+
+---
+
+## Existing Functions: What Changes, What Stays
+
+| Function | Change? | Details |
+|----------|---------|---------|
+| `download_data()` | **NO CHANGE** | Kept as-is for backward compatibility. Still used by `_generate_excel_download()` for registration-only exports. |
+| `generate_data_sheet()` | **NO CHANGE** | Called with `child_form_ids=[]` in zip mode (registration only). Existing merged behavior still works for non-zip path. |
+| `_build_date_filter()` | **NO CHANGE** | Reused by both existing and new code paths. |
+| `get_question_names()` | **NO CHANGE** | Called per-form in new monitoring sheet function. |
+| `generate_definition_sheet()` | **NO CHANGE** | Called with single form (no `child_form_ids`) for monitoring sheets. |
+| `meta_columns` | **NO CHANGE** | Used for registration sheets as before. |
+| `job_generate_data_download()` | **REFACTORED** | Split into `_generate_zip_download()` and `_generate_excel_download()`. |
+| `job_download.py` command | **MODIFIED** | Filename extension changes based on child_form_ids. |
+| `views.py download_file()` | **MODIFIED** | Content type detection for .zip. |
+
+---
+
+## Date Filtering: Regression Prevention
+
+### Current behavior (merged mode)
+
+In `download_data()` with `child_form_ids` and date filter:
+1. Find children created in date range
+2. Get their parent IDs
+3. Also find parents created in date range themselves
+4. Union both sets of parent IDs
+5. Query parents by union of IDs
+6. For each parent, re-filter children by date range
+
+### New behavior (split mode) — equivalent results, simpler logic
+
+**Registration sheet** (date filter applied):
+- Parents filtered by their own `created` date
+- No child dependency — registration data is independent
+
+**Monitoring sheet** (date filter applied):
+- Monitoring records filtered by their own `created` date
+- `parent_id` column always populated (even if parent is outside date range)
+- Users can cross-reference via `parent_id` ↔ registration sheet `id`
+
+**Why no regression**: The split approach gives users **more data, not less**. In the merged mode, a parent outside the date range but with an in-range child would appear — and users see the parent's registration data. In split mode:
+- The monitoring sheet shows the in-range monitoring records with `parent_id`
+- The registration sheet may or may not include that parent (depending on its own date)
+- Users can still correlate via `parent_id`
+
+**If strict parity is needed**: Add a flag to include parents referenced by in-range monitoring records. But this adds complexity — recommend starting without it and validating with users.
+
+### Backward compatibility
+
+- `download_data()` is NOT modified — the merged mode still works exactly as before
+- `_generate_excel_download()` calls `download_data()` with the same parameters
+- Only the zip path uses the new `download_monitoring_data()` function
+
+---
+
+## Test Plan
+
+### Existing tests — verify no regression
+
+All existing tests must pass without modification:
+
+| Test File | Tests | Status |
+|-----------|-------|--------|
+| `tests_bulk_data_download.py` | `test_data_download_with_download_type_all` | Must pass (uses `download_data()` directly) |
+| | `test_data_download_with_download_type_all_no_children` | Must pass |
+| | `test_data_download_with_download_type_recent` | Must pass |
+| | `test_data_download_repeatable_questions` | Must pass |
+| | `test_data_download_list_of_columns` | Must pass |
+| | `test_generate_definition_sheet` | Must pass |
+| | `test_generate_definition_sheet_with_child_forms` | Must pass |
+| | `test_blank_data_template` | Must pass |
+| `tests_download_date_filter.py` | All 8 date filter tests | Must pass (uses `download_data()` directly) |
+| | `test_invalid_date_range_returns_400` | Must pass |
+| `tests_generate_excel_data_endpoint.py` | All 12 endpoint tests | Must pass |
+| `tests_job_download_command.py` | All 6 command tests | Must pass |
+| `tests_download_file_endpoint.py` | `test_successful_file_download` | Must pass |
+| `tests_download_status_endpoint.py` | Both status tests | Must pass |
+| `tests_download_list_endpoint.py` | Both list tests | Must pass |
+
+### New tests — split export coverage
+
+#### File: `tests_split_monitoring_export.py`
+
+**Setup**: Use existing test forms (form pk=1 with child form pk=10001) and seeded data.
+
+```
+Test 1: test_download_monitoring_data_returns_child_ids
+    - Call download_monitoring_data(parent_form, child_form)
+    - Assert each row has "id" != parent.id (it's the monitoring record's own id)
+    - Assert each row has "parent_id" matching a registration FormData.id
+    - Assert "parent_id" column exists in every row
+
+Test 2: test_download_monitoring_data_recent_one_per_parent
+    - Call with download_type="recent"
+    - Assert unique parent_ids == number of rows (one monitoring per parent)
+
+Test 3: test_download_monitoring_data_all_multiple_per_parent
+    - Call with download_type="all"
+    - Assert total rows >= number of unique parent_ids
+    - Assert rows are ordered by parent_id, created
+
+Test 4: test_download_monitoring_data_with_administration_filter
+    - Call with administration_ids=[specific_admin.id]
+    - Assert all rows' parent administration matches filter
+
+Test 5: test_download_monitoring_data_with_date_from
+    - Set known dates on monitoring records
+    - Call with date_from (exclude old monitoring records)
+    - Assert old monitoring records excluded
+    - Assert parent_id still references correct parent
+
+Test 6: test_download_monitoring_data_with_date_to
+    - Call with date_to (exclude recent monitoring records)
+    - Assert recent monitoring records excluded
+
+Test 7: test_download_monitoring_data_with_date_range
+    - Call with both date_from and date_to
+    - Assert only monitoring records within range returned
+
+Test 8: test_download_monitoring_data_date_boundary_inclusivity
+    - Set monitoring record to exactly date_from date
+    - Assert it is included (gte boundary)
+    - Set monitoring record to exactly date_to date
+    - Assert it is included (lt date_to+1 day)
+
+Test 9: test_download_monitoring_data_empty_result
+    - Call with date range that excludes all data
+    - Assert empty list returned
+
+Test 10: test_download_monitoring_data_with_date_and_administration
+    - Combine date range + administration filter
+    - Assert both filters applied correctly
+```
+
+#### File: `tests_zip_download.py`
+
+**Setup**: Use existing test forms with seeded data.
+
+```
+Test 11: test_zip_download_produces_zip_file
+    - Call job_generate_data_download with child_form_ids
+    - Assert result URL contains ".zip"
+    - Assert zip file exists in ./tmp/
+
+Test 12: test_zip_contains_correct_files
+    - Generate zip
+    - Open with zipfile.ZipFile
+    - Assert zip contains N+1 files (1 registration + N monitoring)
+    - Assert filenames match sanitized form names
+
+Test 13: test_zip_registration_excel_has_correct_columns
+    - Extract registration Excel from zip
+    - Read with pd.read_excel
+    - Assert meta_columns present
+    - Assert NO monitoring question columns
+    - Assert "parent_id" NOT in columns
+
+Test 14: test_zip_monitoring_excel_has_correct_columns
+    - Extract monitoring Excel from zip
+    - Read with pd.read_excel
+    - Assert monitoring_meta_columns present (id, parent_id, datapoint_name, ...)
+    - Assert only monitoring form's question columns present
+    - Assert NO registration question columns
+
+Test 15: test_zip_monitoring_parent_id_references_valid
+    - Extract both registration and monitoring Excels
+    - Assert every parent_id in monitoring sheet exists as id in registration sheet
+
+Test 16: test_zip_download_without_child_forms_produces_xlsx
+    - Call job_generate_data_download without child_form_ids
+    - Assert result URL contains ".xlsx" (not .zip)
+    - Existing behavior preserved
+
+Test 17: test_zip_monitoring_recent_mode
+    - Generate zip with download_type="recent"
+    - Read monitoring Excel
+    - Assert unique parent_ids == row count
+
+Test 18: test_zip_monitoring_all_mode
+    - Generate zip with download_type="all"
+    - Read monitoring Excel
+    - Assert total rows >= unique parent_ids
+
+Test 19: test_zip_download_with_date_filter
+    - Set known dates on data
+    - Generate zip with date_from/date_to
+    - Read registration Excel: assert only in-range parents
+    - Read monitoring Excel: assert only in-range monitoring records
+    - Assert parent_id references still valid (even if parent not in registration sheet)
+
+Test 20: test_zip_download_with_administration_filter
+    - Generate zip with administration_id
+    - Read both Excels
+    - Assert administration filter applied to both
+
+Test 21: test_zip_definition_sheets_per_form
+    - Extract registration Excel: assert "questions" sheet has only registration questions
+    - Extract monitoring Excel: assert "questions" sheet has only that monitoring form's questions
+
+Test 22: test_zip_context_sheet_in_registration_only
+    - Assert registration Excel has "context" sheet
+    - Assert monitoring Excels do NOT have "context" sheet (or have minimal info)
+
+Test 23: test_zip_with_use_label_true
+    - Generate zip with use_label=True
+    - Assert option questions show labels not values in both Excels
+
+Test 24: test_zip_with_use_label_false
+    - Generate zip with use_label=False
+    - Assert option questions show raw values
+
+Test 25: test_zip_empty_monitoring_data
+    - Remove/mark-pending all monitoring submissions for one child form
+    - Generate zip
+    - Assert that monitoring Excel either has blank template or is omitted
+```
+
+#### File: `tests_job_download_command.py` (additions)
+
+```
+Test 26: test_download_command_produces_zip_filename
+    - Call job_download command with child_form_ids
+    - Assert job.result ends with ".zip"
+
+Test 27: test_download_command_without_children_produces_xlsx
+    - Call job_download command without child_form_ids
+    - Assert job.result ends with ".xlsx"
+```
+
+#### File: `tests_download_file_endpoint.py` (additions)
+
+```
+Test 28: test_successful_zip_file_download
+    - Create a .zip test file and upload
+    - Create Job with result=filename.zip
+    - GET /api/v1/download/file/{filename.zip}
+    - Assert 200 OK
+    - Assert Content-Type is "application/zip"
+    - Assert Content-Disposition has .zip filename
+```
+
+#### File: `tests_download_date_filter.py` (additions for split mode)
+
+```
+Test 29: test_monitoring_date_filter_independent_from_parent
+    - Parent created 5 days ago (outside range)
+    - Monitoring created yesterday (in range)
+    - Call download_monitoring_data with date_from=yesterday
+    - Assert monitoring record IS returned
+    - Assert parent_id references the old parent
+
+Test 30: test_monitoring_date_filter_excludes_out_of_range
+    - Parent created yesterday, monitoring created 5 days ago
+    - Call download_monitoring_data with date_from=yesterday
+    - Assert monitoring record is NOT returned (monitoring itself is out of range)
+
+Test 31: test_registration_date_filter_no_child_dependency
+    - Parent created yesterday, all monitoring created 5 days ago
+    - Call download_registration_data (via generate_data_sheet with child_form_ids=[])
+    - Assert parent IS included (filtered by own date, not child dates)
+```
+
+---
+
+## Files to Modify
+
+| File | Changes |
+|------|---------|
+| `backend/api/v1/v1_jobs/job.py` | Add `download_monitoring_data()`, `generate_monitoring_data_sheet()`, `_generate_zip_download()`, `_generate_excel_download()`, `_write_context_sheet()`, `_sanitize_form_name()`. Refactor `job_generate_data_download()`. |
+| `backend/utils/export_form.py` | Add `monitoring_meta_columns` list |
+| `backend/api/v1/v1_jobs/management/commands/job_download.py` | `.zip` vs `.xlsx` filename based on `child_form_ids` |
+| `backend/api/v1/v1_jobs/views.py` | Content type detection for `.zip` in `download_file()` |
+
+## Files NOT Modified
+
+| File | Reason |
+|------|--------|
+| `backend/api/v1/v1_data/models.py` | `to_data_frame` already returns FormData's own `id`; `parent_id` is a model field accessible directly |
+| `backend/api/v1/v1_forms/models.py` | Parent-child relationship already works |
+| `backend/api/v1/v1_jobs/models.py` | `result` field stores any filename string |
+| `backend/api/v1/v1_jobs/constants.py` | No new job types or download types needed |
+| `backend/api/v1/v1_jobs/serializers.py` | Request parameters unchanged |
+
+## New Test Files
+
+| File | Coverage |
+|------|----------|
+| `backend/api/v1/v1_jobs/tests/tests_split_monitoring_export.py` | Tests 1-10: `download_monitoring_data()` unit tests |
+| `backend/api/v1/v1_jobs/tests/tests_zip_download.py` | Tests 11-25: End-to-end zip generation tests |
+
+---
+
+## Execution Order
+
+1. **Phase 1**: Add `monitoring_meta_columns` to `export_form.py`
+2. **Phase 2-3**: New `download_monitoring_data()` + `generate_monitoring_data_sheet()` + tests 1-10
+3. **Phase 4-5**: Refactor `job_generate_data_download()` + context helper + tests 11-25
+4. **Phase 6**: Update `job_download.py` command + tests 26-27
+5. **Phase 7**: Update download file endpoint + test 28
+6. **Final**: Run full test suite, verify all existing tests pass (tests 29-31 for date filter regression)
+
+## Risk Mitigation
+
+- **No deletion of existing functions**: `download_data()` and `generate_data_sheet()` remain intact
+- **Feature flag approach**: The zip/excel split is naturally gated by `child_form_ids` — empty means old behavior
+- **Temp file cleanup**: Use `try/finally` to ensure intermediate Excel files are removed after zipping
+- **PostgreSQL-specific `distinct('parent_id')`**: If needed, provide a fallback using Python grouping for test environments using SQLite

--- a/frontend/src/components/filters/DataFilters.js
+++ b/frontend/src/components/filters/DataFilters.js
@@ -29,6 +29,7 @@ import {
   DownOutlined,
   SearchOutlined,
   CalendarOutlined,
+  FileZipOutlined,
 } from "@ant-design/icons";
 import { Can } from "../can/index.js";
 
@@ -55,7 +56,8 @@ const DataFilters = ({
   const { notify } = useNotification();
   const [exporting, setExporting] = useState(false);
   const [downloading, setDownloading] = useState(false);
-  const [selectedChildForms, setSelectedChildForms] = useState([]);
+  const [excelChildForms, setExcelChildForms] = useState([]);
+  const [docxChildForms, setDocxChildForms] = useState([]);
   const [openDocx, setOpenDocx] = useState(false);
   const [openExcel, setOpenExcel] = useState(false);
   const [downloadType, setDownloadType] = useState("recent");
@@ -77,17 +79,23 @@ const DataFilters = ({
     setExporting(true);
     try {
       const adm_id = selectedAdm?.id;
-      const childFormIds = selectedChildForms
+      const childFormIds = excelChildForms
         .map((id) => `child_form_ids=${id}`)
         .join("&");
       const urls = [`download/generate?form_id=${selectedForm}`];
       if (adm_id && selectedAdm?.parent) {
         urls.push(`administration_id=${adm_id}`);
       }
-      if (selectedChildForms.length) {
+      if (excelChildForms.length) {
         urls.push(childFormIds);
       }
-      if (["all", "recent"].includes(downloadType)) {
+      if (selectedRowKeys.length) {
+        const selectionIds = selectedRowKeys
+          .map((id) => `selection_ids=${id}`)
+          .join("&");
+        urls.push(selectionIds);
+      }
+      if (!selectedRowKeys.length && ["all", "recent"].includes(downloadType)) {
         urls.push(`type=${downloadType}`);
       }
       if (dateRange && dateRange.length === 2 && dateRange[0] && dateRange[1]) {
@@ -113,10 +121,11 @@ const DataFilters = ({
   }, [
     selectedAdm,
     selectedForm,
-    selectedChildForms,
+    excelChildForms,
     notify,
     downloadType,
     dateRange,
+    selectedRowKeys,
     text.export2ExcelSuccess,
     text.export2ExcelError,
     navigate,
@@ -125,16 +134,14 @@ const DataFilters = ({
   const export2Docx = useCallback(async () => {
     setDownloading(true);
     try {
-      // Create parameters list URL for selection_ids based on selectedRowKeys
       const selectionIds = selectedRowKeys
         .map((id) => `selection_ids=${id}`)
         .join("&");
-      const childFormIds = selectedChildForms
+      const childFormIds = docxChildForms
         .map((id) => `child_form_ids=${id}`)
         .join("&");
-      // If no child forms are selected, use the selected form
       let apiURL = `/download/datapoint-report?form_id=${selectedForm}&${selectionIds}`;
-      if (selectedChildForms.length) {
+      if (docxChildForms.length) {
         apiURL += `&${childFormIds}`;
       }
       await api.get(apiURL);
@@ -155,7 +162,7 @@ const DataFilters = ({
     }
   }, [
     selectedRowKeys,
-    selectedChildForms,
+    docxChildForms,
     notify,
     selectedForm,
     text.downloadReportError,
@@ -179,28 +186,29 @@ const DataFilters = ({
     });
   }, []);
 
-  const childFormMenuItems = useMemo(() => {
-    const formItems = childForms.map((form) => ({
-      key: form.id,
-      label: (
-        <Checkbox
-          checked={selectedChildForms.includes(form.id)}
-          onChange={(e) => {
-            const { checked } = e.target;
-            if (checked) {
-              setSelectedChildForms([...selectedChildForms, form.id]);
-            } else {
-              setSelectedChildForms(
-                selectedChildForms.filter((id) => id !== form.id)
-              );
-            }
-          }}
-        >
-          {form.content.name}
-        </Checkbox>
-      ),
-    }));
+  const buildCheckboxItems = useCallback(
+    (selected, setSelected) =>
+      childForms.map((form) => ({
+        key: form.id,
+        label: (
+          <Checkbox
+            checked={selected.includes(form.id)}
+            onChange={(e) => {
+              if (e.target.checked) {
+                setSelected([...selected, form.id]);
+              } else {
+                setSelected(selected.filter((id) => id !== form.id));
+              }
+            }}
+          >
+            {form.content.name}
+          </Checkbox>
+        ),
+      })),
+    [childForms]
+  );
 
+  const excelMenuItems = useMemo(() => {
     const menuItems = [];
 
     if (childForms.length > 0) {
@@ -216,7 +224,7 @@ const DataFilters = ({
           ),
           disabled: true,
         },
-        ...formItems,
+        ...buildCheckboxItems(excelChildForms, setExcelChildForms),
         {
           key: "divider",
           type: "divider",
@@ -224,7 +232,7 @@ const DataFilters = ({
       );
     }
 
-    if (openExcel) {
+    if (!selectedRowKeys.length) {
       menuItems.push({
         key: "download-type",
         label: (
@@ -246,16 +254,66 @@ const DataFilters = ({
         label: (
           <Button
             type="primary"
+            icon={<FileZipOutlined />}
+            loading={exporting}
+            onClick={export2Excel}
+            style={{ width: "100%" }}
+          >
+            {text.downloadData}
+          </Button>
+        ),
+        disabled: true,
+      },
+    ];
+  }, [
+    childForms,
+    buildCheckboxItems,
+    excelChildForms,
+    selectedRowKeys,
+    downloadType,
+    exporting,
+    text.selectChildForms,
+    text.allData,
+    text.latestData,
+    text.downloadData,
+    export2Excel,
+  ]);
+
+  const docxMenuItems = useMemo(() => {
+    const menuItems = [];
+
+    if (childForms.length > 0) {
+      menuItems.push(
+        {
+          key: "header",
+          label: (
+            <div
+              style={{ fontWeight: 500, color: "#262626", padding: "4px 0" }}
+            >
+              {text.selectChildForms}
+            </div>
+          ),
+          disabled: true,
+        },
+        ...buildCheckboxItems(docxChildForms, setDocxChildForms),
+        {
+          key: "divider",
+          type: "divider",
+        }
+      );
+    }
+
+    return [
+      ...menuItems,
+      {
+        key: "download-footer",
+        label: (
+          <Button
+            type="primary"
             icon={<FileWordOutlined />}
             loading={downloading}
-            onClick={() => {
-              if (openExcel) {
-                export2Excel();
-              } else {
-                export2Docx();
-              }
-            }}
-            disabled={openDocx && !selectedRowKeys?.length}
+            onClick={export2Docx}
+            disabled={!selectedRowKeys?.length}
             style={{ width: "100%" }}
           >
             {text.downloadReport}
@@ -266,18 +324,13 @@ const DataFilters = ({
     ];
   }, [
     childForms,
-    selectedChildForms,
+    buildCheckboxItems,
+    docxChildForms,
     downloading,
-    openExcel,
-    openDocx,
-    downloadType,
     selectedRowKeys,
-    text.downloadReport,
     text.selectChildForms,
-    text.allData,
-    text.latestData,
+    text.downloadReport,
     export2Docx,
-    export2Excel,
   ]);
 
   return (
@@ -321,7 +374,7 @@ const DataFilters = ({
                     open={openDocx}
                     onOpenChange={setOpenDocx}
                     menu={{
-                      items: childFormMenuItems,
+                      items: docxMenuItems,
                       style: { minWidth: "200px" },
                     }}
                     disabled={!selectedRowKeys.length}
@@ -347,18 +400,20 @@ const DataFilters = ({
                   open={openExcel}
                   onOpenChange={setOpenExcel}
                   menu={{
-                    items: childFormMenuItems,
+                    items: excelMenuItems,
                     style: { minWidth: "200px" },
                   }}
                   placement="bottomRight"
                 >
-                  <Button
-                    icon={<DownloadOutlined />}
-                    shape="round"
-                    loading={exporting}
-                  >
-                    {text.download}
-                  </Button>
+                  <Badge count={selectedRowKeys.length}>
+                    <Button
+                      icon={<DownloadOutlined />}
+                      shape="round"
+                      loading={exporting}
+                    >
+                      {text.download}
+                    </Button>
+                  </Badge>
                 </Dropdown>
               </Can>
             )}

--- a/frontend/src/lib/__test__/__snapshots__/ui-text.test.js.snap
+++ b/frontend/src/lib/__test__/__snapshots__/ui-text.test.js.snap
@@ -246,6 +246,7 @@ Object {
       </b>
        using the QR codes below
     </React.Fragment>,
+    "downloadData": "Download Data",
     "downloadHere": "download here",
     "downloadReport": "Download Report",
     "downloadReportError": "Unable to download report",

--- a/frontend/src/lib/ui-text.js
+++ b/frontend/src/lib/ui-text.js
@@ -923,6 +923,7 @@ const uiText = {
     downloadReport: "Download Report",
     downloadReportSuccess: "Report downloaded successfully",
     downloadReportError: "Unable to download report",
+    downloadData: "Download Data",
     bulkUpload: "Bulk Upload",
     selectChildForms: "Select Monitoring Forms",
     allData: "All Data",

--- a/frontend/src/pages/downloads/components/DownloadTable.jsx
+++ b/frontend/src/pages/downloads/components/DownloadTable.jsx
@@ -9,12 +9,12 @@ import {
   List,
 } from "antd";
 import {
-  FileTextFilled,
   LoadingOutlined,
   DownloadOutlined,
   ExclamationCircleOutlined,
   FileMarkdownFilled,
   FileWordFilled,
+  FileZipFilled,
 } from "@ant-design/icons";
 import { api, store, uiText } from "../../../lib";
 import { useNotification } from "../../../util/hooks";
@@ -31,7 +31,7 @@ const DownloadIcon = ({ type }) => {
     case "download_entities":
       return <FileMarkdownFilled style={{ color: "blue" }} />;
     default:
-      return <FileTextFilled style={{ color: "green" }} />;
+      return <FileZipFilled style={{ color: "green" }} />;
   }
 };
 

--- a/frontend/src/pages/downloads/components/DownloadTable.jsx
+++ b/frontend/src/pages/downloads/components/DownloadTable.jsx
@@ -15,6 +15,7 @@ import {
   FileMarkdownFilled,
   FileWordFilled,
   FileZipFilled,
+  FileExcelFilled,
 } from "@ant-design/icons";
 import { api, store, uiText } from "../../../lib";
 import { useNotification } from "../../../util/hooks";
@@ -30,6 +31,8 @@ const DownloadIcon = ({ type }) => {
     case "download_administration":
     case "download_entities":
       return <FileMarkdownFilled style={{ color: "blue" }} />;
+    case "download_excel":
+      return <FileExcelFilled style={{ color: "green" }} />;
     default:
       return <FileZipFilled style={{ color: "green" }} />;
   }
@@ -155,9 +158,12 @@ const DownloadTable = ({ type = "download" }) => {
   const columns = [
     {
       dataIndex: "type",
-      render: (value) => (
-        <DownloadIcon type={value} style={{ fontSize: "20px" }} />
-      ),
+      render: (value, { attributes }) => {
+        const downloadType = attributes?.length ? value : "download_excel";
+        return (
+          <DownloadIcon type={downloadType} style={{ fontSize: "20px" }} />
+        );
+      },
       width: 40,
     },
     {
@@ -176,7 +182,7 @@ const DownloadTable = ({ type = "download" }) => {
           <div>
             <strong>{row?.form || row?.category}</strong>
           </div>
-          {row?.download_type && (
+          {row?.download_type && row?.attributes?.length > 0 && (
             <span
               className={`download-filter download-type ${row.download_type.toLowerCase()}`}
             >{`${row.download_type} Data - `}</span>

--- a/frontend/src/pages/manage-data/components/ManageDataTable.jsx
+++ b/frontend/src/pages/manage-data/components/ManageDataTable.jsx
@@ -181,6 +181,10 @@ const ManageDataTable = ({
   }, [setSelectedRowKeys]);
 
   useEffect(() => {
+    setSelectedRowKeys([]);
+  }, [administration, setSelectedRowKeys]);
+
+  useEffect(() => {
     setCurrentPage(1);
     setUpdateRecord(true);
   }, [search]);


### PR DESCRIPTION
## Problem

1. **Export bundling**: When downloading data with monitoring (child) forms, all data was merged into a single Excel sheet — making it hard to distinguish registration vs monitoring data.
2. **Selection ignored**: The Excel download button ignored `selectedRowKeys` — users could select specific rows but only the DOCX report respected the selection. The two download dropdowns also shared child form state, causing cross-contamination.

## Solution

### Part 1: Split registration and monitoring into separate files

When child forms are selected, the download produces a **ZIP file** containing:
- One Excel file for **registration data** (parent form only)
- One Excel file **per monitoring form** (with `parent_id` column linking back)

When no child forms are selected, behavior is unchanged (single `.xlsx`).

### Part 2: Selection-aware Excel download

When rows are selected in the data table:
- The "All data" / "Latest data" radio disappears from the Excel dropdown
- `selection_ids` are sent to the backend, which filters to only those registration rows
- A badge shows the selection count on the Excel download button
- The download list shows selected datapoint names (as clickable links) instead of download type

Each dropdown (Excel and DOCX) now has **independent child form state** so checking a child form in one doesn't affect the other.

## Changes

### Backend

| File | Change |
|------|--------|
| `backend/api/v1/v1_jobs/job.py` | Split ZIP generation (`_generate_zip_download`), separate `generate_monitoring_data_sheet` with `monitoring_meta_columns`, `selection_ids` filtering in `download_data` and `download_monitoring_data` |
| `backend/api/v1/v1_jobs/serializers.py` | Add `selection_ids` to `DownloadDataRequestSerializer` (restricted to registration data), update `DownloadListSerializer` to show selected datapoints and null `download_type` when selection present |
| `backend/api/v1/v1_jobs/views.py` | Pass `selection_ids` to command, `application/zip` content type for zip downloads |
| `backend/api/v1/v1_jobs/management/commands/job_download.py` | Add `-s`/`--selection_ids` argument, `.zip` extension when child forms selected |

### Frontend

| File | Change |
|------|--------|
| `frontend/src/components/filters/DataFilters.js` | Split into `excelChildForms`/`docxChildForms` independent state, `buildCheckboxItems` reusable callback, conditional radio hide, `selection_ids` in API call, badge on Excel button |
| `frontend/src/pages/manage-data/components/ManageDataTable.jsx` | Reset `selectedRowKeys` on administration change |
| `frontend/src/lib/ui-text.js` | Add `downloadData` text key |

### Tests

| File | Tests |
|------|-------|
| `backend/api/v1/v1_jobs/tests/tests_zip_download.py` | 13 tests for ZIP structure, registration/monitoring split, recent/all modes, date filter, context sheet |
| `backend/api/v1/v1_jobs/tests/tests_zip_download_with_selection_ids.py` | 6 tests for selection_ids filtering, empty fallback, command args, API endpoint |

### Docs

| File | Content |
|------|---------|
| `doc/claude/split-reg-monitoring-export.md` | Plan for ZIP split feature |
| `doc/claude/selection-aware-excel-download.md` | Plan for selection-aware download |

## Test plan

- [ ] Download with child forms selected (no row selection) — produces ZIP with separate registration + monitoring Excel files
- [ ] Download without child forms — produces single `.xlsx` (unchanged)
- [ ] Select rows → Excel dropdown hides "All data"/"Latest data" radio, shows badge count
- [ ] Select rows → download only contains selected registration data and their monitoring children
- [ ] Deselect rows → reverts to original behavior with radio options
- [ ] Check child form in Excel dropdown — DOCX dropdown is unaffected (independent state)
- [ ] Change administration dropdown — row selection resets
- [ ] Download list page — selection-based downloads show datapoint names as links, no download type label
- [ ] Backend tests pass: `python manage.py test api.v1.v1_jobs.tests`


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1213638849274115