### PR TITLE
Feature/194 visualization human readable dashboard url

### DIFF
--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -107,7 +107,7 @@ const RouteList = () => {
       <Route exact path="/login/:invitationId" element={<Login />} />
       <Route exact path="/forgot-password" element={<Login />} />
       <Route exact path="/data" element={<Home />} />
-      <Route exact path="/dashboard/:formId" element={<Dashboard />} />
+      <Route exact path="/dashboard/:slug" element={<Dashboard />} />
       <Route
         path="/control-center"
         element={

--- a/frontend/src/components/layout/Header.jsx
+++ b/frontend/src/components/layout/Header.jsx
@@ -6,8 +6,7 @@ import { FaChevronDown } from "react-icons/fa";
 import { Link, useLocation, useNavigate } from "react-router-dom";
 import { config, store, uiText } from "../../lib";
 import { eraseCookieFromAllPaths } from "../../util/date";
-import { listVisualizationFormIds } from "../../config/visualizations";
-import CONFIGS from "../../config/visualizations";
+import { listVisualizations } from "../../config/visualizations";
 
 const Header = ({ className = "header", ...props }) => {
   const { isLoggedIn, user } = store.useState();
@@ -18,14 +17,11 @@ const Header = ({ className = "header", ...props }) => {
   const text = useMemo(() => {
     return uiText[activeLang];
   }, [activeLang]);
-  const dashboardFormIds = useMemo(() => listVisualizationFormIds(), []);
-  const dashboardForms = useMemo(
-    () =>
-      (window?.forms || [])
-        .filter((f) => dashboardFormIds.includes(f.id))
-        .map((f) => ({ id: f.id, name: CONFIGS[f.id]?.name || f.name })),
-    [dashboardFormIds]
-  );
+  const dashboardForms = useMemo(() => {
+    const registered = listVisualizations();
+    const availableFormIds = new Set((window?.forms || []).map((f) => f.id));
+    return registered.filter((d) => availableFormIds.has(d.parent_form_id));
+  }, []);
   const showDashboardsMenu =
     location.pathname.startsWith("/control-center") ||
     location.pathname.startsWith("/dashboard");
@@ -87,11 +83,11 @@ const Header = ({ className = "header", ...props }) => {
   const DashboardMenu = useMemo(() => {
     return dashboardForms?.map((d) => {
       return {
-        key: d.id,
+        key: d.slug,
         label: (
           <Link
-            key={`${d.id}`}
-            to={`/dashboard/${d.id}`}
+            key={d.slug}
+            to={`/dashboard/${d.slug}`}
             className="dropdown-menu-item"
           >
             {d.name}

--- a/frontend/src/config/visualizations/1749623934933.json
+++ b/frontend/src/config/visualizations/1749623934933.json
@@ -1,5 +1,6 @@
 {
   "parent_form_id": 1749623934933,
+  "slug": "eps-overview",
   "name": "EPS Overview",
   "description": "Overview of EPS sites monitoring, water quality and construction information.",
   "fiscal_year_start_month": 1,

--- a/frontend/src/config/visualizations/README.md
+++ b/frontend/src/config/visualizations/README.md
@@ -1,10 +1,10 @@
 # Dashboard Visualization Configs
 
 JSON files in this directory drive the config-driven dashboards rendered at
-`/dashboard/:formId`. Each file is a single dashboard definition keyed by the
-parent form's ID. **No component code changes are required to add a new
+`/dashboard/:slug`. Each file is a single dashboard definition identified by a
+kebab-case `slug`. **No component code changes are required to add a new
 dashboard** — drop a JSON file here, register it in [`index.js`](./index.js),
-and visit `/dashboard/<formId>`.
+and visit `/dashboard/<slug>`.
 
 ## Quick start — add a new dashboard
 
@@ -24,6 +24,7 @@ Minimum required top-level keys:
 ```json
 {
   "parent_form_id": 123,
+  "slug": "my-dashboard",
   "name": "My Dashboard",
   "description": "Optional subtitle shown on the page.",
   "fiscal_year_start_month": 1,
@@ -31,8 +32,9 @@ Minimum required top-level keys:
 }
 ```
 
-Everything else — filters, KPIs, charts, tables, maps — is an **item** inside
-`items[]`.
+`slug` is the public route identifier. It must be unique across all
+dashboards and match `^[a-z0-9]+(-[a-z0-9]+)*$` (kebab-case). Everything else
+— filters, KPIs, charts, tables, maps — is an **item** inside `items[]`.
 
 ### 3. Register the config
 
@@ -41,16 +43,17 @@ Add the import + entry in [`index.js`](./index.js):
 ```js
 import myDashboard from "./123.json";
 
-const CONFIGS = {
-  [epsOverview.parent_form_id]: epsOverview,
-  [myDashboard.parent_form_id]: myDashboard,
-};
+const RAW_CONFIGS = [epsOverview, myDashboard];
 ```
+
+Configs with a missing, invalid, or duplicate slug are warned in the dev
+console and skipped; the app still boots. Navigation to an unresolved slug
+redirects to `/control-center`.
 
 ### 4. Visit the route
 
-`/dashboard/123` will render the new dashboard. No component or route code
-changes required.
+`/dashboard/my-dashboard` will render the new dashboard. No component or route
+code changes required.
 
 ---
 
@@ -61,6 +64,7 @@ changes required.
 ```json
 {
   "parent_form_id": 123,
+  "slug": "my-dashboard",
   "name": "My Dashboard",
   "description": "...",
   "fiscal_year_start_month": 1,
@@ -68,7 +72,7 @@ changes required.
 }
 ```
 
-Only these five keys at the top level. Everything else is an item.
+Only these six keys at the top level. Everything else is an item.
 
 ### Common item fields
 
@@ -259,7 +263,7 @@ columns resolved by the renderer:
 ## Testing a new config
 
 1. Start the stack: `./dc.sh up -d`
-2. Open `http://localhost:3000/dashboard/<parent_form_id>`
+2. Open `http://localhost:3000/dashboard/<slug>`
 3. Verify each tab renders without console errors
 4. Click through the filter bar — KPIs and charts should re-fetch and redraw
 5. If a chart shows "No data", check that the corresponding backend response

--- a/frontend/src/config/visualizations/index.js
+++ b/frontend/src/config/visualizations/index.js
@@ -1,23 +1,68 @@
 import epsOverview from "./1749623934933.json";
 
 /**
- * Registry of dashboard configs keyed by `parent_form_id`.
- * To add a new dashboard: drop a `<formId>.json` in this directory and
- * register it below.
+ * Registry of dashboard configs keyed by `slug`.
+ *
+ * To add a new dashboard:
+ *   1. Drop a JSON file in this directory with a kebab-case `"slug"` field at
+ *      the top level (e.g. `"slug": "my-dashboard"`).
+ *   2. Import it below and append to `RAW_CONFIGS`.
+ *
+ * Configs with a missing, invalid, or duplicate slug are warned and skipped;
+ * the app still boots. Navigation to an unresolved slug redirects to
+ * `/control-center`.
  */
-const CONFIGS = {
-  [epsOverview.parent_form_id]: epsOverview,
+const RAW_CONFIGS = [epsOverview];
+
+const SLUG_PATTERN = /^[a-z0-9]+(-[a-z0-9]+)*$/;
+
+const SLUG_INDEX = new Map();
+
+RAW_CONFIGS.forEach((config) => {
+  const slug = config?.slug;
+  const parentFormId = config?.parent_form_id;
+  if (!slug) {
+    // eslint-disable-next-line no-console
+    console.warn(
+      `[visualizations] parent_form_id=${parentFormId}: missing "slug", skipped`
+    );
+    return;
+  }
+  if (typeof slug !== "string" || !SLUG_PATTERN.test(slug)) {
+    // eslint-disable-next-line no-console
+    console.warn(
+      `[visualizations] parent_form_id=${parentFormId}: invalid slug "${slug}" (must be kebab-case), skipped`
+    );
+    return;
+  }
+  if (SLUG_INDEX.has(slug)) {
+    // eslint-disable-next-line no-console
+    console.warn(
+      `[visualizations] duplicate slug "${slug}"; skipping parent_form_id=${parentFormId}`
+    );
+    return;
+  }
+  SLUG_INDEX.set(slug, config);
+});
+
+/**
+ * @param {string} slug
+ * @returns {object|null} The dashboard config, or null if none is registered.
+ */
+export const getVisualizationConfigBySlug = (slug) => {
+  if (!slug) {
+    return null;
+  }
+  return SLUG_INDEX.get(String(slug)) || null;
 };
 
 /**
- * @param {number|string} formId
- * @returns {object|null} The dashboard config, or null if none is registered.
+ * Enumerate all registered dashboards for menu rendering.
+ * @returns {Array<{slug: string, name: string, parent_form_id: number}>}
  */
-export const getVisualizationConfig = (formId) => {
-  const key = Number(formId);
-  return CONFIGS[key] || null;
-};
-
-export const listVisualizationFormIds = () => Object.keys(CONFIGS).map(Number);
-
-export default CONFIGS;
+export const listVisualizations = () =>
+  Array.from(SLUG_INDEX.values()).map((c) => ({
+    slug: c.slug,
+    name: c.name,
+    parent_form_id: c.parent_form_id,
+  }));

--- a/frontend/src/config/visualizations/index.js
+++ b/frontend/src/config/visualizations/index.js
@@ -18,20 +18,31 @@ const SLUG_PATTERN = /^[a-z0-9]+(-[a-z0-9]+)*$/;
 
 const SLUG_INDEX = new Map();
 
-RAW_CONFIGS.forEach((config) => {
+RAW_CONFIGS.forEach((config, index) => {
   const slug = config?.slug;
   const parentFormId = config?.parent_form_id;
+  // Prefer slug in diagnostics when available; otherwise the array index
+  // so a misconfigured entry is still identifiable in the console.
+  const ref = slug ? `slug="${slug}"` : `entry #${index}`;
+
   if (!slug) {
     // eslint-disable-next-line no-console
     console.warn(
-      `[visualizations] parent_form_id=${parentFormId}: missing "slug", skipped`
+      `[visualizations] ${ref} (parent_form_id=${parentFormId}): missing "slug", skipped`
     );
     return;
   }
   if (typeof slug !== "string" || !SLUG_PATTERN.test(slug)) {
     // eslint-disable-next-line no-console
     console.warn(
-      `[visualizations] parent_form_id=${parentFormId}: invalid slug "${slug}" (must be kebab-case), skipped`
+      `[visualizations] ${ref}: invalid slug "${slug}" (must be kebab-case), skipped`
+    );
+    return;
+  }
+  if (typeof parentFormId !== "number" || !Number.isFinite(parentFormId)) {
+    // eslint-disable-next-line no-console
+    console.warn(
+      `[visualizations] ${ref}: missing or invalid "parent_form_id" (must be a finite number), skipped`
     );
     return;
   }

--- a/frontend/src/pages/dashboard/Dashboard.jsx
+++ b/frontend/src/pages/dashboard/Dashboard.jsx
@@ -1,6 +1,6 @@
 import React, { useCallback, useMemo, useState, useEffect } from "react";
-import { useParams } from "react-router-dom";
-import { Alert, Col, Empty, Row, Typography } from "antd";
+import { Navigate, useParams } from "react-router-dom";
+import { Alert, Col, Row, Typography } from "antd";
 import {
   useDashboardConfig,
   useDashboardFilters,
@@ -124,11 +124,11 @@ const collectComplianceParamIds = (items = []) => {
  * by param item id) and `cellComputersById` (keyed by table item id) then
  * injected into DashboardRenderer as context.
  *
- * Route: /dashboard/:formId
+ * Route: /dashboard/:slug
  */
 const Dashboard = () => {
-  const { formId } = useParams();
-  const { config, definitionsById } = useDashboardConfig(formId);
+  const { slug } = useParams();
+  const { config, definitionsById } = useDashboardConfig(slug);
 
   // Component-scoped "now" anchor; threaded into DashboardRenderer so
   // mark_lines with type="today" can resolve to an axis-matching label.
@@ -345,13 +345,9 @@ const Dashboard = () => {
   if (!config) {
     // eslint-disable-next-line no-console
     console.warn(
-      `No dashboard config registered for formId=${formId}. Drop a JSON file in src/config/visualizations/ and register it in index.js.`
+      `No dashboard config registered for slug="${slug}". Drop a JSON file in src/config/visualizations/ with a matching "slug" field and register it in index.js.`
     );
-    return (
-      <div className="dashboard">
-        <Empty description="This dashboard isn't available yet." />
-      </div>
-    );
+    return <Navigate to="/control-center" replace />;
   }
 
   return (

--- a/frontend/src/util/__test__/useDashboardConfig.test.js
+++ b/frontend/src/util/__test__/useDashboardConfig.test.js
@@ -3,30 +3,39 @@ import React from "react";
 import { render } from "@testing-library/react";
 import { useDashboardConfig } from "../hooks";
 import {
-  getVisualizationConfig,
-  listVisualizationFormIds,
+  getVisualizationConfigBySlug,
+  listVisualizations,
 } from "../../config/visualizations";
 
 /**
  * Minimal harness that captures the hook's return value for each render.
  * Avoids @testing-library/react-hooks (not in deps; RTL v12).
  */
-const HookProbe = ({ formId, onResult }) => {
-  const result = useDashboardConfig(formId);
+const HookProbe = ({ slug, onResult }) => {
+  const result = useDashboardConfig(slug);
   onResult(result);
   return null;
 };
 
 describe("config/visualizations registry", () => {
-  test("registers the EPS Overview config under its parent_form_id", () => {
-    const ids = listVisualizationFormIds();
-    expect(ids).toContain(1749623934933);
+  test("registers the EPS Overview config under its slug", () => {
+    const entries = listVisualizations();
+    expect(entries).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          slug: "eps-overview",
+          name: "EPS Overview",
+          parent_form_id: 1749623934933,
+        }),
+      ])
+    );
   });
 
-  test("getVisualizationConfig returns the EPS config when passed the matching id", () => {
-    const config = getVisualizationConfig(1749623934933);
+  test("getVisualizationConfigBySlug returns the EPS config for the matching slug", () => {
+    const config = getVisualizationConfigBySlug("eps-overview");
     expect(config).not.toBeNull();
     expect(config.name).toBe("EPS Overview");
+    expect(config.parent_form_id).toBe(1749623934933);
     // Flat schema: top-level `items[]` with a `tabs` container holding 3 panes.
     expect(Array.isArray(config.items)).toBe(true);
     const tabsItem = config.items.find((it) => it.chart_type === "tabs");
@@ -59,14 +68,14 @@ describe("config/visualizations registry", () => {
     );
   });
 
-  test("getVisualizationConfig accepts numeric strings (route params)", () => {
-    const config = getVisualizationConfig("1749623934933");
-    expect(config).not.toBeNull();
-    expect(config.parent_form_id).toBe(1749623934933);
+  test("getVisualizationConfigBySlug returns null for unknown slugs", () => {
+    expect(getVisualizationConfigBySlug("does-not-exist")).toBeNull();
   });
 
-  test("getVisualizationConfig returns null for unknown ids", () => {
-    expect(getVisualizationConfig(99999)).toBeNull();
+  test("getVisualizationConfigBySlug returns null for falsy input", () => {
+    expect(getVisualizationConfigBySlug("")).toBeNull();
+    expect(getVisualizationConfigBySlug(undefined)).toBeNull();
+    expect(getVisualizationConfigBySlug(null)).toBeNull();
   });
 });
 
@@ -79,11 +88,11 @@ describe("useDashboardConfig", () => {
     console.warn = originalWarn;
   });
 
-  test("returns { config, loading: false, error: null } for a known formId", () => {
+  test("returns { config, loading: false, error: null } for a known slug", () => {
     let latest;
     render(
       <HookProbe
-        formId={1749623934933}
+        slug="eps-overview"
         onResult={(r) => {
           latest = r;
         }}
@@ -95,11 +104,11 @@ describe("useDashboardConfig", () => {
     expect(latest.config.name).toBe("EPS Overview");
   });
 
-  test("returns { config: null } and warns for an unknown formId", () => {
+  test("returns { config: null } and warns for an unknown slug", () => {
     let latest;
     render(
       <HookProbe
-        formId={42}
+        slug="does-not-exist"
         onResult={(r) => {
           latest = r;
         }}
@@ -109,11 +118,11 @@ describe("useDashboardConfig", () => {
     expect(console.warn).toHaveBeenCalled();
   });
 
-  test("returns { config: null } without warning when formId is falsy", () => {
+  test("returns { config: null } without warning when slug is falsy", () => {
     let latest;
     render(
       <HookProbe
-        formId={undefined}
+        slug={undefined}
         onResult={(r) => {
           latest = r;
         }}
@@ -123,12 +132,12 @@ describe("useDashboardConfig", () => {
     expect(console.warn).not.toHaveBeenCalled();
   });
 
-  test("memoizes across renders with the same formId", () => {
+  test("memoizes across renders with the same slug", () => {
     let first;
     let second;
     const { rerender } = render(
       <HookProbe
-        formId={1749623934933}
+        slug="eps-overview"
         onResult={(r) => {
           first = r;
         }}
@@ -136,7 +145,7 @@ describe("useDashboardConfig", () => {
     );
     rerender(
       <HookProbe
-        formId={1749623934933}
+        slug="eps-overview"
         onResult={(r) => {
           second = r;
         }}

--- a/frontend/src/util/hooks/useDashboardConfig.js
+++ b/frontend/src/util/hooks/useDashboardConfig.js
@@ -1,5 +1,5 @@
 import { useMemo } from "react";
-import { getVisualizationConfig } from "../../config/visualizations";
+import { getVisualizationConfigBySlug } from "../../config/visualizations";
 
 /**
  * Walk the item tree and collect every item into a flat Map keyed by id.
@@ -35,17 +35,17 @@ const collectDefinitions = (items = [], acc = new Map()) => {
 };
 
 /**
- * Loads the dashboard config for a given form id and enriches it with:
+ * Loads the dashboard config for a given slug and enriches it with:
  *   - `definitionsById`: Map<id, item> covering every item in the tree
  *
  * Configs are bundled at build time from `src/config/visualizations/`.
  *
- * @param {number|string} formId
+ * @param {string} slug
  * @returns {{ config: object|null, definitionsById: Map<string, object>, loading: boolean, error: Error|null }}
  */
-export const useDashboardConfig = (formId) => {
+export const useDashboardConfig = (slug) => {
   return useMemo(() => {
-    if (!formId) {
+    if (!slug) {
       return {
         config: null,
         definitionsById: new Map(),
@@ -54,11 +54,11 @@ export const useDashboardConfig = (formId) => {
       };
     }
 
-    const config = getVisualizationConfig(formId);
+    const config = getVisualizationConfigBySlug(slug);
     if (!config) {
       // eslint-disable-next-line no-console
       console.warn(
-        `[useDashboardConfig] no config registered for formId=${formId}`
+        `[useDashboardConfig] no config registered for slug="${slug}"`
       );
       return {
         config: null,
@@ -83,7 +83,7 @@ export const useDashboardConfig = (formId) => {
     }
 
     return { config, definitionsById, loading: false, error: null };
-  }, [formId]);
+  }, [slug]);
 };
 
 export default useDashboardConfig;


### PR DESCRIPTION
## Summary

Replaces the opaque numeric dashboard URL (`/dashboard/1749623934933`) with
a human-readable slug (`/dashboard/eps-overview`). Slug is the public route
identifier and single source of truth for routing; `parent_form_id` stays
inside each config JSON and continues to drive every downstream data-fetch
(filters, KPI cards, map, compliance fan-out, progress fetchers) unchanged.

Scope is routing only — no widget, chart, or API behaviour changes. Mobile
app is untouched.

## What's shipped

### Config schema

- New **required** top-level field `"slug"` on every visualization JSON.
  Must be unique, kebab-case (`^[a-z0-9]+(-[a-z0-9]+)*$`).
- `1749623934933.json` gets `"slug": "eps-overview"`.

### Registry (`frontend/src/config/visualizations/index.js`)

Rewritten to be slug-keyed with load-time validation. New public API:

```js
getVisualizationConfigBySlug(slug) : Config | null
listVisualizations() : Array<{ slug, name, parent_form_id }>
```

Old helpers (`getVisualizationConfig(formId)`, `listVisualizationFormIds()`,
default `CONFIGS` export) removed — Header was the only external caller and
is migrated in the same PR.

**Error handling** — configs with a missing, invalid, or duplicate slug are
`console.warn`'d and skipped at module load. The app still boots, and
navigation to an unresolved slug redirects to `/control-center`.

### Routing (`frontend/src/App.js`)

```
- <Route exact path="/dashboard/:formId" element={<Dashboard />} />
+ <Route exact path="/dashboard/:slug"   element={<Dashboard />} />
```

### Dashboard page (`frontend/src/pages/dashboard/Dashboard.jsx`)

- `useParams().formId` → `useParams().slug`
- `useDashboardConfig(formId)` → `useDashboardConfig(slug)`
- `<Empty>` "dashboard isn't available" fallback replaced with
  `<Navigate to="/control-center" replace />`. Unknown-slug URLs, missing
  `slug` fields in JSON, and duplicate-slug skips all land the user back on
  the control center instead of a dead page.

### Header dropdown (`frontend/src/components/layout/Header.jsx`)

- Imports `listVisualizations` (replaces `listVisualizationFormIds` + raw
  `CONFIGS` default import)
- Menu items still filter by `window.forms` but now join via
  `parent_form_id` and link to `/dashboard/${d.slug}`

### Hook (`frontend/src/util/hooks/useDashboardConfig.js`)

- Parameter renamed `formId` → `slug`; internal lookup swapped to
  `getVisualizationConfigBySlug`
- Warn message updated to reference slug and the new registration path
- Behaviour preserved: memoization, `definitionsById` tree build,
  duplicate-id error path

### Docs (`frontend/src/config/visualizations/README.md`)

- Route shown as `/dashboard/:slug` throughout
- "Quick start — add a new dashboard" uses the new `RAW_CONFIGS` array
  registration pattern and documents slug format + skip-on-error semantics
- Schema reference lists `slug` as a required top-level key

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1214118618572760