### PR TITLE
Feature/196 visualization individual overview

### DIFF
--- a/doc/claude/dashboard-custom-component/README.md
+++ b/doc/claude/dashboard-custom-component/README.md
@@ -1,0 +1,69 @@
+# Dashboard `custom_component` Escape Hatch — SDD
+
+Software Design Document for the `custom_component` chart_type and `is_public` tab-pane flag, introduced to support the **Individual Overview** tab on the EPS dashboard (and analogous record-centric tabs on future dashboards).
+
+**Status**: Design approved, implementation pending.
+**Branch**: `feature/196-visualization-individual-overview`
+**Issue**: #196
+
+---
+
+## Documents in this folder
+
+| Document | Purpose | Audience |
+|---|---|---|
+| [design.md](./dashboard-custom-component-design.md) | Schema additions, component design, auth gating flow, sequence diagrams, README update spec, test specification, risks, explicit out-of-scope list | Reviewers approving the design; implementer needing the *what* and *why* |
+| [implementation-plan.md](./implementation-plan.md) | Sequenced, checklisted task breakdown ready to execute | Implementer driving the PR; reviewer tracking progress |
+
+---
+
+## TL;DR
+
+- All other dashboard tabs are **aggregate** (one API call per chart, global filters, counts/distributions over the whole population).
+- The Individual Overview tab is **record-centric** — user picks one EPS, downstream widgets render that single record.
+- Bolting record-centric primitives onto the JSON schema (token DSL, `dependencies`, `endpoint`, `fieldNames`, `dataSource`, `render`) would double the schema surface and re-introduce a mini-DSL inside JSON.
+- Instead: a tiny escape hatch — `chart_type: "custom_component"` plus `is_public: false` — that delegates the whole tab to a React component the developer freely authors.
+- The custom component owns its data fetching, state, loading/error UI. The dashboard renderer stays out of its way.
+- `is_public: false` disables (not hides) the tab for anonymous viewers; `destroyInactiveTabPane` ensures the component never mounts or fetches.
+- Stay specific until rule-of-three. Generic "individual overview" deferred until ≥3 working examples.
+
+---
+
+## Decisions locked during brainstorm
+
+| Decision | Value | Rationale |
+|---|---|---|
+| Registry style | Explicit named-export map in `custom-components/index.js` | Tree-shakeable, grep-friendly, no surprises |
+| Naming convention | Free-form | Avoid bikeshedding; `IndividualEPSOverview` / `RWSDetailPanel` etc. |
+| Auth source | `UIState.isLoggedIn` from `frontend/src/lib/store.js` | Existing Pullstate; no new auth machinery |
+| Anonymous UX | Tab disabled (visible, not clickable) | Communicates that authenticated functionality exists; avoids misleading anonymous viewers |
+| Generic component | Deferred — rule of three | Premature abstraction would re-grow the DSL we just escaped |
+| Loading/error states | Component's responsibility | Keeps the escape hatch escape-hatch-shaped |
+| Props contract | Minimum (component name only) | Add props when a real second consumer needs them |
+
+---
+
+## Out of scope (explicitly deferred)
+
+These were considered during the brainstorm and intentionally not designed. Each can be revisited if a real recurring need appears:
+
+- Token-substitution DSL (`{{filter.x.data.y}}`)
+- `dependencies: [{id}]` for component-level prerequisite gating
+- `endpoint` + `params` blocks for arbitrary REST calls in JSON
+- `fieldNames` mapping for AntD Select payload shaping
+- `dataSource` + `render` for table-driven pivot views
+- New `conditional` / `progress` chart types
+- Generic shared "individual overview" component
+- Per-role permission gating beyond binary login state
+- Server-side stripping of `is_public: false` items from the config payload
+- Deep-link query-param tab activation
+
+---
+
+## Workflow
+
+1. **Brainstorm** (done, captured in design.md Goals/Non-Goals + Out of Scope)
+2. **Design** (done — see [design.md](./dashboard-custom-component-design.md))
+3. **Implementation** — follow [implementation-plan.md](./implementation-plan.md)
+4. **Verification** — manual smoke + Jest (defined in design.md "Test Specification")
+5. **PR** — title pattern `[#196] feat(dashboard): add custom_component chart_type and is_public tab gating`

--- a/doc/claude/dashboard-custom-component/dashboard-custom-component-design.md
+++ b/doc/claude/dashboard-custom-component/dashboard-custom-component-design.md
@@ -1,0 +1,439 @@
+# Dashboard `custom_component` Escape Hatch — Design
+
+## Overview
+
+The config-driven dashboard system in `frontend/src/config/visualizations/` is built around an aggregate-data paradigm: each chart binds to a backend `/visualization/values` endpoint, gets filtered globally, and renders a count or distribution. This pattern works for the Monitoring Overview, Water Quality, and Construction Monitoring tabs of the EPS dashboard.
+
+The **Individual Overview** tab inverts that paradigm — it is record-centric: a user picks one EPS, and every downstream widget renders that single record (or its monitoring children). Bolting record-centric primitives (`dependencies`, `{{token}}` templates, `endpoint`/`params`, `fieldNames`, `dataSource`, `render`) onto the existing aggregate schema would double the schema surface and re-introduce a mini-DSL inside JSON.
+
+Instead, this design ships a small **escape hatch**: a new `chart_type: "custom_component"` that delegates rendering to a named React component drawn from an explicit registry, plus an `is_public: false` tab-pane flag that disables the tab for anonymous viewers. The custom component owns its own data fetching, state, and UI; the dashboard renderer stays out of its way.
+
+This keeps the JSON schema coherent for the 95% case and gives the 5% record-centric case a clean, code-first home.
+
+---
+
+## Goals & Non-Goals
+
+### Goals
+
+- Add `chart_type: "custom_component"` that resolves a string component name from a registry.
+- Add `is_public: false` on a tab pane that disables the tab for anonymous viewers (logged-out users).
+- Keep all existing JSON-driven dashboards behaviorally unchanged.
+- Document the escape hatch with explicit guidance for when to use it (and when not to).
+
+### Non-Goals
+
+- A generic "individual overview" component shared across dashboards. Deferred until ≥3 working examples make the shared abstractions obvious (rule of three).
+- A token-substitution DSL (`{{filter.x.data.y}}`), `dependencies` arrays, `fieldNames`, `dataSource`, or named `render` registries. All deferred — these belong inside the custom component as plain React, not in JSON.
+- Per-role permission gating beyond the binary `isLoggedIn` check. Deferred until a concrete role-based requirement appears.
+- A props contract richer than "component name". The component imports what it needs from existing stores/hooks. Adding `parentFormId`, `globalFilters`, etc. is a future change driven by a real second consumer.
+
+---
+
+## Schema Additions
+
+### `chart_type: "custom_component"`
+
+A new leaf-item type. Carries one new required field.
+
+| Field | Type | Required | Notes |
+|---|---|---|---|
+| `chart_type` | string | yes | Literal `"custom_component"` |
+| `component` | string | yes | Registry key — must match an export from `custom-components/index.js` |
+| `id` | string | yes | Standard item id |
+| `order` | number | yes | Standard sort key |
+| `col_span` | number | no | Standard 1–24 grid; defaults to `24` |
+| `hide` | boolean | no | Standard hide flag |
+
+**Example** (from [`1749623934933.json`](../../../frontend/src/config/visualizations/1749623934933.json)):
+
+```json
+{
+  "id": "individual_overview_component",
+  "chart_type": "custom_component",
+  "order": 1,
+  "component": "IndividualEPSOverview"
+}
+```
+
+The dashboard renderer does not introspect any other field on this item. The component itself is the source of truth for everything that happens inside its render boundary.
+
+### `is_public: false` on tab panes
+
+A new optional boolean on tab pane objects (the `items[]` of a `tabs` container item).
+
+| Field | Type | Default | Notes |
+|---|---|---|---|
+| `is_public` | boolean | `true` | When `false`, tab is **disabled** for anonymous viewers (rendered visible-but-not-clickable) |
+
+**Example**:
+
+```json
+{
+  "id": "tab_individual_overview",
+  "is_public": false,
+  "label": "Individual Overview",
+  "items": [ /* ... */ ]
+}
+```
+
+Rationale for "disabled, not hidden": the user-visible tab label communicates that authenticated functionality exists. Hiding it entirely would mislead anonymous viewers about what the dashboard offers. Disabling prevents access while preserving discoverability.
+
+`is_public` is **only** evaluated on tab panes (children of a `tabs` container). It is ignored elsewhere.
+
+---
+
+## Component Design
+
+### Registry shape — `custom-components/index.js`
+
+Explicit named-export map. No dynamic imports, no convention-based lookup. Tree-shakeable and grep-friendly.
+
+```js
+// frontend/src/components/dashboard/custom-components/index.js
+import IndividualEPSOverview from "./IndividualEPSOverview";
+
+export { IndividualEPSOverview };
+```
+
+Adding a new custom component is a three-step change:
+
+1. Create `frontend/src/components/dashboard/custom-components/<Name>.jsx`.
+2. Add a named export to `custom-components/index.js`.
+3. Reference it from JSON via `"component": "<Name>"`.
+
+Naming is free-form — pick whatever describes the component (`IndividualEPSOverview`, `RWSDetailPanel`, `WTPSiteHistory`). The registry map is the source of truth for what is importable.
+
+### `CustomComponentWidget` — new dispatch wrapper
+
+A new thin widget colocated with the other dashboard widgets:
+
+`frontend/src/components/dashboard/widgets/CustomComponentWidget.jsx`
+
+Responsibilities:
+
+1. Look up `item.component` in the registry.
+2. If found → render the component (no extra props beyond what the component imports for itself).
+3. If not found → log a `console.warn` and render an Ant Design `<Alert type="warning">` with the message `Custom component "<name>" not found in registry`. Do not throw; the rest of the dashboard must continue rendering.
+
+Pseudocode:
+
+```jsx
+const CustomComponentWidget = ({ item }) => {
+  const Component = REGISTRY[item.component];
+  if (!Component) {
+    console.warn(`[CustomComponentWidget] Unknown component: "${item.component}" (id: ${item.id})`);
+    return <Alert type="warning" message={`Custom component "${item.component}" not found`} />;
+  }
+  return <Component />;
+};
+```
+
+Note: `REGISTRY` here is the imported `* as customComponents` namespace from `custom-components/index.js`.
+
+### `DashboardRenderer.jsx` change
+
+Add a single dispatch branch in `renderWidget` ([DashboardRenderer.jsx:104](../../../frontend/src/components/dashboard/DashboardRenderer.jsx#L104)):
+
+```jsx
+if (type === "custom_component") {
+  return <CustomComponentWidget item={item} />;
+}
+```
+
+Placed before the unknown-type fallback. No other changes to renderer logic — the custom component slots into the existing `<Col span={col_span ?? 24}>` wrapper.
+
+### Component-side responsibilities
+
+The custom component is fully responsible for:
+
+- **Data fetching** — uses existing axios/util hooks or `axios` directly.
+- **Auth-aware errors** — handles 401/403 from authenticated endpoints.
+- **Loading / empty / error states** — renders its own `<Skeleton>`, `<Empty>`, `<Alert>` as needed.
+- **Internal state** — selection, filters, drill-downs all live inside the component.
+- **Internal layout** — the component receives one `<Col span={col_span ?? 24}>` and lays out its interior however it wants.
+- **Internal tests** — colocated `.test.jsx` next to the component.
+
+The dashboard renderer does **not**:
+
+- Pass `filterState`, `definitionsById`, `parentFormId`, `globalFilters`, or any other context.
+- Wrap the component in a `<Card>`, error boundary, or loading skeleton.
+- Re-render the component when global filters change.
+
+If a future component needs context from the dashboard, the right move is to add a single, well-named prop at that time — not to design a speculative props contract now.
+
+---
+
+## Auth Gating Flow
+
+### Source of truth
+
+`UIState.isLoggedIn` from [`frontend/src/lib/store.js`](../../../frontend/src/lib/store.js) (Pullstate store).
+
+### Where the check lives
+
+[`TabsWidget.jsx`](../../../frontend/src/components/dashboard/widgets/TabsWidget.jsx) is modified to:
+
+1. Subscribe to `UIState.isLoggedIn` via `UIState.useState((s) => s.isLoggedIn)`.
+2. When constructing `tabItems`, set `disabled: pane.is_public === false && !isLoggedIn` on the AntD `<Tabs>` item.
+3. The default-active key falls through to the first **non-disabled** tab so anonymous viewers don't land on a disabled tab on first paint.
+
+Pseudocode:
+
+```jsx
+const isLoggedIn = UIState.useState((s) => s.isLoggedIn);
+
+const tabItems = panes.map((pane) => ({
+  key: pane.id,
+  label: pane.label,
+  disabled: pane.is_public === false && !isLoggedIn,
+  children: <div>{renderItems(pane.items || [])}</div>,
+}));
+
+const firstEnabled = panes.find((p) => !(p.is_public === false && !isLoggedIn));
+```
+
+### Anonymous-safety guarantee
+
+Because `<Tabs destroyInactiveTabPane>` is already in use, an inactive tab's children are **not mounted**, so the custom component does not run, does not fetch, and does not appear in the DOM. The disabled flag prevents the user from activating it. Combined: anonymous viewers cannot trigger the authenticated component's network calls via this UI path.
+
+This is the entire auth-gating mechanism. There is no server-side stripping of config, no separate route, no permission system integration. If a stronger guarantee is ever needed (e.g., the dashboard JSON itself contains sensitive endpoint paths), that's a future concern.
+
+### Direct-URL behavior
+
+The dashboard route `/dashboard/:slug` doesn't currently support `?tab=<id>` deep-linking. The disabled-tab mechanism is sufficient because there is no anonymous URL that lands directly on the `is_public: false` tab. If deep-linking is added later, the same `is_public + isLoggedIn` check would gate URL-driven tab activation.
+
+---
+
+## Sequence: Anonymous viewer loads dashboard
+
+```
+User → /dashboard/eps-overview (anonymous)
+  ↓
+useDashboardConfig loads JSON, returns items unchanged
+  ↓
+DashboardRenderer walks items, dispatches `tabs` → TabsWidget
+  ↓
+TabsWidget reads UIState.isLoggedIn = false
+  ↓
+For tab_individual_overview (is_public: false):
+  → tabItem.disabled = true
+  ↓
+defaultActiveKey resolves to first non-disabled pane (tab_monitoring_overview)
+  ↓
+AntD Tabs renders 4 tabs; "Individual Overview" greyed out and unclickable
+  ↓
+destroyInactiveTabPane = true → IndividualEPSOverview never mounts
+```
+
+## Sequence: Logged-in viewer activates Individual Overview
+
+```
+User → /dashboard/eps-overview (logged in)
+  ↓
+TabsWidget: tabItem.disabled = false, all 4 tabs clickable
+  ↓
+User clicks "Individual Overview"
+  ↓
+TabsWidget renders pane via renderItems(pane.items)
+  ↓
+DashboardRenderer dispatches custom_component → CustomComponentWidget
+  ↓
+CustomComponentWidget looks up "IndividualEPSOverview" in REGISTRY
+  ↓
+Component mounts, owns its own location/EPS selection, fetches authenticated APIs
+  ↓
+On tab change away → destroyInactiveTabPane unmounts component, frees state
+```
+
+---
+
+## File Touch List
+
+### New files
+
+| Path | Purpose |
+|---|---|
+| `frontend/src/components/dashboard/widgets/CustomComponentWidget.jsx` | Registry lookup + render or warn |
+| `frontend/src/components/dashboard/widgets/__test__/CustomComponentWidget.test.jsx` | Smoke test: known name renders, unknown name warns |
+
+### Modified files
+
+| Path | Change |
+|---|---|
+| `frontend/src/components/dashboard/DashboardRenderer.jsx` | Add `custom_component` dispatch branch + import |
+| `frontend/src/components/dashboard/widgets/TabsWidget.jsx` | Read `isLoggedIn`, set `disabled` on `is_public: false` panes, choose first-enabled default |
+| `frontend/src/config/visualizations/README.md` | Document the new chart_type, the `is_public` flag, and the "when to use the escape hatch" guidance |
+
+### Already in place (no change needed)
+
+| Path | Notes |
+|---|---|
+| `frontend/src/components/dashboard/custom-components/index.js` | Registry already wired with `IndividualEPSOverview` |
+| `frontend/src/components/dashboard/custom-components/IndividualEPSOverview.jsx` | Component already authored; managed separately from this design |
+
+---
+
+## README Updates (specification)
+
+Apply these diffs to [`frontend/src/config/visualizations/README.md`](../../../frontend/src/config/visualizations/README.md):
+
+### 1. `chart_type` catalogue — append a row
+
+```
+| `custom_component` | Arbitrary React component from the custom-components registry | `component` (string, registry key) |
+```
+
+### 2. Tab pane shape — add `is_public` note
+
+Under the existing "Tab pane shape" section, append:
+
+> **`is_public`** (optional, defaults `true`) — when set to `false`, the tab is rendered **disabled** for anonymous viewers and only becomes clickable for users with `UIState.isLoggedIn === true`. Use this for tabs whose children fetch authenticated endpoints.
+
+### 3. New section: "Custom component escape hatch"
+
+Insert a new top-level section between "Chart data-source modes" and "Filter hints", roughly:
+
+> ## Custom component escape hatch
+>
+> Some dashboard tabs follow a record-centric pattern that doesn't fit the aggregate
+> chart paradigm — the user picks one record and downstream widgets render details
+> for that record. Rather than extending the JSON schema with primitives that only
+> make sense for these tabs (`dependencies`, token templates, custom endpoints,
+> render registries), use the `custom_component` chart_type to delegate rendering
+> to a React component.
+>
+> ### When to reach for it
+>
+> - The interaction model is **record-centric**, not aggregate.
+> - The tab needs internal state that isn't expressible as a global filter.
+> - The behavior is unique enough that no other dashboard would reuse it.
+>
+> ### When NOT to reach for it
+>
+> - The widget can be expressed as `card` / `bar` / `doughnut` / `table` etc. with
+>   an `api` block — extend the existing schema instead.
+> - Two or three other dashboards would benefit from the same widget — promote
+>   it to a first-class `chart_type` rather than copying components.
+>
+> ### Adding a custom component
+>
+> 1. Create `frontend/src/components/dashboard/custom-components/<Name>.jsx`.
+> 2. Add a named export in `custom-components/index.js`.
+> 3. Reference it in JSON:
+>
+> ```json
+> {
+>   "id": "individual_overview_component",
+>   "chart_type": "custom_component",
+>   "order": 1,
+>   "component": "<Name>"
+> }
+> ```
+>
+> ### What the component owns
+>
+> - Data fetching, including auth-aware error handling.
+> - Loading, empty, and error UI states.
+> - Internal selection state, drill-downs, sub-tabs.
+> - Any internal filters (the dashboard's global filter bar is not piped in).
+>
+> ### Stay specific until rule-of-three
+>
+> Don't generalize prematurely. The first per-dashboard custom component is fine
+> as a one-off. When a third dashboard needs a similar pattern, refactor the
+> common pieces into shared building-block components (`<RecordSelectorBar>`,
+> `<RegistrationDetailTable>`, etc.) — not into a single mega-component
+> driven by yet another schema.
+
+### 4. Related components — append
+
+```
+- [`widgets/CustomComponentWidget`](../../components/dashboard/widgets/CustomComponentWidget.jsx) — registry-backed escape hatch
+```
+
+---
+
+## Test Specification
+
+### `CustomComponentWidget.test.jsx`
+
+Two cases sufficient for the dispatcher:
+
+| Case | Expectation |
+|---|---|
+| Known component name | The named component renders (assert by data-testid or text) |
+| Unknown component name | Renders `<Alert>` with "not found" copy; no throw; `console.warn` called |
+
+### `TabsWidget` modification
+
+Add to existing `TabsWidget.test.jsx` (or create one if missing):
+
+| Case | Expectation |
+|---|---|
+| `is_public: false` pane + `isLoggedIn = false` | Tab item rendered with `disabled=true`; `defaultActiveKey` is first non-disabled pane |
+| `is_public: false` pane + `isLoggedIn = true` | Tab item not disabled; behaves identically to public panes |
+| All `is_public` true (or omitted) | No behavioral change vs current implementation |
+
+### `IndividualEPSOverview` tests
+
+Live with the component itself, not in scope of this design. Out-of-band per FR-3 (component owns its own testing).
+
+### Manual smoke test
+
+1. `./dc.sh up -d` and load `/dashboard/eps-overview` while logged out.
+2. Verify the four tabs render and "Individual Overview" is greyed out / unclickable.
+3. Log in, reload the dashboard.
+4. Click "Individual Overview" — the component mounts and runs.
+5. Click another tab and back — `destroyInactiveTabPane` should remount the component cleanly.
+
+---
+
+## Backwards Compatibility
+
+- All existing dashboards have no `is_public` set on any tab — defaults to `true`, behavior unchanged.
+- All existing dashboards have no `custom_component` items — the new dispatch branch is never hit.
+- The registry export shape (`export { Name }`) is additive; removing a component requires removing its JSON references in lockstep.
+
+No migration of existing config files is required.
+
+---
+
+## Risk Register
+
+| Risk | Likelihood | Impact | Mitigation |
+|---|---|---|---|
+| `custom-components/` becomes a dumping ground over time | Medium | Medium | README documents "when NOT to use" + rule-of-three guidance |
+| Components silently break if registry export is removed but JSON still references it | Low | Low | `console.warn` + `<Alert>` fallback; future work could add config-load-time validation |
+| A custom component leaks into anonymous view via a future router change (deep-link to tab) | Low | Medium | Auth check is centralized in `TabsWidget`; same check would be reused for any deep-link feature |
+| Over-coupling: a custom component imports too many app internals and becomes hard to move | Medium | Low | Keep components scoped; revisit at rule-of-three refactor |
+
+---
+
+## Out of Scope (Explicit Deferrals)
+
+These were considered during the brainstorm and intentionally not designed:
+
+- Token-substitution DSL (`{{filter.x.data.y}}`).
+- `dependencies: [{id}]` for component-level prerequisite gating.
+- `endpoint` + `params` blocks under `api` for arbitrary REST calls.
+- `fieldNames` mapping for AntD Select payload shaping.
+- `dataSource` + `render` for table-driven pivot views.
+- A new `conditional` chart_type.
+- A new `progress` chart_type.
+- A generic "individual overview" component.
+- Per-role permission gating beyond binary login state.
+- Server-side stripping of `is_public: false` items from the config payload.
+- Deep-link query-param tab activation.
+
+Each of these can be revisited if and when a real, recurring need appears. Today they would be premature.
+
+---
+
+## Next Step
+
+Approved design → implement per the file touch list above. The change is small enough that PR review covers any remaining design adjustments inline.
+
+Suggested PR title: `[#196] feat(dashboard): add custom_component chart_type and is_public tab gating`
+
+To start implementation: `/sc:implement` referencing this document.

--- a/doc/claude/dashboard-custom-component/implementation-plan.md
+++ b/doc/claude/dashboard-custom-component/implementation-plan.md
@@ -1,0 +1,148 @@
+# Implementation Plan — `custom_component` Escape Hatch
+
+Sequenced, checklisted tasks ready for execution. Companion to [design.md](./dashboard-custom-component-design.md). Read the design first — this doc is the *how* and *in what order*; design.md is the *what* and *why*.
+
+**Branch**: `feature/196-visualization-individual-overview`
+**Issue**: #196
+
+---
+
+## Pre-flight
+
+- [ ] Confirm working directory is on `feature/196-visualization-individual-overview`
+- [ ] Pull latest from origin to ensure no upstream changes since the design was approved
+- [ ] Run `./dc.sh up -d` so the stack is reachable for manual verification later
+- [ ] Open [`1749623934933.json`](../../../frontend/src/config/visualizations/1749623934933.json) — confirm the simplified `tab_individual_overview` already references `chart_type: "custom_component"` with `component: "IndividualEPSOverview"` (lines ~1045–1057)
+
+---
+
+## Phase 1 — Renderer dispatch (the new chart_type)
+
+Goal: the dashboard renderer recognizes `custom_component`, looks up the React component from the registry, and renders it (or a "not found" alert).
+
+- [ ] **Create** [`frontend/src/components/dashboard/widgets/CustomComponentWidget.jsx`](../../../frontend/src/components/dashboard/widgets/CustomComponentWidget.jsx)
+  - Import `* as registry` from `../custom-components`
+  - Component receives `{ item }` props
+  - Resolve `registry[item.component]`
+  - If found → render `<Component />` (no extra props per design FR-4)
+  - If missing → `console.warn` with item id + name; render `<Alert type="warning" message="Custom component \"<name>\" not found" />`
+  - PropTypes for `item` (shape: `{ id, component }`)
+
+- [ ] **Modify** [`DashboardRenderer.jsx`](../../../frontend/src/components/dashboard/DashboardRenderer.jsx)
+  - Import `CustomComponentWidget`
+  - Add dispatch branch in `renderWidget` *before* the unknown-type fallback at [line ~196](../../../frontend/src/components/dashboard/DashboardRenderer.jsx#L196):
+    ```jsx
+    if (type === "custom_component") {
+      return <CustomComponentWidget item={item} />;
+    }
+    ```
+
+- [ ] **Verify (smoke)**: load `/dashboard/eps-overview` while logged in, click "Individual Overview" tab. The existing `IndividualEPSOverview` component should mount and render. No console errors.
+
+---
+
+## Phase 2 — Auth gating on tab panes
+
+Goal: `is_public: false` panes render disabled when `UIState.isLoggedIn` is false; default-active tab skips disabled panes; component never mounts under destroyInactiveTabPane semantics.
+
+- [ ] **Modify** [`TabsWidget.jsx`](../../../frontend/src/components/dashboard/widgets/TabsWidget.jsx)
+  - Import `UIState` from `../../../lib/store`
+  - Inside the component: `const isLoggedIn = UIState.useState((s) => s.isLoggedIn);`
+  - When mapping panes, add `disabled: pane.is_public === false && !isLoggedIn` to each `tabItem`
+  - Compute `firstEnabledKey = panes.find((p) => !(p.is_public === false && !isLoggedIn))?.id`
+  - Pass `firstEnabledKey` (instead of `panes[0]?.id`) to `defaultActiveKey`
+  - Update PropTypes shape on pane to include optional `is_public: PropTypes.bool`
+
+- [ ] **Verify (manual, anonymous)**: log out, reload `/dashboard/eps-overview`. Confirm "Individual Overview" tab is greyed out and unclickable. Confirm initial active tab is "Monitoring overview" (not "Individual Overview"). Open DevTools Network — confirm no requests fired by `IndividualEPSOverview`.
+
+- [ ] **Verify (manual, signed-in)**: log in, reload. Confirm "Individual Overview" tab is clickable and the component mounts on click.
+
+---
+
+## Phase 3 — Tests
+
+Goal: enough automated coverage that the dispatch + gating behavior cannot silently regress.
+
+- [ ] **Create** `frontend/src/components/dashboard/widgets/__test__/CustomComponentWidget.test.jsx`
+  - Test 1: known component name renders (mock the registry import; assert rendered output)
+  - Test 2: unknown component name renders Alert + calls `console.warn`; does not throw
+
+- [ ] **Create or extend** `frontend/src/components/dashboard/widgets/__test__/TabsWidget.test.jsx`
+  - Test 1: pane with `is_public: false` + `isLoggedIn: false` → tab item rendered with `disabled: true`; default active is the first non-disabled pane
+  - Test 2: pane with `is_public: false` + `isLoggedIn: true` → not disabled
+  - Test 3: panes with no `is_public` field → behavior unchanged from current
+  - Use Pullstate test helpers to seed `UIState`; reset between tests
+
+- [ ] Run `cd frontend && npm test -- --watchAll=false` — confirm all green
+
+---
+
+## Phase 4 — Documentation
+
+Goal: future maintainers find the escape hatch from the visualization README and understand when (and when not) to reach for it.
+
+- [ ] **Modify** [`frontend/src/config/visualizations/README.md`](../../../frontend/src/config/visualizations/README.md) per the four diffs in [design.md "README Updates"](./dashboard-custom-component-design.md#readme-updates-specification):
+  - [ ] Append `custom_component` row to the chart_type catalogue
+  - [ ] Add `is_public` note under "Tab pane shape"
+  - [ ] Insert new top-level section "Custom component escape hatch" between "Chart data-source modes" and "Filter hints"
+  - [ ] Append `CustomComponentWidget` to "Related components"
+
+---
+
+## Phase 5 — Verification
+
+- [ ] `cd frontend && npm run lint` — no new warnings
+- [ ] `cd frontend && npm run prettier` — formatting clean
+- [ ] `./dc.sh exec -T frontend npx eslint src/components/dashboard/widgets/CustomComponentWidget.jsx src/components/dashboard/widgets/TabsWidget.jsx src/components/dashboard/DashboardRenderer.jsx` — zero errors (this enforces the project's `curly`, `no-undefined`, `prefer-arrow-callback` rules)
+- [ ] `cd frontend && npm test -- --watchAll=false` — all green
+- [ ] Manual smoke (anonymous + signed-in) per Phase 2/3 verification steps
+
+---
+
+## Phase 6 — Commit & PR
+
+- [ ] `git status` — confirm only the expected files changed
+- [ ] `git diff` — re-skim each diff
+- [ ] Commit message format per project convention:
+  ```
+  [#196] feat(dashboard): add custom_component chart_type and is_public tab gating
+
+  - Add CustomComponentWidget for registry-backed React component rendering
+  - Add is_public flag on tab panes that disables tabs for anonymous viewers
+  - Wire dispatch in DashboardRenderer; auth check in TabsWidget via UIState
+  - Document the escape hatch and when to use it in the visualizations README
+  - Tests for dispatcher (known/unknown name) and tab gating (logged-in/out)
+
+  🤖 Generated with [Claude Code](https://claude.com/claude-code)
+
+  Co-Authored-By: Claude <noreply@anthropic.com>
+  ```
+- [ ] **Wait for user confirmation before push** (per project convention — do not auto-push)
+- [ ] After confirmation: push and open PR titled `[#196] feat(dashboard): add custom_component chart_type and is_public tab gating`
+
+---
+
+## Out of scope for this PR (do not bundle)
+
+These belong in separate follow-up work, not in this implementation:
+
+- Any logic *inside* `IndividualEPSOverview.jsx` itself (managed separately per design FR-3)
+- Any new custom components for RWS / WTP / WWTP dashboards
+- A generic / shared individual-overview component
+- Server-side config stripping based on `is_public`
+- Deep-link tab activation via URL query param
+- Schema-load-time validation of registry references
+- Refactoring shared building blocks (defer until rule-of-three)
+
+If you find yourself touching any of the above while implementing, stop and split it into a follow-up issue.
+
+---
+
+## Rollback plan
+
+The change is additive: a new chart_type and a new optional flag. To rollback:
+
+1. Revert the commits.
+2. The existing JSON config still works because `tab_individual_overview` was already in the file but the `custom_component` dispatch wouldn't match — `DashboardRenderer` would log "Unknown chart_type" and render nothing for that tab. **Preferred**: also revert the JSON to remove the `custom_component` entry, or temporarily replace the tab with a section_title placeholder.
+
+No database migrations, no API changes, no shared-component changes outside the dashboard subtree.

--- a/doc/claude/dashboard-individual-overview/README.md
+++ b/doc/claude/dashboard-individual-overview/README.md
@@ -1,0 +1,64 @@
+# Individual Overview — SDD
+
+Software Design Document for the **Individual Overview** record-centric tab pattern used by both the EPS dashboard ([`/dashboard/eps-overview`](../../../frontend/src/config/visualizations/1749623934933.json)) and the RWS dashboard ([`/dashboard/rws-overview`](../../../frontend/src/config/visualizations/1749621221728.json)).
+
+**Status**: Design approved, implementation pending.
+**Branch**: `feature/196-visualization-individual-overview`
+**Issue**: #196
+**Builds on**: [`dashboard-custom-component/`](../dashboard-custom-component/) — defines the `custom_component` escape-hatch this pattern plugs into.
+
+---
+
+## Documents in this folder
+
+| Document | Purpose | Audience |
+|---|---|---|
+| [design.md](./design.md) | Architecture, primitive interfaces, sequence diagrams, edge-case behaviour, risk register, explicit out-of-scope list | Reviewer approving the design; implementer needing the *what* and *why* |
+| [implementation-plan.md](./implementation-plan.md) | Sequenced, checklisted task breakdown with question-ID reference tables ready to execute | Implementer driving the PR; reviewer tracking progress |
+
+---
+
+## TL;DR
+
+- Both EPS and RWS dashboards need a record-centric "Individual Overview" tab where the user picks one EPS / RWS site, then downstream widgets render details for that single record.
+- Built as React components delegated via the `custom_component` escape-hatch — the JSON-driven aggregate dashboard schema stays unchanged.
+- Six small primitives in `custom-components/shared/` are reused across both shells (≥4× each); shell-specific bits (project-scope rows, qid lists, project-type formulas, badges, stats card) stay per-dashboard per the [escape-hatch SDD](../dashboard-custom-component/dashboard-custom-component-design.md)'s "rule of three until ≥3 working examples."
+- Result: each shell is ~180–220 lines of composition; future "Individual X Overview" tabs are also small.
+
+---
+
+## Decisions locked from brainstorm + RWS scope expansion
+
+| Decision | Value | Rationale |
+|---|---|---|
+| Composition style | One shell per dashboard, composing shared primitives | Avoids the DSL trap the escape-hatch SDD warned against |
+| Primitive extraction | Six primitives (helpers + 3 React + 2 hooks) extracted from day 1 | Each appears ≥4× across the two designs — past the rule-of-two threshold |
+| RWS scope | Included in this PR | Two designs in hand; primitives benefit from being designed against both |
+| RWS slug | `rws-overview` | Mirrors `eps-overview`; easy to type |
+| RWS monitoring forms | `1749621962296` (comprehensive) **plus** `1749631041125` (quick) | Comprehensive covers most fields; quick form provides 5 fields not in the comprehensive form (operational status, contact persons, phone, water-committee training, photo description) |
+| RWS project-type progress formula | **Deferred** to a follow-up PR | Per-project-type math (SWP=÷7, BH=÷8, D=÷8, RH=÷4) is its own surface |
+| RWS WSMP monitor sub-tab | Placeholder `<Empty>` — content TBD | Mockup not provided yet |
+| Lab/CBT chart history | Client-side N+1 via `useMonitoringHistory` | `/visualization/values` cannot filter to one parent_uuid; backend endpoint deferred |
+
+---
+
+## Out of scope (explicitly deferred)
+
+- RWS project-type-aware progress formula
+- RWS WSMP monitor sub-tab content
+- Editing capabilities on photos / tables (read-only view)
+- Linking back to underlying datapoint detail page
+- Photo lightbox (AntD `<Image>` default zoom is enough)
+- Localised strings
+- URL state for selected datapoint
+- Backend endpoint for per-record monitoring history (current N+1 acceptable)
+
+---
+
+## Workflow
+
+1. **Brainstorm** (done) — captured in [design.md](./design.md) "Goals & Non-Goals"
+2. **Design** (done) — see [design.md](./design.md)
+3. **Implementation** — follow [implementation-plan.md](./implementation-plan.md)
+4. **Verification** — manual smoke + Jest (in design.md "Test Specification")
+5. **PR** — six sequential commits with `[#196]` prefix per implementation-plan Phase 7

--- a/doc/claude/dashboard-individual-overview/design.md
+++ b/doc/claude/dashboard-individual-overview/design.md
@@ -1,0 +1,520 @@
+# Individual Overview — Design
+
+Architecture and interface specifications for the record-centric Individual Overview tabs on both the EPS and RWS dashboards.
+
+For task-level execution checklists and qid mappings, see [implementation-plan.md](./implementation-plan.md). For the escape-hatch this design plugs into, see [`dashboard-custom-component/dashboard-custom-component-design.md`](../dashboard-custom-component/dashboard-custom-component-design.md).
+
+---
+
+## Overview
+
+All other tabs on both dashboards follow an **aggregate** pattern — one `/visualization/values` API call per chart, filtered globally, counts/distributions over the whole population. The Individual Overview tabs invert that: the user picks one EPS / RWS, then every downstream widget renders details for that single record.
+
+Two designs in hand share enough surface (Photo + Characteristics + WQ details + Lab/CBT line charts) to extract small composable primitives, but diverge enough (project-type formulas, badges, stats card, sub-tab list, project scope rows) to keep each shell as a per-dashboard composition rather than a single generic component. This design captures the seams.
+
+---
+
+## Goals & Non-Goals
+
+### Goals
+
+- Render both Individual Overview tabs (EPS + RWS) per their mockups, fully data-driven from `window.forms` + `/data/<id>` answer payloads.
+- Extract six primitives into `custom-components/individual-overview/shared/` so future record-centric tabs are thin compositions.
+- Keep each shell ≤ ~220 lines.
+- Anonymous viewers see a disabled tab (existing escape-hatch behaviour from [TabsWidget](../../../frontend/src/components/dashboard/widgets/TabsWidget.jsx)).
+- Add no new schema concepts to the JSON-driven dashboard config beyond `custom_component` + `is_public` (already shipped).
+
+### Non-Goals
+
+- A single generic `<IndividualOverview>` mega-component driven by per-dashboard JSON config — would re-introduce the DSL the [escape-hatch SDD](../dashboard-custom-component/dashboard-custom-component-design.md) explicitly rejected.
+- Backend endpoint for per-record monitoring history — current N+1 client fetches acceptable for typical N≤20.
+- RWS project-type-aware progress formula — separate concern, deferred to follow-up PR with placeholder `<Empty>`.
+- RWS WSMP monitor sub-tab content — mockup not provided; placeholder only.
+- Editing the rendered data, deep-linking, lightbox, localisation, URL state for selection.
+
+---
+
+## Architecture
+
+### File layout
+
+```
+frontend/src/components/dashboard/custom-components/
+├── index.js                                  # registry — exports both shells
+├── IndividualEPSOverview.jsx                 # EPS shell (~180 lines)
+├── IndividualRWSOverview.jsx                 # RWS shell (~220 lines)
+└── individual-overview/                      # pieces specific to this pattern
+    ├── shared/                               # primitives reusable across both shells
+    │   ├── helpers.js                        # findQuestion, findAnswer, formatAnswerValue,
+    │   │                                     #   extractPhotoUrl, sortByDateAscending
+    │   ├── CharacteristicsTable.jsx          # Question/Answer table
+    │   ├── PhotoCaptionCard.jsx              # photo + caption + empty state
+    │   ├── HistoricalLineChart.jsx           # Line chart + threshold band
+    │   ├── useIndividualOverviewData.js      # admin → datapoints → values fetch chain
+    │   └── useMonitoringHistory.js           # paginated history per parent_uuid
+    └── config/                               # per-dashboard constants
+        ├── eps.js                            # EPS-specific constants
+        └── rws.js                            # RWS-specific constants (project-type-aware
+                                              #   row sets, dual-form qid mappings)
+```
+
+The two shell components stay at the `custom-components/` root because that's
+what the registry `index.js` imports + exports for the `custom_component`
+chart-type dispatcher to find. Everything else specific to the
+individual-overview pattern lives under `individual-overview/`. A future
+custom component (e.g. `<DataExportPanel>`) would similarly own a sibling
+subfolder rather than polluting the root.
+
+### Composition map
+
+```
+IndividualEPSOverview.jsx ──compose──┐
+                                     │
+IndividualRWSOverview.jsx ──compose──┤───► individual-overview/shared/
+                                     │      ├── helpers.js
+                                     │      ├── PhotoCaptionCard
+                                     │      ├── CharacteristicsTable
+                                     │      ├── HistoricalLineChart
+                                     │      ├── useIndividualOverviewData
+                                     │      └── useMonitoringHistory
+                                     │
+                                     └─── individual-overview/config/<shell>.js
+                                          + per-shell JSX:
+                                          ├── filter row (badges, selectors)
+                                          ├── top-section grid (2-col vs 3-col)
+                                          ├── tab list (2 vs 3 panes)
+                                          ├── project-scope table
+                                          ├── stats card (RWS only)
+                                          ├── progress display (single qid vs formula)
+                                          └── WSMP placeholder (RWS only)
+```
+
+---
+
+## Primitive Interfaces
+
+### `individual-overview/shared/helpers.js`
+
+Pure functions, no React. Centralises all `window.forms` + `/data/<id>` lookup logic so shells stay free of form-walking code.
+
+```js
+/**
+ * Find a question definition by id across every form in `window.forms`.
+ * Returns null when not found (older configs, deleted questions).
+ *
+ * @param {number|string} questionId
+ * @returns {object|null} The question with { id, label, type, option, ... }
+ */
+findQuestion(questionId)
+
+/**
+ * Resolve an answer entry for `questionId` from a /data/<id> response.
+ * Returns null when missing.
+ *
+ * @param {Array} values   Array of { question, value, index, history }
+ * @param {number|string} questionId
+ * @returns {object|null} The matching answer entry
+ */
+findAnswer(values, questionId)
+
+/**
+ * Pretty-print an answer value for display in tables. Handles option /
+ * multiple_option (comma-joined option labels), geo (lat/long pair), arrays
+ * (comma-joined). Returns null for empty/missing values.
+ *
+ * @param {object} answer    The /data/<id> answer entry
+ * @param {object} question  The window.forms question definition
+ * @returns {string|null}
+ */
+formatAnswerValue(answer, question)
+
+/**
+ * Extract a photo URL from an answer. Photo answers store the absolute URL
+ * directly in `value`; treats blank/non-string as absent.
+ *
+ * @param {Array} values
+ * @param {number|string} questionId
+ * @returns {string|null}
+ */
+extractPhotoUrl(values, questionId)
+
+/**
+ * Convenience: findAnswer + findQuestion + formatAnswerValue in one call.
+ *
+ * @param {Array} values
+ * @param {number|string} questionId
+ * @returns {string|null}
+ */
+resolveAnswerLabel(values, questionId)
+
+/**
+ * Sort an array of {date, value} ascending by date. Stable; null dates
+ * sort first.
+ *
+ * @param {Array<{date: string, value: number}>} rows
+ * @returns {Array<{date: string, value: number}>}
+ */
+sortByDateAscending(rows)
+```
+
+### `individual-overview/shared/PhotoCaptionCard.jsx`
+
+```jsx
+/**
+ * Photo card with caption + AntD Image zoom. Renders <Empty> when no URL.
+ *
+ * @prop {string|null} photoUrl
+ * @prop {string|null} caption
+ * @prop {string}      [alt]      Defaults to "Photo"
+ * @prop {number}      [height]   Defaults to 240
+ */
+<PhotoCaptionCard photoUrl={...} caption={...} />
+```
+
+### `individual-overview/shared/CharacteristicsTable.jsx`
+
+```jsx
+/**
+ * Two-column AntD <Table> rendering Question (window.forms label) /
+ * Answer (formatAnswerValue) for a list of question ids. Skips qids
+ * with no resolvable answer rather than rendering blank rows.
+ *
+ * @prop {string}                  [title]    Card title; if omitted, no Card wrapper
+ * @prop {Array<number|string>}    qids       Ordered list of qids to render
+ * @prop {Array}                   values     /data/<id> answer payload
+ * @prop {boolean}                 [bordered] Default true
+ */
+<CharacteristicsTable
+  title="EPS Characteristics"
+  qids={REGISTRATION_CHARACTERISTICS_QIDS}
+  values={regValues}
+/>
+```
+
+### `individual-overview/shared/HistoricalLineChart.jsx`
+
+```jsx
+/**
+ * akvo-charts <Line> wrapped with optional threshold band (markArea).
+ * Sorts data ascending before render.
+ *
+ * @prop {string}                  title
+ * @prop {Array<{label, value}>}   data
+ * @prop {number}                  [thresholdMin]   Lower acceptable bound
+ * @prop {number}                  [thresholdMax]   Upper acceptable bound
+ * @prop {string}                  [unit]           Y-axis unit label (e.g., "cfu/100mL")
+ * @prop {number}                  [height]         Default 240
+ */
+<HistoricalLineChart
+  title="Total e-coli levels"
+  data={[{ label: "01-2025", value: 12 }, ...]}
+  thresholdMax={0}
+  unit="cfu/100mL"
+/>
+```
+
+When both `thresholdMin` and `thresholdMax` are set, the band is rendered between them (e.g., pH 6.5–8.5 acceptable range). When only one is set, the band extends from min/max of data range to the threshold.
+
+### `individual-overview/shared/useIndividualOverviewData.js`
+
+```js
+/**
+ * Hook that drives the admin → datapoints → values fetch chain.
+ *
+ * @param {object} options
+ * @param {number} options.regFormId             Registration form id
+ * @param {Array<number>} options.monitoringFormIds   Monitoring form ids to fetch latest of
+ *
+ * @returns {{
+ *   loadingDataPoints: boolean,
+ *   dataPoints: Array<{id, name, uuid, ...}>,
+ *   selectedDataPoint: object|null,
+ *   setSelectedDataPoint: (dp: object) => void,
+ *   regValues: Array,                            // /data/<id> response for selected EPS
+ *   monitoringValues: { [formId]: Array },       // latest /data/<id> per monitoring form
+ *   loadingValues: boolean,
+ *   refetch: () => void,
+ * }}
+ */
+useIndividualOverviewData({ regFormId, monitoringFormIds })
+```
+
+Contracts:
+- Subscribes to `store.administration` (Pullstate). When the deepest selected level changes, refetches `dataPoints` and clears `selectedDataPoint`.
+- When `selectedDataPoint` changes, fetches `regValues` and the latest monitoring submission for each `monitoringFormIds[i]`, then their answer payloads.
+- All fetches `try/catch` with `console.error` on failure; the consuming shell sees `null` / empty arrays rather than an exception.
+
+### `individual-overview/shared/useMonitoringHistory.js`
+
+```js
+/**
+ * Fetch all monitoring submissions for a parent record and their answer
+ * payloads. Charts then project per-parameter without extra calls.
+ *
+ * Pagination: fetches first page, then subsequent pages until exhausted
+ * (typical N <= 20 for a single record). N+1 round-trips overall:
+ * 1 list page (cheap) + N answer fetches.
+ *
+ * @param {number} formId
+ * @param {string|null} parentUuid    null disables the fetch
+ *
+ * @returns {{
+ *   rows: Array<{ id, date, values }>,    // chronological metadata + answers
+ *   loading: boolean,
+ *   error: Error|null,
+ * }}
+ */
+useMonitoringHistory(formId, parentUuid)
+```
+
+The caller projects per-chart by mapping `rows` to `[{label: row.date, value: findAnswer(row.values, paramQid)?.value}]`.
+
+---
+
+## Component Composition
+
+### `IndividualEPSOverview.jsx`
+
+```jsx
+const IndividualEPSOverview = () => {
+  const {
+    dataPoints, selectedDataPoint, setSelectedDataPoint,
+    regValues, monitoringValues, loadingValues,
+  } = useIndividualOverviewData({
+    regFormId: REGISTRATION_FORM_ID,
+    monitoringFormIds: [CONSTRUCTION_FORM_ID, WATER_QUALITY_FORM_ID],
+  });
+
+  const constructionValues = monitoringValues[CONSTRUCTION_FORM_ID] || [];
+  const wqValues = monitoringValues[WATER_QUALITY_FORM_ID] || [];
+
+  const wqHistory = useMonitoringHistory(
+    WATER_QUALITY_FORM_ID,
+    selectedDataPoint?.uuid
+  );
+
+  return (
+    <div className="individual-overview">
+      <FilterRow ... />
+      <Row gutter={16}>
+        <Col span={12}><PhotoCaptionCard ... /></Col>
+        <Col span={12}><CharacteristicsTable ... /></Col>
+      </Row>
+      <Tabs destroyInactiveTabPane>
+        <ConstructionMonitoringPane values={constructionValues} />
+        <WaterQualityPane values={wqValues} history={wqHistory.rows} />
+      </Tabs>
+    </div>
+  );
+};
+```
+
+### `IndividualRWSOverview.jsx`
+
+```jsx
+const IndividualRWSOverview = () => {
+  const {
+    dataPoints, selectedDataPoint, setSelectedDataPoint,
+    regValues, monitoringValues,
+  } = useIndividualOverviewData({
+    regFormId: REGISTRATION_FORM_ID,
+    // Comprehensive form for most fields + quick form for the 5 fields the
+    // comprehensive form does not provide (operational status, contact persons,
+    // phone, water-committee training, photo description).
+    monitoringFormIds: [COMPREHENSIVE_FORM_ID, QUICK_FORM_ID],
+  });
+
+  const compValues = monitoringValues[COMPREHENSIVE_FORM_ID] || [];
+  const quickValues = monitoringValues[QUICK_FORM_ID] || [];
+  const projectType = resolveAnswerLabel(compValues, PROJECT_TYPE_QID);
+  const waterSource = resolveAnswerLabel(compValues, WATER_SOURCE_QID);
+  const scopeRows = PROJECT_SCOPE_ROWS_BY_TYPE.get(projectType) || [];
+
+  // Per-field source helper — qids in QUICK_FORM_QIDS resolve against quick
+  // form, all others against the comprehensive form.
+  const valuesFor = (qid) =>
+    Object.values(QUICK_FORM_QIDS).includes(qid) ? quickValues : compValues;
+
+  const wqHistory = useMonitoringHistory(COMPREHENSIVE_FORM_ID, selectedDataPoint?.uuid);
+
+  return (
+    <div className="individual-overview">
+      <FilterRow extraBadges={{ waterSource, projectType }} ... />
+      <Row gutter={16}>
+        <Col span={8}><PhotoCaptionCard ... /></Col>
+        <Col span={8}><CharacteristicsTable ... /></Col>
+        <Col span={8}><StatsCard regValues={regValues} qids={STATS_CARD_QIDS} /></Col>
+      </Row>
+      <Tabs destroyInactiveTabPane>
+        <ConstructionMonitoringPane
+          comprehensiveValues={compValues}
+          quickValues={quickValues}
+          scopeRows={scopeRows}
+        />
+        <WaterQualityPane
+          comprehensiveValues={compValues}
+          quickValues={quickValues}
+          history={wqHistory.rows}
+        />
+        <Tabs.TabPane key="wsmp" tab="WSMP monitor">
+          <Empty description="WSMP monitor coming soon" />
+        </Tabs.TabPane>
+      </Tabs>
+    </div>
+  );
+};
+```
+
+`<FilterRow>`, `<ConstructionMonitoringPane>`, `<WaterQualityPane>`, `<StatsCard>` are inline JSX in each shell — not extracted to `individual-overview/shared/` because their internals diverge between EPS and RWS (different qid sets, different column meanings, different chart groupings). Promoting to shared primitives would require parameterising too many shapes; the rule-of-three test doesn't pass yet.
+
+---
+
+## Sequence Diagrams
+
+### Selection flow
+
+```
+User picks Location
+   ↓
+AdministrationDropdown updates store.administration
+   ↓
+useIndividualOverviewData effect fires
+   ↓
+fetchDataPoints(REG_FORM_ID, deepestAdminId)
+   ↓
+dataPoints[] populated; selectedDataPoint cleared
+   ↓
+EPS / RWS Select shows new options
+
+User picks an EPS / RWS
+   ↓
+setSelectedDataPoint(dp)
+   ↓
+useIndividualOverviewData effect (selectedDataPoint dep)
+   ├──► fetchValues(REG, dp.id) → regValues
+   ├──► fetchLatestMonitoring(monitoringForm[0], dp.uuid) → latestSubmission
+   │       └──► fetchValues(monitoringForm[0], latest.id) → monitoringValues[0]
+   └──► fetchLatestMonitoring(monitoringForm[1], dp.uuid)   (EPS only)
+           └──► fetchValues(monitoringForm[1], latest.id)
+   ↓
+All shell sections re-render with values
+
+User clicks Water Quality sub-tab
+   ↓
+useMonitoringHistory(WQ_FORM, dp.uuid) starts
+   ├──► fetchPage(1) → list
+   └──► fetchValues(each.id) in parallel
+   ↓
+history.rows[] populated; charts re-render with time-series data
+```
+
+### Tab gating (anonymous viewer — already implemented)
+
+```
+Anonymous viewer loads /dashboard/eps-overview
+   ↓
+TabsWidget reads store.useState(s => s.isLoggedIn) = false
+   ↓
+For tab_individual_overview (is_public: false):
+  → tabItem.disabled = true
+   ↓
+defaultActiveKey resolves to first non-disabled pane
+   ↓
+destroyInactiveTabPane = true → IndividualEPSOverview never mounts
+   ↓
+Anonymous user cannot trigger any of this hook chain
+```
+
+---
+
+## Edge Cases & Behaviour
+
+| Condition | Behaviour |
+|---|---|
+| User on the tab without picking Location | `dataPoints = []`, EPS/RWS select shows empty + disabled. Top + sub-tab sections hidden by `selectedDataPoint == null` guard, replaced with `<Empty description="Select an EPS to view details" />`. |
+| User picks Location with no EPS records | `dataPoints = []`, select shows empty state ("No data"). |
+| User picks EPS with no monitoring submissions | `monitoringValues[formId] = []`. Construction sub-tab shows progress 0% + empty rows. WQ sub-tab details table has no rows; charts show "No data" placeholder. |
+| Photo qid resolves to no answer | `<PhotoCaptionCard>` falls back to `<Empty image="/static/no-photo.svg" />`. |
+| `window.forms` doesn't include a question id from the config | `findQuestion` returns `null`, `<CharacteristicsTable>` skips that row, console.warn once. |
+| Backend returns 401 (anonymous viewer somehow bypassed gating) | `try/catch` in fetch helpers; `console.error` then state stays at `null`/`[]`. UI shows empty states. |
+| User changes EPS while history fetch in progress | Hook discards stale results via mounted-flag pattern. |
+| Test method qid returns `["lab_test", "cbt_test"]` (both) | Both Lab and CBT chart cards render. |
+| Test method qid returns no answer | Neither chart card renders; user sees only the details table + photo. |
+
+---
+
+## Test Specification
+
+### Unit tests (Jest + RTL)
+
+| File | Cases |
+|---|---|
+| `individual-overview/shared/__test__/helpers.test.js` | `findQuestion` (found / not found / missing forms), `findAnswer` (found / not found), `formatAnswerValue` (option / multiple_option / number / date / geo / array / null), `extractPhotoUrl` (string / null / non-string), `sortByDateAscending` (chronological / null dates) |
+| `individual-overview/shared/__test__/CharacteristicsTable.test.js` | Renders rows with labels from `window.forms`; skips qids with no answer; respects `title` Card wrapper |
+| `individual-overview/shared/__test__/PhotoCaptionCard.test.js` | Renders `<Image>` when URL present; renders `<Empty>` when null; caption appears |
+| `individual-overview/shared/__test__/HistoricalLineChart.test.js` | Sorts data ascending; renders threshold band when min/max provided |
+
+Hooks (`useIndividualOverviewData`, `useMonitoringHistory`) tested via integration in shell test below.
+
+### Shell smoke tests
+
+| File | Cases |
+|---|---|
+| `custom-components/__test__/IndividualEPSOverview.test.jsx` | Renders empty state when no dp selected; renders Photo + Characteristics + tabs when dp selected (mocked api) |
+| `custom-components/__test__/IndividualRWSOverview.test.jsx` | Same plus Stats card + WSMP placeholder + project-type-aware row selection |
+
+### Existing test updates
+
+| File | Update |
+|---|---|
+| `util/__test__/useDashboardConfig.test.js` | Already updated to assert EPS has 4 tabs + `tab_individual_overview` is `is_public: false`. **Add** RWS dashboard registration (4 tabs, including a public `tab_individual_overview`-equivalent). |
+
+### Manual smoke
+
+1. `./dc.sh up -d` → `/dashboard/eps-overview` → Individual Overview tab → pick a location + EPS → both sub-tabs render
+2. Same for `/dashboard/rws-overview` → also exercise the project type badge update + project scope row selection
+3. Log out → both Individual Overview tabs greyed out / unclickable
+4. Pick Lab-test EPS → 3 microbial line charts render; pick CBT-test → 1 chart
+5. Pick Lab-test RWS → 8 charts (Microbial + Chemical + Physical) render
+6. WSMP monitor sub-tab on RWS → "coming soon" placeholder
+
+---
+
+## Risk Register
+
+| Risk | Likelihood | Impact | Mitigation |
+|---|---|---|---|
+| Premature primitive abstraction wrong-shaped for RWS | Medium | Medium | Designed against both mockups; only ≥4× primitives extracted |
+| RWS qid mapping discrepancies (RWS plan §4 references `1749631041125`; user clarified `1749621962296` canonical) | High | Medium | Phase 2 validates each RWS qid; missing qids → `—` rather than crash |
+| `window.forms` shape variance dev/prod | Low | Medium | `findQuestion` defensively guards every level |
+| Photo answer URL format variance | Medium | Low | `<Image>` accepts both relative and absolute |
+| WQ history N+1 round-trips | Medium | Low | Acceptable for N≤20; isolated in `useMonitoringHistory` for future swap |
+| RWS project-type formula deferred — placeholder confuses reviewers | High | Low | Phase 5 explicit; risk register mentions it; TODO comment in shell |
+| AntD `<Progress>` expects 0–100 number | Medium | Low | Coerce + clamp |
+| `useMonitoringHistory` race on rapid EPS switching | Medium | Low | Mounted-flag pattern in hook |
+
+---
+
+## Out of Scope
+
+Repeated from [README](./README.md) for design-doc completeness:
+
+- RWS project-type-aware progress formula (SWP/BH/D/RH)
+- RWS WSMP monitor sub-tab content
+- Editing capabilities, deep-linking, lightbox, localisation, URL state
+- Backend endpoint to return per-record monitoring history in one call
+
+---
+
+## Companion documents
+
+- [README.md](./README.md) — SDD index + locked decisions
+- [implementation-plan.md](./implementation-plan.md) — sequenced tasks + qid reference tables
+- [`../dashboard-custom-component/dashboard-custom-component-design.md`](../dashboard-custom-component/dashboard-custom-component-design.md) — escape-hatch SDD
+- [`../dashboard-visualization-rws-plan.md`](../dashboard-visualization-rws-plan.md) — full RWS dashboard plan including §4
+
+---
+
+## Next Step
+
+Approved design → execute [implementation-plan.md](./implementation-plan.md) Phase 1 onwards. Stop after Phase 6 for user confirmation before commit/push (Phase 7).

--- a/doc/claude/dashboard-individual-overview/design.md
+++ b/doc/claude/dashboard-individual-overview/design.md
@@ -45,8 +45,10 @@ frontend/src/components/dashboard/custom-components/
 ├── IndividualRWSOverview.jsx                 # RWS shell (~220 lines)
 └── individual-overview/                      # pieces specific to this pattern
     ├── shared/                               # primitives reusable across both shells
-    │   ├── helpers.js                        # findQuestion, findAnswer, formatAnswerValue,
-    │   │                                     #   extractPhotoUrl, sortByDateAscending
+    │   ├── helpers.js                        # findQuestion, findQuestionGroup, findAnswer,
+    │   │                                     #   formatAnswerValue, extractPhotoUrl,
+    │   │                                     #   resolveAnswerLabel, collectGroupAnswers,
+    │   │                                     #   sortByDateAscending
     │   ├── CharacteristicsTable.jsx          # Question/Answer table
     │   ├── PhotoCaptionCard.jsx              # photo + caption + empty state
     │   ├── HistoricalLineChart.jsx           # Line chart + threshold band
@@ -155,6 +157,31 @@ resolveAnswerLabel(values, questionId)
  * @returns {Array<{date: string, value: number}>}
  */
 sortByDateAscending(rows)
+
+/**
+ * Find a question_group definition by id across every form in
+ * window.forms. Returns null when not found. Mirrors findQuestion's
+ * shape but at the group level.
+ *
+ * @param {number|string} groupId
+ * @returns {object|null} The group with { id, name, label, question[], ... }
+ */
+findQuestionGroup(groupId)
+
+/**
+ * Walk every question in a group, drop type=photo questions and any
+ * whose formatAnswerValue resolves to null/empty, then join the
+ * surviving formatted answers. Used for the EPS Construction
+ * Information "Implementation / Construction" cell where each row
+ * displays a comma-joined summary of one question group.
+ *
+ * @param {number|string} groupId
+ * @param {Array} values                    /data/<id> answer payload
+ * @param {object} [options]
+ * @param {string} [options.separator=", "]
+ * @returns {string}                         "" when group is unknown or every answer is empty
+ */
+collectGroupAnswers(groupId, values, options)
 ```
 
 ### `individual-overview/shared/PhotoCaptionCard.jsx`

--- a/doc/claude/dashboard-individual-overview/implementation-plan.md
+++ b/doc/claude/dashboard-individual-overview/implementation-plan.md
@@ -1,0 +1,420 @@
+# Individual Overview — Implementation Plan (EPS + RWS)
+
+Build the Individual Overview escape-hatch tab for **both** the EPS dashboard ([`IndividualEPSOverview`](../../../frontend/src/components/dashboard/custom-components/IndividualEPSOverview.jsx) — already scaffolded) and the RWS dashboard ([`IndividualRWSOverview`](../../../frontend/src/components/dashboard/custom-components/) — to be created), composing shared primitives so future record-centric tabs cost ≪200 lines per shell.
+
+**Branch**: `feature/196-visualization-individual-overview`
+**Issue**: #196
+**Companion**: [`dashboard-custom-component/`](../dashboard-custom-component/) — escape-hatch SDD
+**Mockups** (internal, not committed): [`doc/claude/dashboard-visualization-individual-overview/`](../dashboard-visualization-individual-overview/)
+**RWS dashboard plan**: [`dashboard-visualization-rws-plan.md`](../dashboard-visualization-rws-plan.md)
+
+---
+
+## Scope (this PR — both EPS and RWS individual overviews)
+
+### EPS Individual Overview
+
+| Section | What it shows | Source |
+|---|---|---|
+| Filter row | Administration cascade + EPS-list select | `store.administration` + `/form-data/<reg>?administration=<id>&sort_by=latest_activity` |
+| Top: Photo card (left, col 12) | Photo from latest construction monitoring with caption | Latest `/form-data/<construction>?parent=<uuid>` → `/data/<id>` → `inspection_photo` |
+| Top: EPS Characteristics (right, col 12) | Key/value table of registration answers | `/data/<eps_id>` cross-referenced with `window.forms` for labels |
+| Sub-tab: Construction monitoring | Progress bar + 12-row Construction Information table + General remarks | Latest construction monitoring values |
+| Sub-tab: Water quality monitoring | Last Water Monitoring Information table + sampling-point photo + status tag + conditional Lab/CBT line charts (Microbial only, 3 charts) | Latest water-quality values + paginated history |
+
+### RWS Individual Overview
+
+| Section | What it shows | Source |
+|---|---|---|
+| Filter row | Administration cascade + RWS-list select + Water Source badge + Project Type badge | `store.administration` + `/form-data/<reg>?administration=<id>` + comprehensive monitoring `water_source_type` / `type_of_project` |
+| Top: Photo card (col 8) | Photo from latest comprehensive monitoring sampling-point | `extractPhotoUrl(monitoringValues, sampling_point_photo qid)` |
+| Top: RWS Characteristics (col 8) | Key/value table — Division, Village, Water Committee, Implementation Date, Implementing Agency, Project Background, Name of village head, Contact, WSMP approved | Registration form values |
+| Top: Stats card (col 8) | Households served / People served / Project costs (icon row) | Registration form values |
+| Sub-tab: Construction monitoring | Progress bar (project-type formula) + Construction Information table (project-type-aware rows: SWP / BH / D / RH) + General remarks | Comprehensive monitoring values |
+| Sub-tab: Water quality monitoring | Last Water Monitoring Information table + sampling-point photo + status tag + conditional Lab/CBT line charts (Microbial 3 + Chemical 3 + Physical 2 = 8 charts on Lab; 1 chart on CBT) | Comprehensive monitoring values + paginated history |
+| Sub-tab: WSMP monitor | **Out of scope** — placeholder pane with empty state, content TBD | — |
+
+---
+
+## Cross-dashboard reusability analysis
+
+Comparing both pairs of mockups:
+
+| Surface | EPS | RWS | Verdict |
+|---|---|---|---|
+| Filter row | Admin + EPS select | Admin + RWS select + Water Source badge + Project Type badge | Selector primitive shared; badges RWS-only |
+| Top section grid | 2-col (Photo + Characteristics) | 3-col (Photo + Characteristics + Stats card) | Photo + Characteristics primitives shared; Stats card RWS-only |
+| Sub-tab list | Construction + Water Quality | Construction + Water Quality + WSMP monitor | Container shared; tab list per-dashboard |
+| Progress % source | Single qid | Project-type formula (SWP/BH/D/RH) | Display primitive shared; computation per-dashboard |
+| Project Scope table | 12 fixed rows; cols = Scope \| In scope? \| Implementation \| Photo | Project-type-dependent rows; cols = Scope \| Implementation \| Notes/issues \| Photo | Container shared if columns parameterised; rows + col defs per-dashboard |
+| Water Quality details | 9 rows | 11 rows (adds Inspector, Major issues, Description) | Same primitive (Question/Answer table), different qid lists |
+| WQ charts | Microbial only (3 charts) | Microbial + Chemical + Physical (8 charts) | Same primitive (`<HistoricalLineChart>` w/ threshold band); different param lists |
+
+**Reusable primitives extracted from day 1** (each appears ≥4× across the two designs):
+
+1. `findQuestion` / `findAnswer` / `formatAnswerValue` / `extractPhotoUrl` / `sortByDateAscending` (helpers, no UI)
+2. `<CharacteristicsTable>` — Question/Answer table given `{ qids[], values, fallbackForms? }` — used **6×** (EPS chars, EPS WQ details, RWS chars, RWS WQ details, plus secondary tables)
+3. `<PhotoCaptionCard>` — photo + caption + empty state — used **4×**
+4. `<HistoricalLineChart>` — `<Line>` from akvo-charts + threshold band + ascending sort — used **3× in EPS WQ + 8× in RWS WQ = 11×**
+5. `useIndividualOverviewData` — hook for admin → datapoints → reg-values + monitoring-values fetch chain (EPS=2 monitoring forms, RWS=1)
+6. `useMonitoringHistory` — paginated history fetcher feeding the line charts
+
+**Per-dashboard (rule of three NOT met → don't abstract yet)**:
+
+- The shell components (`IndividualEPSOverview.jsx`, `IndividualRWSOverview.jsx`)
+- Project Scope table cell renderers (different status semantics, different column meaning)
+- All constants (qid lists, project scope rows, lab/cbt param lists, project-type formulas)
+- Progress % calculation (RWS needs project-type-aware formula, EPS reads a single qid)
+- Stats card (RWS-only)
+- Water source / project type badges (RWS-only)
+
+This avoids the platform-design trap the [escape-hatch SDD](../dashboard-custom-component/dashboard-custom-component-design.md) explicitly warned against, while reaping ~50% code-share between the two shells.
+
+---
+
+## Approach
+
+### File layout
+
+```
+custom-components/
+├── index.js                                  # registry (modified — registers both shells)
+├── IndividualEPSOverview.jsx                 # EPS shell (~180 lines)
+├── IndividualRWSOverview.jsx                 # RWS shell (~220 lines — extra Stats card, WSMP placeholder)
+└── individual-overview/                      # pieces specific to the individual-overview pattern
+    ├── shared/                               # primitives reusable across both shells
+    │   ├── helpers.js                        # findQuestion, findAnswer, formatAnswerValue,
+    │   │                                     #   extractPhotoUrl, sortByDateAscending
+    │   ├── CharacteristicsTable.jsx          # generic Question/Answer table
+    │   ├── PhotoCaptionCard.jsx              # photo + caption + empty state
+    │   ├── HistoricalLineChart.jsx           # Line chart + threshold band
+    │   ├── useIndividualOverviewData.js      # admin → datapoints → values fetch chain
+    │   └── useMonitoringHistory.js           # paginated history per parent_uuid
+    └── config/                               # per-dashboard constants (qids, scope rows, params)
+        ├── eps.js                            # EPS-specific constants
+        └── rws.js                            # RWS-specific constants (project-type-aware row sets,
+                                              #   dual-form qid mappings)
+```
+
+The two shells stay at the `custom-components/` root because that's what the
+registry index.js imports and exports. Everything else specific to the
+individual-overview pattern lives under `individual-overview/`. A future
+`<DataExportPanel>` or other custom component would similarly own a sibling
+subfolder rather than polluting the root.
+
+### Data flow (lifted into the hook)
+
+```
+useIndividualOverviewData({ regFormId, monitoringFormIds })
+   │
+   ├── store.useState(s => s.administration) → deepest selected level
+   │
+   ├── effect ─► fetchDataPoints(reg, adminId)         → dataPoints[]
+   │
+   ├── selectedDataPoint state                          (set by consumer)
+   │
+   ├── effect ─► fetchValues(reg, eps.id)               → regValues
+   │
+   └── effect (per monitoringFormId)
+       ├──► fetchLatestMonitoring(formId, parent_uuid) → latestSubmissions[formId]
+       └──► fetchValues(formId, latest.id)             → monitoringValues[formId]
+
+Returned shape:
+{
+  loadingDataPoints, dataPoints, selectedDataPoint, setSelectedDataPoint,
+  regValues, monitoringValues: { [formId]: values[] },
+  refetch
+}
+```
+
+EPS: `monitoringFormIds = [1749624452908, 1749632545233]`.
+RWS: `monitoringFormIds = [1749621962296, 1749631041125]` — comprehensive form for most fields + quick form for the 5 fields the comprehensive form does not provide (operational status, contact persons, phone, water-committee training, photo description). The shell reads from `monitoringValues[1749621962296]` first, falling back to `monitoringValues[1749631041125]` for the marked qids.
+
+History fetch lives in `useMonitoringHistory(formId, parentUuid)` — only invoked when a Water Quality sub-tab is active.
+
+### Charts strategy
+
+`/visualization/values` aggregates across all records — cannot filter to one parent UUID. Both shells use `useMonitoringHistory` to do the N+1 round-trips client-side; charts then project per-parameter without extra calls.
+
+### Conditional Lab vs CBT
+
+Read latest WQ submission's `water_testing_method` answer (EPS qid `1749633001462`, RWS qid `1749622849604`). Render Lab charts when `lab_test ∈ methods`, CBT charts when `cbt_test ∈ methods`.
+
+---
+
+## Question-ID Reference
+
+### EPS
+
+Pulled from [`backend/source/forms/2_1749623934933.prod.json`](../../../backend/source/forms/2_1749623934933.prod.json), [`2_1749624452908.monitoring.prod.json`](../../../backend/source/forms/2_1749624452908.monitoring.prod.json), [`2_1749632545233.monitoring.prod.json`](../../../backend/source/forms/2_1749632545233.monitoring.prod.json).
+
+#### Registration `1749623934933`
+
+| Design row | qid |
+|---|---|
+| Division / Province / Tikina | `1749624452990` |
+| Village name | `1749624452991` |
+| Active Water Committee | `1749624452105` |
+| Implementation date | `1749632480584` |
+| Implementing Agency | `1749624452993` |
+| Project Background | `174962445299` |
+| Number of households | `1749624452106` |
+| Total population | `1749624452107` |
+
+#### Construction `1749624452908`
+
+| Design row | qid |
+|---|---|
+| Inspection date | `1749624452911` |
+| Construction start date | `1749624452910` |
+| Proposed completion date | `1749630516825` |
+| Weather Condition | `1749630701234` |
+| Concrete Base (completion / photo / caption) | `1849633499999` / `1849633500001` / `1849633600001` |
+| URF Tank | `1849633720001` / `1849633800001` / `1849633900001` |
+| EPS Tank | `1849633900003` / `1849634100001` / `1849634200001` |
+| Balance Tank | `1849634300002` / `1849634400001` / `1849634500001` |
+| Storage Tank | `1849634690001` / `1849634700001` / `1849634800001` |
+| Standpipes | `1849635200001` / `1849635000001` / `1849635100001` |
+| Drainage | — / `1849635300001` / `1849635400001` |
+| Site Security & Perimeter | `1849635500001` / `1849635600001` / `1849635700001` |
+| Project completion % | `1849635800001` |
+| General remarks | `1749624532451` |
+| Top photo (inspection / caption) | `1749624521442` / `1749631662652` |
+
+#### Water quality `1749632545233`
+
+| Design row | qid |
+|---|---|
+| Date of Inspection | `1749632545235` |
+| Name of village headman | `1749632793266` |
+| Phone contact | `1749632819551` |
+| EPS Training conducted | `1749632835123` |
+| Weather Condition | `1749632196724` |
+| Water sample taken | `1749632647507` |
+| Why water sample could not be taken | `1749632887312` |
+| Method of Water Testing | `1749633001462` |
+| General remarks | `1749633350893` |
+| Sampling point photo / caption | `1749633073911` / `1749633110662` |
+| Operational status (current status tag) | `1749633373968` |
+| Lab — E-coli | `1749633220746` |
+| Lab — Total Coliform | `1749633259392` |
+| Lab — Faecal Coliform | `1749633295165` |
+| CBT — Contamination count | `1749633325456` |
+
+### RWS
+
+**RWS uses two monitoring forms** — comprehensive `1749621962296` for most fields plus quick form `1749631041125` for 5 fields not present in the comprehensive form (operational status, contact persons, phone, water-committee training, photo description). The marker `🔵 QUICK-FORM` in [`dashboard-visualization-rws-plan.md`](../dashboard-visualization-rws-plan.md) flags those qids; the shell looks them up against `monitoringValues[1749631041125]`. All other RWS qids resolve against the comprehensive form.
+
+Source forms: [`3_1749621221728.prod.json`](../../../backend/source/forms/3_1749621221728.prod.json) (registration), [`3_1749621962296.monitoring.prod.json`](../../../backend/source/forms/3_1749621962296.monitoring.prod.json) (comprehensive monitoring).
+
+#### Registration `1749621221728`
+
+| Design row | qid |
+|---|---|
+| Division / Province / Tikina | `1749621221730` |
+| Village name | `1749621329696` |
+| Water Committee | `1749622715678` |
+| Construction Start Date | `1749622701234` |
+| Implementing Agency | `1749622571775` |
+| Project Background | `1749621347162` |
+| Number of households | `1749622327890` |
+| Total population | `1749622341234` |
+| Project costs | `1749622354567` |
+| WSMP submitted / approved | `1749622652941` / `1749622675800` |
+
+#### Comprehensive monitoring `1749621962296`
+
+| Design row | qid |
+|---|---|
+| Inspection date | `1749621962298` |
+| Proposed completion date | `1749622695675` |
+| Weather Condition | `1749622774567` |
+| Water sample taken | `1749622785185` |
+| Sampling point photo | `1849622785200` |
+| Method of Water Testing | `1749622849604` |
+| Parameters tested | `1749621050010` |
+| Project type (drives scope rows + progress formula) | `1749621851234` |
+| Water source (drives top-row badge) | `1749621374500` |
+| Lab — E-coli | `1749622991234` |
+| Lab — Total Coliform | `1749623024122` |
+| Lab — Fecal Coliform | `1749623074194` |
+| Lab — Turbidity | `1749623109418` |
+| Lab — Temperature | `1723459200023` |
+| Lab — pH | `1723459200024` |
+| Lab — Conductivity | `1723459200025` |
+| Lab — Salinity | `1723459200026` |
+| CBT — E.coli count | `1749622982588` |
+| CBT — Risk level | `1849622785201` |
+| CBT — Photo | `1749623001234` |
+
+#### Project-type-aware project scope rows
+
+Per [RWS plan §4 D](../dashboard-visualization-rws-plan.md). Stored as a `Map<projectType, Row[]>` in `individual-overview/config/rws.js`. Each row has `{ key, label, status_qid, implementation_qid?, issues_qid, photo_qid? }`.
+
+| Project type | Row count | Components |
+|---|---|---|
+| `surface_water_project` | 7 | Dam, Raw water main, Reservoir, Distribution main, Reticulation, Pumps, Piping works |
+| `borehole` | 8 | Borehole, Raw water main, Reservoir, Distribution main, Reticulation, Pumps, Piping works, Tanks |
+| `desalination` | 8 | Desalination unit, Raw water main, Reservoir, Distribution main, Reticulation, Pumps, Piping works, Tanks |
+| `rainwater_harvesting` | 4 | Rainwater tanks, Gutters, Base construction, Piping works |
+
+Exact qids per row from the existing `progress_construction.components[]` block in [`1749621221728.json`](../../../frontend/src/config/visualizations/1749621221728.json) (lines 21–117) plus the RWS plan §4 D Implementation/Issues/Photo qid columns.
+
+---
+
+## API contract recap
+
+| Endpoint | Returns | Notes |
+|---|---|---|
+| `GET /api/v1/form-data/<form_id>?administration=<id>&sort_by=latest_activity&sort_type=descend` | `{ data: [{id, name, uuid, …}], total }` | Paginated; renders into the RWS / EPS Select |
+| `GET /api/v1/form-data/<monitoring_form>?parent=<uuid>` | Same shape, sorted | First page → latest monitoring; full pagination → history |
+| `GET /api/v1/data/<data_id>` | `[{question, value, index, history}]` | `value` shape varies by question type — see [`backend/utils/functions.py:35`](../../../backend/utils/functions.py#L35) |
+
+---
+
+## Phased Task Breakdown
+
+### Phase 1 — Shared primitives
+
+- [ ] `individual-overview/shared/helpers.js` — pure functions: `findQuestion(qid)`, `findAnswer(values, qid)`, `formatAnswerValue(answer, question)`, `extractPhotoUrl(values, qid)`, `resolveAnswerLabel(values, qid)`, `sortByDateAscending(rows)`
+- [ ] `individual-overview/shared/PhotoCaptionCard.jsx` — props: `{ photoUrl, caption, alt, height? }`. AntD `<Card cover={<Image …>}>` + caption; falls back to `<Empty>`.
+- [ ] `individual-overview/shared/CharacteristicsTable.jsx` — props: `{ title?, qids[], values, formIdHint? }`. Two-column AntD `<Table>` (Question / Answer) with rows from `window.forms` labels and `formatAnswerValue` answers. Skips qids with no answer.
+- [ ] `individual-overview/shared/HistoricalLineChart.jsx` — props: `{ title, data: [{label, value}], thresholdMin?, thresholdMax?, unit? }`. Renders akvo-charts `<Line>` with optional shaded threshold band (markArea).
+- [ ] `individual-overview/shared/useIndividualOverviewData.js` — hook described above; exposes `{ loadingDataPoints, dataPoints, selectedDataPoint, setSelectedDataPoint, regValues, monitoringValues, refetch }`. Subscribes to `store.administration` for the deepest selected admin.
+- [ ] `individual-overview/shared/useMonitoringHistory.js` — `(formId, parentUuid) → { rows: [{date, values[]}], loading, error }`. Paginated list + per-submission `/data/<id>` fetches.
+
+### Phase 2 — Per-dashboard config modules
+
+- [ ] `individual-overview/config/eps.js`:
+  - `REGISTRATION_FORM_ID`, `CONSTRUCTION_FORM_ID`, `WATER_QUALITY_FORM_ID`
+  - `REGISTRATION_CHARACTERISTICS_QIDS` (8 qids)
+  - `WATER_QUALITY_DETAIL_QIDS` (9 qids)
+  - `PROJECT_SCOPE_ROWS` (12 fixed rows)
+  - `PROGRESS_QUESTION_ID`, `REMARKS_QUESTION_ID`
+  - `CONSTRUCTION_PHOTO_QID`, `CONSTRUCTION_PHOTO_CAPTION_QID`
+  - `WQ_PHOTO_QID`, `WQ_PHOTO_CAPTION_QID`, `WQ_STATUS_QID`, `WQ_TEST_METHOD_QID`, `WQ_DATE_QID`
+  - `WQ_LAB_PARAMS` (3 entries), `WQ_CBT_PARAM` (1 entry)
+
+- [ ] `individual-overview/config/rws.js`:
+  - `REGISTRATION_FORM_ID = 1749621221728`, `COMPREHENSIVE_FORM_ID = 1749621962296`, `QUICK_FORM_ID = 1749631041125`
+  - `QUICK_FORM_QIDS = { operationalStatus: 1749631041155, contactPersons: 1749631041128, phoneContact: 1749631041129, trainingConducted: 1749631041131, photoDescription: 1749631041153 }` — explicit set of qids that should be read from the quick form rather than the comprehensive form
+  - `REGISTRATION_CHARACTERISTICS_QIDS` (10+ qids per RWS mockup)
+  - `STATS_CARD_QIDS` (households, population, project_costs)
+  - `WATER_SOURCE_QID`, `PROJECT_TYPE_QID`
+  - `WATER_QUALITY_DETAIL_QIDS` (11 qids)
+  - `PROJECT_SCOPE_ROWS_BY_TYPE` — `Map<projectType, Row[]>` for the 4 project types
+  - `WSMP_APPROVED_QID`
+  - `INSPECTION_DATE_QID`, `PROPOSED_COMPLETION_QID`, `WEATHER_CONDITION_QID`
+  - `CONSTRUCTION_PHOTO_QID` (sampling point reused as Photo from Last Monitoring)
+  - `WQ_PHOTO_QID`, `WQ_PHOTO_CAPTION_QID`, `WQ_STATUS_QID`, `WQ_TEST_METHOD_QID`, `WQ_DATE_QID`
+  - `WQ_LAB_PARAMS` — 8 entries (Microbial 3 + Chemical 3 + Physical 2)
+  - `WQ_CBT_PARAMS` — 1+ entries (Contamination using CBT bags)
+
+### Phase 3 — Dashboard JSON wiring
+
+- [ ] Modify [`1749621221728.json`](../../../frontend/src/config/visualizations/1749621221728.json):
+  - Add top-level `"slug": "rws-overview"` (required by [`config validator`](../../../frontend/src/config/visualizations/index.js#L42))
+  - Append a 4th tab pane to `main_tabs.items[]`:
+    ```json
+    {
+      "id": "tab_individual_overview",
+      "is_public": false,
+      "label": "Individual Overview",
+      "items": [
+        {
+          "id": "individual_overview_component",
+          "chart_type": "custom_component",
+          "order": 1,
+          "component": "IndividualRWSOverview"
+        }
+      ]
+    }
+    ```
+- [ ] Modify [`frontend/src/config/visualizations/index.js`](../../../frontend/src/config/visualizations/index.js):
+  - Import RWS JSON: `import rwsOverview from "./1749621221728.json";`
+  - Append to `RAW_CONFIGS`: `const RAW_CONFIGS = [epsOverview, rwsOverview];`
+- [ ] Modify [`custom-components/index.js`](../../../frontend/src/components/dashboard/custom-components/index.js):
+  - Add named export for `IndividualRWSOverview`
+
+### Phase 4 — EPS shell composition
+
+Rewrite [`IndividualEPSOverview.jsx`](../../../frontend/src/components/dashboard/custom-components/IndividualEPSOverview.jsx) as a thin orchestrator (~180 lines):
+
+- [ ] Filter row: `<AdministrationDropdown />` + EPS `<Select>` (driven by `useIndividualOverviewData.dataPoints`)
+- [ ] Top row (col 12 / col 12):
+  - `<PhotoCaptionCard>` ← `extractPhotoUrl(monitoringValues[CONSTRUCTION], CONSTRUCTION_PHOTO_QID)`
+  - `<CharacteristicsTable title="EPS Characteristics" qids={REGISTRATION_CHARACTERISTICS_QIDS} values={regValues} />`
+- [ ] AntD `<Tabs destroyInactiveTabPane>` with two panes:
+  - **Construction monitoring**: progress bar from `PROGRESS_QUESTION_ID`; Construction Information `<Table>` driven by `PROJECT_SCOPE_ROWS` (12 rows) with In-scope tag / Implementation cell / Photo thumbnail; General remarks block.
+  - **Water quality monitoring**: 2-col layout — left `<CharacteristicsTable>` (9 rows); right stacked `<PhotoCaptionCard>` + status `<Tag>`. Conditional Microbial Parameters card containing 3× `<HistoricalLineChart>` (Lab) and CBT card with 1× `<HistoricalLineChart>`.
+
+### Phase 5 — RWS shell composition
+
+Create `IndividualRWSOverview.jsx` (~220 lines):
+
+- [ ] Filter row: `<AdministrationDropdown />` + RWS `<Select>` + Water Source badge + Project Type badge (badges read from latest monitoring `monitoringValues[1749621962296]`)
+- [ ] Top row (col 8 / col 8 / col 8):
+  - `<PhotoCaptionCard>` ← `extractPhotoUrl(monitoringValues[1749621962296], CONSTRUCTION_PHOTO_QID)`
+  - `<CharacteristicsTable title="RWS Characteristics" qids={REGISTRATION_CHARACTERISTICS_QIDS} values={regValues} />`
+  - Stats card: 3 icon rows (Households served / People served / Project costs) sourced from `regValues`
+- [ ] AntD `<Tabs destroyInactiveTabPane>` with three panes:
+  - **Construction monitoring**: progress bar — for now **read raw % from a single qid if available**, else show `<Empty>` with TODO note for the project-type formula computation (defer the formula to a follow-up). Construction Information `<Table>` driven by `PROJECT_SCOPE_ROWS_BY_TYPE.get(projectType)` rows; columns Scope \| Implementation \| Notes/issues \| Photo.
+  - **Water quality monitoring**: 2-col layout same as EPS but with 11-row details + Lab charts split into Microbial / Chemical / Physical sections (8 charts) and CBT card (1 chart).
+  - **WSMP monitor**: placeholder pane with `<Empty description="WSMP monitor coming soon" />` (mockup content not specified yet).
+
+### Phase 6 — Verification
+
+- [ ] `npm run lint` clean
+- [ ] `npm run prettier` clean
+- [ ] `npm test -- --watchAll=false` — full suite green; **update** `useDashboardConfig` test to assert RWS dashboard now has 4 tabs and is registered (currently the test only covers EPS)
+- [ ] Manual smoke (signed-in): `/dashboard/eps-overview` and `/dashboard/rws-overview` both render the Individual Overview tab without console errors
+- [ ] Manual smoke (anonymous): both Individual Overview tabs disabled
+
+### Phase 7 — Commit & push
+
+- [ ] Sequential commits with `[#196]` prefix:
+  1. `feat(dashboard): add shared primitives for individual-overview pattern`
+  2. `feat(dashboard): add EPS individual-overview config + finalize EPS shell`
+  3. `feat(dashboard): add RWS individual-overview config + RWS shell`
+  4. `feat(dashboard): wire RWS dashboard slug + register IndividualRWSOverview`
+  5. `test(dashboard): cover RWS dashboard registration + 4-tab assertion`
+  6. `docs(dashboard): document individual-overview reusability strategy`
+- [ ] Wait for explicit user go-ahead before push.
+
+---
+
+## Risk register
+
+| Risk | Likelihood | Impact | Mitigation |
+|---|---|---|---|
+| Premature abstraction — primitives shaped wrongly for RWS | Medium | Medium | Designed against both mockups; only extracting primitives that appear ≥4× across the two designs |
+| RWS qid mapping discrepancies (RWS plan references `1749631041125` qids; user clarified comprehensive `1749621962296`) | High | Medium | Phase 2 explicitly validates each RWS qid against the comprehensive form definition; missing qids surface as `—` placeholders rather than crashes |
+| `window.forms` shape varies between dev/prod | Low | Medium | `findQuestion` defensively guards every level (`forms || []`, `groups || []`) and returns `null` |
+| Photo answers may be relative URLs in some envs | Medium | Low | `<Image>` accepts both; render only when `typeof value === "string"` |
+| WQ history fetch is N+1 round-trips | Medium | Low | Acceptable for typical N≤20; isolated in `useMonitoringHistory` for future swap |
+| RWS project-type progress formula not implemented in this PR | High | Low | Phase 5 explicitly defers to a future PR; placeholder `<Empty>` + TODO comment in the shell |
+| AntD `<Progress>` expects 0–100 number; backend may return string | Medium | Low | Coerce with `Number()` and clamp `0 ≤ pct ≤ 100` |
+
+## Out of Scope (this PR)
+
+- **WSMP monitor sub-tab content** for RWS (mockup content not specified) — placeholder `<Empty>` rendered.
+- **RWS project-type-aware progress formula** — placeholder `<Empty>` with TODO; Surface Water = sum of completed components / 7, Borehole = /8, Desalination = /8, Rainwater = /4. Defer until first dashboard with real data exercises it.
+- Editing capabilities on photo / tables (read-only view).
+- Linking back to the underlying datapoint detail page (parent dashboard map handles that).
+- Photo lightbox / gallery (AntD `<Image>` provides default zoom).
+- Localised strings (English literals matching design copy).
+- URL state for selected datapoint (selection is component-local; reload resets).
+- Backend endpoint to return per-EPS / per-RWS history in one call (current N+1 is OK).
+
+## Companion documents
+
+- [`dashboard-custom-component/dashboard-custom-component-design.md`](../dashboard-custom-component/dashboard-custom-component-design.md) — escape-hatch design both shells plug into
+- [`dashboard-visualization-individual-overview/`](../dashboard-visualization-individual-overview/) — EPS + RWS design mockups (internal)
+- [`dashboard-visualization-rws-plan.md`](../dashboard-visualization-rws-plan.md) — full RWS dashboard plan including §4 Individual Overview spec
+- [`backend/source/forms/`](../../../backend/source/forms/) — authoritative form definitions
+
+---
+
+## Next step
+
+Approved plan → execute Phase 1 (shared primitives) onwards. Stop after Phase 6 for user confirmation before commit/push (Phase 7).

--- a/doc/claude/dashboard-individual-overview/implementation-plan.md
+++ b/doc/claude/dashboard-individual-overview/implementation-plan.md
@@ -381,6 +381,153 @@ Create `IndividualRWSOverview.jsx` (~220 lines):
   6. `docs(dashboard): document individual-overview reusability strategy`
 - [ ] Wait for explicit user go-ahead before push.
 
+### Phase 8 — Scope-row refactor (group-walk + generator script)
+
+Follow-up after the first six phases ship. Replaces the per-row
+`impl_qid` single-qid lookup with a per-row **question-group walk**, so
+the Implementation / Construction cell combines every non-photo answer
+in the scope's question group (matching the design mockup), and
+exposes a Python generator so the row list stays in sync with the
+authoritative form JSON.
+
+#### Row shape change
+
+`PROJECT_SCOPE_ROWS` supports two row variants — pick whichever fits
+the source data:
+
+**Scope row** (one per project component the user can opt into):
+
+```js
+{
+  key: "concrete_base",
+  label: "Concrete Base Construction",
+  scope_value: "concrete_base_construction",  // Matches a project_scope option value
+  impl_group_id: 1749624600001,                // Question group walked for the Implementation cell
+  photo_qid: 1849633500001,                    // Photo question (type: "photo")
+  photo_caption_qid: 1849633600001,            // Text description accompanying the photo
+}
+```
+
+**Metadata row** (one per single-answer project field that belongs in
+the Construction Information table but is not scope-gated — e.g.
+Inspection Date, Construction Start Date, Weather Condition):
+
+```js
+{
+  key: "inspection_date",
+  label: "Inspection Date",
+  scope_value: null,                           // null -> "In Scope?" cell renders blank
+  impl_group_id: null,                         // null -> Implementation cell falls back to question_id
+  photo_qid: null,                             // null -> Photo cell renders blank
+  photo_caption_qid: null,
+  question_id: 1749624452911,                  // Single-qid lookup via resolveAnswerLabel
+}
+```
+
+Shell render rules (`scopeRows` useMemo + `SCOPE_COLUMNS` render):
+
+| Cell | When `scope_value` / `impl_group_id` / `photo_qid` is set | When it is null |
+|---|---|---|
+| In Scope? | `Yes`/`No` tag from `projectScopeSelections.has(scope_value)` | Cell renders blank |
+| Implementation | `collectGroupAnswers(impl_group_id, constructionValues)` | Falls back to `resolveAnswerLabel(constructionValues, question_id)`, then `null → —` |
+| Photo | Thumbnail from `extractPhotoUrl(photo_qid)` + caption | Cell renders blank |
+
+Removed from earlier shape: `status_qid` (replaced by `scope_value` +
+`PROJECT_SCOPE_QUESTION_ID`), `impl_qid` (replaced by
+`impl_group_id` for scope rows or `question_id` for metadata rows).
+
+The previous wiring had two latent bugs it fixes at the same time:
+`impl_qid` pointed at the group's photo question (type=photo, so
+`formatAnswerValue` returned the raw URL as text), and `photo_qid`
+pointed at the photo's description text (so `extractPhotoUrl` always
+returned null and no thumbnail rendered).
+
+#### New helper
+
+- [ ] `individual-overview/shared/helpers.js` — add
+  `collectGroupAnswers(groupId, values, { separator = ", " })`:
+  finds the group in `window.forms`, iterates its questions, skips
+  `type === "photo"` and any question whose
+  `formatAnswerValue(findAnswer(values, q.id), q)` resolves to `null`,
+  and joins the surviving formatted answers with `separator`.
+  Returns `""` when the group is unknown or all answers are null so
+  the shell can render `—` via the existing fallback.
+
+#### Shell changes (`IndividualEPSOverview.jsx`)
+
+- [ ] `projectScopeSelections` useMemo reads `PROJECT_SCOPE_QUESTION_ID`
+  from `constructionValues` (note: this question lives on the
+  monitoring form, not the registration form) into a `Set` of selected
+  option values.
+- [ ] "In Scope?" cell: `null` → render nothing; `true` →
+  `<Tag color="green">Yes</Tag>`; `false` → `<Tag color="red">No</Tag>`.
+- [ ] "Implementation / Construction" cell: `impl_group_id` →
+  `collectGroupAnswers(impl_group_id, constructionValues)`; otherwise
+  `question_id` → `resolveAnswerLabel(constructionValues, question_id)`;
+  otherwise `null` → `—` placeholder.
+- [ ] "Photo" cell: when both `photo_qid`'s URL and the caption are
+  empty, render nothing; otherwise render the thumbnail +
+  `<Text type="secondary">` caption stacked vertically.
+
+#### Generator script
+
+- [ ] `scripts/visualization/gen_individual_overview_scope_rows.py`:
+  - CLI: `--form <path-to-monitoring-form.json>` (required),
+    `--registration <path-to-registration-form.json>` (required),
+    `--project-scope-qid <qid>` (optional override; falls back to the
+    registration form's `project_scope` multiple_option question when
+    there is exactly one).
+  - Walks the monitoring form's `question_groups`. A group is treated
+    as a scope group when its `name` ends with `_group` AND it is
+    neither the top-level project-info group nor the general-remarks
+    group (allowlist rather than blocklist; skip list includes
+    `project_info`, `project_details`, `general_remarks_group`,
+    `water_quality_testing`, `photo_of_eps_group`, `contact_details`).
+  - Per group, emits one row:
+    - `key` = `group.name` with trailing `_group` stripped
+    - `label` = `group.label`
+    - `scope_value` = option value from `project_scope` whose `label`
+      matches `group.label` case-insensitively; logs a `// TODO`
+      comment when no match is found so humans can hand-edit
+    - `impl_group_id` = `group.id`
+    - `photo_qid` = first question with `type: "photo"` inside the
+      group
+    - `photo_caption_qid` = the `text` question immediately after the
+      photo question in `order`, or the first `_desc`/`_description`
+      text question in the group as a fallback
+  - Output: prints only the `PROJECT_SCOPE_ROWS = [ ... ]` JS array
+    (no surrounding imports, no comments except TODO annotations) to
+    stdout for manual paste. Does **not** auto-edit
+    `individual-overview/config/eps.js`.
+  - The script emits **scope rows only** (one per matching question
+    group). Metadata rows (Inspection Date, Construction Start Date,
+    etc.) are stable across forms and are hand-added to the top of the
+    config — the script does not try to enumerate them.
+  - Caller workflow: paste the script's output over the existing
+    scope-row block in `individual-overview/config/eps.js`, leaving
+    any hand-added metadata rows above untouched.
+
+#### Verification
+
+- [ ] Regenerate the EPS scope rows with the script, diff against the
+  hand-edited config, paste the generator output over the old block
+  (preserving hand-added metadata rows above)
+- [ ] `npm run lint` + `npm run prettier` + targeted Jest suites green
+- [ ] Manual smoke:
+  - Metadata rows (Inspection Date, Construction Start Date, Proposed
+    Completion Date, Weather Conditions) render their single answer in
+    the Implementation column with blank In Scope? and Photo cells.
+  - Each scope row's Implementation cell shows the combined answer
+    text, Photo cell shows a thumbnail + caption, In Scope? cell
+    reflects the project_scope answer.
+- [ ] Update `helpers.test.js` to cover `collectGroupAnswers`
+  (missing group → `""`, empty values → `""`, photos excluded,
+  multiple types joined)
+- [ ] Commit plan (sequential on `feature/196`):
+  1. `feat(dashboard): add collectGroupAnswers helper + test`
+  2. `feat(dashboard): rewrite EPS scope rows on question-group walk + project_scope gating`
+  3. `chore(scripts): add scope-row generator for individual-overview configs`
+
 ---
 
 ## Risk register

--- a/frontend/src/components/dashboard/DashboardRenderer.jsx
+++ b/frontend/src/components/dashboard/DashboardRenderer.jsx
@@ -8,6 +8,7 @@ import KPICard from "./widgets/KPICard";
 import SectionTitleWidget from "./widgets/SectionTitleWidget";
 import FilterBarWidget from "./widgets/FilterBarWidget";
 import TabsWidget from "./widgets/TabsWidget";
+import CustomComponentWidget from "./widgets/CustomComponentWidget";
 
 const { Paragraph } = Typography;
 
@@ -189,6 +190,10 @@ const DashboardRenderer = ({
 
     if (type === "tabs") {
       return <TabsWidget item={item} renderItems={renderItems} />;
+    }
+
+    if (type === "custom_component") {
+      return <CustomComponentWidget item={item} />;
     }
 
     // Unknown type — silently skip in production.

--- a/frontend/src/components/dashboard/__test__/CustomComponentWidget.test.js
+++ b/frontend/src/components/dashboard/__test__/CustomComponentWidget.test.js
@@ -1,0 +1,48 @@
+import React from "react";
+import { render, screen } from "@testing-library/react";
+import CustomComponentWidget from "../widgets/CustomComponentWidget";
+
+jest.mock("../custom-components", () => ({
+  KnownComponent: () => (
+    <div data-testid="known-component">known component rendered</div>
+  ),
+}));
+
+describe("CustomComponentWidget", () => {
+  let consoleErrorSpy;
+
+  beforeEach(() => {
+    consoleErrorSpy = jest.spyOn(console, "error").mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    consoleErrorSpy.mockRestore();
+  });
+
+  test("renders the named component when present in the registry", () => {
+    render(
+      <CustomComponentWidget
+        item={{ id: "ok-item", component: "KnownComponent" }}
+      />
+    );
+
+    expect(screen.getByTestId("known-component")).toBeInTheDocument();
+    expect(consoleErrorSpy).not.toHaveBeenCalled();
+  });
+
+  test("renders an Alert and logs an error when the component is unknown", () => {
+    render(
+      <CustomComponentWidget
+        item={{ id: "missing-item", component: "DoesNotExist" }}
+      />
+    );
+
+    expect(screen.queryByTestId("known-component")).not.toBeInTheDocument();
+    expect(
+      screen.getByText(/Custom component "DoesNotExist" not found/)
+    ).toBeInTheDocument();
+    expect(consoleErrorSpy).toHaveBeenCalledTimes(1);
+    expect(consoleErrorSpy.mock.calls[0][0]).toContain("DoesNotExist");
+    expect(consoleErrorSpy.mock.calls[0][0]).toContain("missing-item");
+  });
+});

--- a/frontend/src/components/dashboard/__test__/TabsWidget.test.js
+++ b/frontend/src/components/dashboard/__test__/TabsWidget.test.js
@@ -1,0 +1,102 @@
+import React from "react";
+import { render, screen, act, cleanup } from "@testing-library/react";
+import TabsWidget from "../widgets/TabsWidget";
+import store from "../../../lib/store";
+
+const renderItems = (items) => (
+  <div data-testid={`pane-children-${items?.[0]?.id || "empty"}`}>
+    {items?.length || 0} child(ren)
+  </div>
+);
+
+const buildItem = (panes) => ({ id: "tabs", chart_type: "tabs", items: panes });
+
+const setIsLoggedIn = (value) => {
+  act(() => {
+    store.update((s) => {
+      s.isLoggedIn = value;
+    });
+  });
+};
+
+describe("TabsWidget — is_public gating", () => {
+  afterEach(() => {
+    // Unmount before resetting store state so Pullstate's listeners on the
+    // mounted TabsWidget do not fire a state-update outside an act() boundary.
+    cleanup();
+    setIsLoggedIn(false);
+  });
+
+  test("when anonymous, panes with is_public=false render as disabled tabs", () => {
+    setIsLoggedIn(false);
+    const item = buildItem([
+      { id: "public_tab", label: "Public", items: [{ id: "a" }] },
+      {
+        id: "private_tab",
+        label: "Private",
+        is_public: false,
+        items: [{ id: "b" }],
+      },
+    ]);
+
+    render(<TabsWidget item={item} renderItems={renderItems} />);
+
+    const privateTab = screen.getByRole("tab", { name: "Private" });
+    expect(privateTab).toHaveAttribute("aria-disabled", "true");
+
+    const publicTab = screen.getByRole("tab", { name: "Public" });
+    expect(publicTab).not.toHaveAttribute("aria-disabled", "true");
+  });
+
+  test("when anonymous and the first pane is private, default-active falls through to the first enabled pane", () => {
+    setIsLoggedIn(false);
+    const item = buildItem([
+      {
+        id: "private_first",
+        label: "Private",
+        is_public: false,
+        items: [{ id: "a" }],
+      },
+      { id: "public_second", label: "Public", items: [{ id: "b" }] },
+    ]);
+
+    render(<TabsWidget item={item} renderItems={renderItems} />);
+
+    const publicTab = screen.getByRole("tab", { name: "Public" });
+    expect(publicTab).toHaveAttribute("aria-selected", "true");
+  });
+
+  test("when signed in, is_public=false panes are not disabled", () => {
+    setIsLoggedIn(true);
+    const item = buildItem([
+      { id: "public_tab", label: "Public", items: [{ id: "a" }] },
+      {
+        id: "private_tab",
+        label: "Private",
+        is_public: false,
+        items: [{ id: "b" }],
+      },
+    ]);
+
+    render(<TabsWidget item={item} renderItems={renderItems} />);
+
+    const privateTab = screen.getByRole("tab", { name: "Private" });
+    expect(privateTab).not.toHaveAttribute("aria-disabled", "true");
+  });
+
+  test("panes without is_public behave unchanged regardless of auth state", () => {
+    setIsLoggedIn(false);
+    const item = buildItem([
+      { id: "tab_a", label: "A", items: [{ id: "a" }] },
+      { id: "tab_b", label: "B", items: [{ id: "b" }] },
+    ]);
+
+    render(<TabsWidget item={item} renderItems={renderItems} />);
+
+    const tabA = screen.getByRole("tab", { name: "A" });
+    const tabB = screen.getByRole("tab", { name: "B" });
+    expect(tabA).not.toHaveAttribute("aria-disabled", "true");
+    expect(tabB).not.toHaveAttribute("aria-disabled", "true");
+    expect(tabA).toHaveAttribute("aria-selected", "true");
+  });
+});

--- a/frontend/src/components/dashboard/custom-components/IndividualEPSOverview.jsx
+++ b/frontend/src/components/dashboard/custom-components/IndividualEPSOverview.jsx
@@ -1,0 +1,12 @@
+import React from "react";
+
+const IndividualEPSOverview = () => {
+  return (
+    <div>
+      <h1>Individual EPS Overview</h1>
+      <p>This is the Individual EPS Overview component.</p>
+    </div>
+  );
+};
+
+export default IndividualEPSOverview;

--- a/frontend/src/components/dashboard/custom-components/IndividualEPSOverview.jsx
+++ b/frontend/src/components/dashboard/custom-components/IndividualEPSOverview.jsx
@@ -20,6 +20,7 @@ import HistoricalLineChart from "./individual-overview/shared/HistoricalLineChar
 import useIndividualOverviewData from "./individual-overview/shared/useIndividualOverviewData";
 import useMonitoringHistory from "./individual-overview/shared/useMonitoringHistory";
 import {
+  collectGroupAnswers,
   extractPhotoUrl,
   findAnswer,
   resolveAnswerLabel,
@@ -30,6 +31,7 @@ import {
   CONSTRUCTION_PHOTO_QID,
   CONSTRUCTION_PROGRESS_QID,
   CONSTRUCTION_REMARKS_QID,
+  PROJECT_SCOPE_QUESTION_ID,
   PROJECT_SCOPE_ROWS,
   REGISTRATION_CHARACTERISTICS_QIDS,
   REGISTRATION_FORM_ID,
@@ -48,38 +50,53 @@ import {
 const { Title, Text } = Typography;
 
 const SCOPE_COLUMNS = [
-  { title: "Project Scope", dataIndex: "label", key: "label", width: "30%" },
+  { title: "Project Scope", dataIndex: "label", key: "label", width: "25%" },
   {
     title: "In Scope?",
     dataIndex: "inScope",
     key: "inScope",
-    width: "15%",
-    render: (text) =>
-      text ? <Tag color="green">{text}</Tag> : <Text type="secondary">—</Text>,
+    width: "10%",
+    render: (inScope) =>
+      inScope === null ? null : inScope ? (
+        <Tag color="green">Yes</Tag>
+      ) : (
+        <Tag color="red">No</Tag>
+      ),
   },
   {
     title: "Implementation / Construction",
     dataIndex: "implementation",
     key: "implementation",
-    width: "35%",
-    render: (text) => text || <Text type="secondary">—</Text>,
+    width: "45%",
+    render: (text) => (text ? text : <Text type="secondary">—</Text>),
   },
   {
     title: "Photo",
-    dataIndex: "photoUrl",
-    key: "photoUrl",
+    dataIndex: "photo",
+    key: "photo",
     width: "20%",
-    render: (url) =>
-      url ? (
-        <Image
-          src={url}
-          width={80}
-          height={60}
-          style={{ objectFit: "cover" }}
-        />
-      ) : (
-        <Text type="secondary">—</Text>
-      ),
+    render: (photo) => {
+      if (!photo?.url && !photo?.caption) {
+        return null;
+      }
+      return (
+        <div>
+          {photo.url ? (
+            <Image
+              src={photo.url}
+              width={80}
+              height={60}
+              style={{ objectFit: "cover" }}
+            />
+          ) : null}
+          {photo.caption ? (
+            <div style={{ marginTop: 4 }}>
+              <Text type="secondary">{photo.caption}</Text>
+            </div>
+          ) : null}
+        </div>
+      );
+    },
   },
 ];
 
@@ -165,21 +182,43 @@ const IndividualEPSOverview = () => {
     CONSTRUCTION_REMARKS_QID
   );
 
+  const projectScopeSelections = useMemo(() => {
+    // PROJECT_SCOPE_QUESTION_ID lives on the construction monitoring form,
+    // not the registration form, so we read from constructionValues.
+    const answer = findAnswer(constructionValues, PROJECT_SCOPE_QUESTION_ID);
+    const value = answer?.value;
+    if (Array.isArray(value)) {
+      return new Set(value);
+    }
+    if (typeof value === "string" && value.length > 0) {
+      return new Set([value]);
+    }
+    return new Set();
+  }, [constructionValues]);
+
   const scopeRows = useMemo(() => {
     return PROJECT_SCOPE_ROWS.map((row) => ({
       key: row.key,
       label: row.label,
-      inScope: row.status_qid
-        ? resolveAnswerLabel(constructionValues, row.status_qid)
+      inScope:
+        row.scope_value === null
+          ? null
+          : projectScopeSelections.has(row.scope_value),
+      implementation: row.impl_group_id
+        ? collectGroupAnswers(row.impl_group_id, constructionValues)
+        : row.question_id
+        ? resolveAnswerLabel(constructionValues, row.question_id)
         : null,
-      implementation: row.impl_qid
-        ? resolveAnswerLabel(constructionValues, row.impl_qid)
-        : null,
-      photoUrl: row.photo_qid
-        ? extractPhotoUrl(constructionValues, row.photo_qid)
-        : null,
+      photo: {
+        url: row.photo_qid
+          ? extractPhotoUrl(constructionValues, row.photo_qid)
+          : null,
+        caption: row.photo_caption_qid
+          ? resolveAnswerLabel(constructionValues, row.photo_caption_qid)
+          : null,
+      },
     }));
-  }, [constructionValues]);
+  }, [constructionValues, projectScopeSelections]);
 
   const wqPhotoUrl = extractPhotoUrl(wqValues, WQ_PHOTO_QID);
   const wqPhotoCaption = resolveAnswerLabel(wqValues, WQ_PHOTO_CAPTION_QID);

--- a/frontend/src/components/dashboard/custom-components/IndividualEPSOverview.jsx
+++ b/frontend/src/components/dashboard/custom-components/IndividualEPSOverview.jsx
@@ -1,10 +1,347 @@
-import React from "react";
+import React, { useMemo } from "react";
+import {
+  Card,
+  Col,
+  Empty,
+  Image,
+  Progress,
+  Row,
+  Select,
+  Space,
+  Table,
+  Tabs,
+  Tag,
+  Typography,
+} from "antd";
+import AdministrationDropdown from "../../filters/AdministrationDropdown";
+import CharacteristicsTable from "./individual-overview/shared/CharacteristicsTable";
+import PhotoCaptionCard from "./individual-overview/shared/PhotoCaptionCard";
+import HistoricalLineChart from "./individual-overview/shared/HistoricalLineChart";
+import useIndividualOverviewData from "./individual-overview/shared/useIndividualOverviewData";
+import useMonitoringHistory from "./individual-overview/shared/useMonitoringHistory";
+import {
+  extractPhotoUrl,
+  findAnswer,
+  resolveAnswerLabel,
+} from "./individual-overview/shared/helpers";
+import {
+  CONSTRUCTION_FORM_ID,
+  CONSTRUCTION_PHOTO_CAPTION_QID,
+  CONSTRUCTION_PHOTO_QID,
+  CONSTRUCTION_PROGRESS_QID,
+  CONSTRUCTION_REMARKS_QID,
+  PROJECT_SCOPE_ROWS,
+  REGISTRATION_CHARACTERISTICS_QIDS,
+  REGISTRATION_FORM_ID,
+  TEST_METHOD_CBT,
+  TEST_METHOD_LAB,
+  WATER_QUALITY_DETAIL_QIDS,
+  WATER_QUALITY_FORM_ID,
+  WQ_CBT_PARAMS,
+  WQ_LAB_PARAMS,
+  WQ_PHOTO_CAPTION_QID,
+  WQ_PHOTO_QID,
+  WQ_STATUS_QID,
+  WQ_TEST_METHOD_QID,
+} from "./individual-overview/config/eps";
+
+const { Title, Text } = Typography;
+
+const SCOPE_COLUMNS = [
+  { title: "Project Scope", dataIndex: "label", key: "label", width: "30%" },
+  {
+    title: "In Scope?",
+    dataIndex: "inScope",
+    key: "inScope",
+    width: "15%",
+    render: (text) =>
+      text ? <Tag color="green">{text}</Tag> : <Text type="secondary">—</Text>,
+  },
+  {
+    title: "Implementation / Construction",
+    dataIndex: "implementation",
+    key: "implementation",
+    width: "35%",
+    render: (text) => text || <Text type="secondary">—</Text>,
+  },
+  {
+    title: "Photo",
+    dataIndex: "photoUrl",
+    key: "photoUrl",
+    width: "20%",
+    render: (url) =>
+      url ? (
+        <Image
+          src={url}
+          width={80}
+          height={60}
+          style={{ objectFit: "cover" }}
+        />
+      ) : (
+        <Text type="secondary">—</Text>
+      ),
+  },
+];
+
+const toMethodList = (methodAnswer) => {
+  if (!methodAnswer) {
+    return [];
+  }
+  const v = methodAnswer.value;
+  if (Array.isArray(v)) {
+    return v;
+  }
+  if (typeof v === "string") {
+    return [v];
+  }
+  return [];
+};
+
+const buildSeries = (history, qid) => {
+  if (!Array.isArray(history)) {
+    return [];
+  }
+  return history
+    .map((row) => {
+      const answer = findAnswer(row.values, qid);
+      if (!answer) {
+        return null;
+      }
+      const numeric = Number(answer.value);
+      if (Number.isNaN(numeric)) {
+        return null;
+      }
+      return { label: row.date || "", value: numeric };
+    })
+    .filter(Boolean);
+};
 
 const IndividualEPSOverview = () => {
+  const {
+    dataPoints,
+    selectedDataPoint,
+    setSelectedDataPoint,
+    regValues,
+    monitoringValues,
+  } = useIndividualOverviewData({
+    regFormId: REGISTRATION_FORM_ID,
+    monitoringFormIds: [CONSTRUCTION_FORM_ID, WATER_QUALITY_FORM_ID],
+  });
+
+  const constructionValues = useMemo(
+    () => monitoringValues[CONSTRUCTION_FORM_ID] || [],
+    [monitoringValues]
+  );
+  const wqValues = useMemo(
+    () => monitoringValues[WATER_QUALITY_FORM_ID] || [],
+    [monitoringValues]
+  );
+
+  const wqHistory = useMonitoringHistory(
+    WATER_QUALITY_FORM_ID,
+    selectedDataPoint?.uuid
+  );
+
+  const photoUrl = extractPhotoUrl(constructionValues, CONSTRUCTION_PHOTO_QID);
+  const photoCaption = resolveAnswerLabel(
+    constructionValues,
+    CONSTRUCTION_PHOTO_CAPTION_QID
+  );
+
+  const progressPct = useMemo(() => {
+    const answer = findAnswer(constructionValues, CONSTRUCTION_PROGRESS_QID);
+    if (!answer) {
+      return null;
+    }
+    const n = Number(answer.value);
+    if (Number.isNaN(n)) {
+      return null;
+    }
+    return Math.max(0, Math.min(100, n));
+  }, [constructionValues]);
+
+  const remarks = resolveAnswerLabel(
+    constructionValues,
+    CONSTRUCTION_REMARKS_QID
+  );
+
+  const scopeRows = useMemo(() => {
+    return PROJECT_SCOPE_ROWS.map((row) => ({
+      key: row.key,
+      label: row.label,
+      inScope: row.status_qid
+        ? resolveAnswerLabel(constructionValues, row.status_qid)
+        : null,
+      implementation: row.impl_qid
+        ? resolveAnswerLabel(constructionValues, row.impl_qid)
+        : null,
+      photoUrl: row.photo_qid
+        ? extractPhotoUrl(constructionValues, row.photo_qid)
+        : null,
+    }));
+  }, [constructionValues]);
+
+  const wqPhotoUrl = extractPhotoUrl(wqValues, WQ_PHOTO_QID);
+  const wqPhotoCaption = resolveAnswerLabel(wqValues, WQ_PHOTO_CAPTION_QID);
+  const wqStatus = resolveAnswerLabel(wqValues, WQ_STATUS_QID);
+
+  const methods = toMethodList(findAnswer(wqValues, WQ_TEST_METHOD_QID));
+  const showLabCharts = methods.includes(TEST_METHOD_LAB);
+  const showCbtCharts = methods.includes(TEST_METHOD_CBT);
+
+  const renderEmptySelection = () => (
+    <Empty description="Select a Location and an EPS to view details" />
+  );
+
   return (
-    <div>
-      <h1>Individual EPS Overview</h1>
-      <p>This is the Individual EPS Overview component.</p>
+    <div className="individual-overview">
+      <Space style={{ marginBottom: 16 }} wrap>
+        <AdministrationDropdown />
+        <Select
+          placeholder="Select an EPS"
+          style={{ minWidth: 240 }}
+          options={dataPoints}
+          value={selectedDataPoint?.id || null}
+          onChange={(_, option) =>
+            setSelectedDataPoint(
+              dataPoints.find((dp) => dp.id === option?.id) || null
+            )
+          }
+          fieldNames={{ value: "id", label: "name" }}
+          allowClear
+          showSearch
+          optionFilterProp="name"
+        />
+      </Space>
+
+      {!selectedDataPoint ? (
+        renderEmptySelection()
+      ) : (
+        <>
+          <Row gutter={16} style={{ marginBottom: 16 }}>
+            <Col span={12}>
+              <PhotoCaptionCard
+                title="Latest construction photo"
+                photoUrl={photoUrl}
+                caption={photoCaption}
+                alt="Construction photo"
+              />
+            </Col>
+            <Col span={12}>
+              <CharacteristicsTable
+                title="EPS Characteristics"
+                qids={REGISTRATION_CHARACTERISTICS_QIDS}
+                values={regValues}
+              />
+            </Col>
+          </Row>
+
+          <Tabs destroyInactiveTabPane>
+            <Tabs.TabPane key="construction" tab="Construction monitoring">
+              <Card
+                title="Project completion"
+                size="small"
+                style={{ marginBottom: 16 }}
+              >
+                {progressPct === null ? (
+                  <Empty description="No progress data yet" />
+                ) : (
+                  <Progress percent={progressPct} status="active" />
+                )}
+              </Card>
+              <Card
+                title="Construction Information — EPS"
+                size="small"
+                style={{ marginBottom: 16 }}
+              >
+                <Table
+                  rowKey="key"
+                  size="small"
+                  pagination={false}
+                  columns={SCOPE_COLUMNS}
+                  dataSource={scopeRows}
+                />
+              </Card>
+              <Card title="General remarks" size="small">
+                {remarks ? (
+                  <Text>{remarks}</Text>
+                ) : (
+                  <Text type="secondary">No remarks</Text>
+                )}
+              </Card>
+            </Tabs.TabPane>
+
+            <Tabs.TabPane key="water_quality" tab="Water quality monitoring">
+              <Row gutter={16} style={{ marginBottom: 16 }}>
+                <Col span={12}>
+                  <CharacteristicsTable
+                    title="Last Water Monitoring Information"
+                    qids={WATER_QUALITY_DETAIL_QIDS}
+                    values={wqValues}
+                  />
+                </Col>
+                <Col span={12}>
+                  <PhotoCaptionCard
+                    title="Sampling point"
+                    photoUrl={wqPhotoUrl}
+                    caption={wqPhotoCaption}
+                    alt="Sampling point photo"
+                  />
+                  <Card size="small" style={{ marginTop: 16 }}>
+                    <Title level={5} style={{ marginBottom: 8 }}>
+                      Operational status
+                    </Title>
+                    {wqStatus ? (
+                      <Tag color="blue">{wqStatus}</Tag>
+                    ) : (
+                      <Text type="secondary">Not reported</Text>
+                    )}
+                  </Card>
+                </Col>
+              </Row>
+
+              {showLabCharts && (
+                <Card
+                  title="Microbial parameters"
+                  size="small"
+                  style={{ marginBottom: 16 }}
+                >
+                  <Row gutter={16}>
+                    {WQ_LAB_PARAMS.map((p) => (
+                      <Col span={8} key={p.key}>
+                        <HistoricalLineChart
+                          title={p.title}
+                          data={buildSeries(wqHistory.rows, p.qid)}
+                          unit={p.unit}
+                          thresholdMin={p.thresholdMin}
+                          thresholdMax={p.thresholdMax}
+                        />
+                      </Col>
+                    ))}
+                  </Row>
+                </Card>
+              )}
+
+              {showCbtCharts && (
+                <Card title="CBT parameters" size="small">
+                  <Row gutter={16}>
+                    {WQ_CBT_PARAMS.map((p) => (
+                      <Col span={12} key={p.key}>
+                        <HistoricalLineChart
+                          title={p.title}
+                          data={buildSeries(wqHistory.rows, p.qid)}
+                          unit={p.unit}
+                          thresholdMax={p.thresholdMax}
+                        />
+                      </Col>
+                    ))}
+                  </Row>
+                </Card>
+              )}
+            </Tabs.TabPane>
+          </Tabs>
+        </>
+      )}
     </div>
   );
 };

--- a/frontend/src/components/dashboard/custom-components/IndividualEPSOverview.jsx
+++ b/frontend/src/components/dashboard/custom-components/IndividualEPSOverview.jsx
@@ -68,7 +68,14 @@ const SCOPE_COLUMNS = [
     dataIndex: "implementation",
     key: "implementation",
     width: "45%",
-    render: (text) => (text ? text : <Text type="secondary">—</Text>),
+    // Explicit emptiness check — `text ? text : —` would render the
+    // placeholder for legitimate falsy values like 0 or "0".
+    render: (text) =>
+      text === null || typeof text === "undefined" || text === "" ? (
+        <Text type="secondary">—</Text>
+      ) : (
+        text
+      ),
   },
   {
     title: "Photo",
@@ -124,7 +131,18 @@ const buildSeries = (history, qid) => {
       if (!answer) {
         return null;
       }
-      const numeric = Number(answer.value);
+      const raw = answer.value;
+      // Treat null / undefined / "" / whitespace-only as missing before
+      // numeric conversion — Number("") and Number("   ") both yield 0,
+      // which would chart spurious zero-value datapoints.
+      if (
+        raw === null ||
+        typeof raw === "undefined" ||
+        (typeof raw === "string" && raw.trim() === "")
+      ) {
+        return null;
+      }
+      const numeric = Number(raw);
       if (Number.isNaN(numeric)) {
         return null;
       }
@@ -170,7 +188,18 @@ const IndividualEPSOverview = () => {
     if (!answer) {
       return null;
     }
-    const n = Number(answer.value);
+    const raw = answer.value;
+    // Treat null / undefined / "" / whitespace-only as missing before
+    // numeric conversion — Number("") yields 0, which would render a
+    // legitimate-looking 0% progress bar instead of the empty state.
+    if (
+      raw === null ||
+      typeof raw === "undefined" ||
+      (typeof raw === "string" && raw.trim() === "")
+    ) {
+      return null;
+    }
+    const n = Number(raw);
     if (Number.isNaN(n)) {
       return null;
     }

--- a/frontend/src/components/dashboard/custom-components/IndividualEPSOverview.jsx
+++ b/frontend/src/components/dashboard/custom-components/IndividualEPSOverview.jsx
@@ -1,4 +1,4 @@
-import React, { useMemo } from "react";
+import React, { useMemo, useState } from "react";
 import {
   Card,
   Col,
@@ -13,7 +13,7 @@ import {
   Tag,
   Typography,
 } from "antd";
-import AdministrationDropdown from "../../filters/AdministrationDropdown";
+import AdministrationDropdownLocal from "../../filters/AdministrationDropdownLocal";
 import CharacteristicsTable from "./individual-overview/shared/CharacteristicsTable";
 import PhotoCaptionCard from "./individual-overview/shared/PhotoCaptionCard";
 import HistoricalLineChart from "./individual-overview/shared/HistoricalLineChart";
@@ -152,6 +152,11 @@ const buildSeries = (history, qid) => {
 };
 
 const IndividualEPSOverview = () => {
+  // Component-local admin selection. Lives in React state instead of
+  // store.administration so picking a location here does NOT trigger a
+  // dashboard-wide refetch of every chart, table, and KPI on the page.
+  const [embeddedAdmin, setEmbeddedAdmin] = useState(null);
+
   const {
     dataPoints,
     selectedDataPoint,
@@ -161,6 +166,7 @@ const IndividualEPSOverview = () => {
   } = useIndividualOverviewData({
     regFormId: REGISTRATION_FORM_ID,
     monitoringFormIds: [CONSTRUCTION_FORM_ID, WATER_QUALITY_FORM_ID],
+    selectedLocation: embeddedAdmin,
   });
 
   const constructionValues = useMemo(
@@ -264,7 +270,7 @@ const IndividualEPSOverview = () => {
   return (
     <div className="individual-overview">
       <Space style={{ marginBottom: 16 }} wrap>
-        <AdministrationDropdown />
+        <AdministrationDropdownLocal onChange={setEmbeddedAdmin} />
         <Select
           placeholder="Select an EPS"
           style={{ minWidth: 240 }}

--- a/frontend/src/components/dashboard/custom-components/index.js
+++ b/frontend/src/components/dashboard/custom-components/index.js
@@ -1,0 +1,3 @@
+import IndividualEPSOverview from "./IndividualEPSOverview";
+
+export { IndividualEPSOverview };

--- a/frontend/src/components/dashboard/custom-components/individual-overview/config/eps.js
+++ b/frontend/src/components/dashboard/custom-components/individual-overview/config/eps.js
@@ -1,0 +1,173 @@
+/**
+ * EPS Individual Overview — per-dashboard constants.
+ *
+ * Question ids resolved from:
+ *   backend/source/forms/2_1749623934933.prod.json
+ *   backend/source/forms/2_1749624452908.monitoring.prod.json
+ *   backend/source/forms/2_1749632545233.monitoring.prod.json
+ *
+ * See doc/claude/dashboard-individual-overview/implementation-plan.md
+ * § Question-ID Reference / EPS for the full mapping table.
+ */
+
+export const REGISTRATION_FORM_ID = 1749623934933;
+export const CONSTRUCTION_FORM_ID = 1749624452908;
+export const WATER_QUALITY_FORM_ID = 1749632545233;
+
+export const REGISTRATION_CHARACTERISTICS_QIDS = [
+  1749624452990, // Division / Province / Tikina
+  1749624452991, // Village name
+  1749624452105, // Active Water Committee
+  1749632480584, // Implementation date
+  1749624452993, // Implementing Agency
+  174962445299, // Project Background
+  1749624452106, // Number of households
+  1749624452107, // Total population
+];
+
+export const CONSTRUCTION_INSPECTION_DATE_QID = 1749624452911;
+export const CONSTRUCTION_START_DATE_QID = 1749624452910;
+export const CONSTRUCTION_PROPOSED_COMPLETION_QID = 1749630516825;
+export const CONSTRUCTION_WEATHER_QID = 1749630701234;
+export const CONSTRUCTION_REMARKS_QID = 1749624532451;
+export const CONSTRUCTION_PROGRESS_QID = 1849635800001;
+export const CONSTRUCTION_PHOTO_QID = 1749624521442;
+export const CONSTRUCTION_PHOTO_CAPTION_QID = 1749631662652;
+
+/**
+ * Project scope rows for the Construction Information table.
+ * Columns: Scope | In scope? | Implementation/Construction | Photo
+ *   - status_qid     → "In scope?" / completion status answer
+ *   - impl_qid       → "Implementation" cell answer (date or note)
+ *   - photo_qid      → "Photo" thumbnail
+ */
+export const PROJECT_SCOPE_ROWS = [
+  {
+    key: "concrete_base",
+    label: "Concrete Base",
+    status_qid: 1849633499999,
+    impl_qid: 1849633500001,
+    photo_qid: 1849633600001,
+  },
+  {
+    key: "urf_tank",
+    label: "URF Tank",
+    status_qid: 1849633720001,
+    impl_qid: 1849633800001,
+    photo_qid: 1849633900001,
+  },
+  {
+    key: "eps_tank",
+    label: "EPS Tank",
+    status_qid: 1849633900003,
+    impl_qid: 1849634100001,
+    photo_qid: 1849634200001,
+  },
+  {
+    key: "balance_tank",
+    label: "Balance Tank",
+    status_qid: 1849634300002,
+    impl_qid: 1849634400001,
+    photo_qid: 1849634500001,
+  },
+  {
+    key: "storage_tank",
+    label: "Storage Tank",
+    status_qid: 1849634690001,
+    impl_qid: 1849634700001,
+    photo_qid: 1849634800001,
+  },
+  {
+    key: "standpipes",
+    label: "Standpipes",
+    status_qid: 1849635200001,
+    impl_qid: 1849635000001,
+    photo_qid: 1849635100001,
+  },
+  {
+    key: "drainage",
+    label: "Drainage",
+    status_qid: null,
+    impl_qid: 1849635300001,
+    photo_qid: 1849635400001,
+  },
+  {
+    key: "site_security",
+    label: "Site Security & Perimeter",
+    status_qid: 1849635500001,
+    impl_qid: 1849635600001,
+    photo_qid: 1849635700001,
+  },
+];
+
+export const WQ_DATE_QID = 1749632545235;
+export const WQ_VILLAGE_HEADMAN_QID = 1749632793266;
+export const WQ_PHONE_QID = 1749632819551;
+export const WQ_TRAINING_QID = 1749632835123;
+export const WQ_WEATHER_QID = 1749632196724;
+export const WQ_SAMPLE_TAKEN_QID = 1749632647507;
+export const WQ_SAMPLE_NOT_TAKEN_REASON_QID = 1749632887312;
+export const WQ_TEST_METHOD_QID = 1749633001462;
+export const WQ_REMARKS_QID = 1749633350893;
+export const WQ_PHOTO_QID = 1749633073911;
+export const WQ_PHOTO_CAPTION_QID = 1749633110662;
+export const WQ_STATUS_QID = 1749633373968;
+
+export const WATER_QUALITY_DETAIL_QIDS = [
+  WQ_DATE_QID,
+  WQ_VILLAGE_HEADMAN_QID,
+  WQ_PHONE_QID,
+  WQ_TRAINING_QID,
+  WQ_WEATHER_QID,
+  WQ_SAMPLE_TAKEN_QID,
+  WQ_SAMPLE_NOT_TAKEN_REASON_QID,
+  WQ_TEST_METHOD_QID,
+  WQ_REMARKS_QID,
+];
+
+/**
+ * Lab / CBT chart parameter lists. `qid` resolves the per-submission value
+ * for the chart series; `unit` and threshold drive the akvo-charts y-axis
+ * + markArea band.
+ */
+export const WQ_LAB_PARAMS = [
+  {
+    key: "ecoli",
+    title: "E-coli",
+    qid: 1749633220746,
+    unit: "cfu/100mL",
+    thresholdMax: 0,
+  },
+  {
+    key: "total_coliform",
+    title: "Total Coliform",
+    qid: 1749633259392,
+    unit: "cfu/100mL",
+    thresholdMax: 0,
+  },
+  {
+    key: "fecal_coliform",
+    title: "Faecal Coliform",
+    qid: 1749633295165,
+    unit: "cfu/100mL",
+    thresholdMax: 0,
+  },
+];
+
+export const WQ_CBT_PARAMS = [
+  {
+    key: "cbt_count",
+    title: "CBT contamination count",
+    qid: 1749633325456,
+    unit: "count",
+    thresholdMax: 0,
+  },
+];
+
+/**
+ * Test-method option values that flag Lab / CBT chart sections as
+ * applicable. The latest WQ submission's WQ_TEST_METHOD_QID answer is
+ * cross-referenced against these option values.
+ */
+export const TEST_METHOD_LAB = "lab_test";
+export const TEST_METHOD_CBT = "cbt_test";

--- a/frontend/src/components/dashboard/custom-components/individual-overview/config/eps.js
+++ b/frontend/src/components/dashboard/custom-components/individual-overview/config/eps.js
@@ -35,68 +35,130 @@ export const CONSTRUCTION_PHOTO_QID = 1749624521442;
 export const CONSTRUCTION_PHOTO_CAPTION_QID = 1749631662652;
 
 /**
+ * Registration `project_scope` multiple_option question. Its answer
+ * lists the component keys that belong to the current EPS project;
+ * the shell shows a green "Yes" tag in the "In Scope?" column when
+ * PROJECT_SCOPE_ROWS[i].scope_value appears in this answer, red "No"
+ * otherwise.
+ */
+export const PROJECT_SCOPE_QUESTION_ID = 1749624505915;
+
+/**
  * Project scope rows for the Construction Information table.
- * Columns: Scope | In scope? | Implementation/Construction | Photo
- *   - status_qid     → "In scope?" / completion status answer
- *   - impl_qid       → "Implementation" cell answer (date or note)
- *   - photo_qid      → "Photo" thumbnail
+ * Columns: Project Scope | In scope? | Implementation/Construction | Photo
+ *   - scope_value         → option value checked against PROJECT_SCOPE_QUESTION_ID
+ *                           answer for the "In scope?" tag
+ *   - impl_group_id       → question group walked by collectGroupAnswers to
+ *                           combine every non-photo answer into the
+ *                           Implementation / Construction cell
+ *   - photo_qid           → actual photo question (type: "photo") for the
+ *                           Photo column thumbnail
+ *   - photo_caption_qid   → text description shown under the thumbnail
+ *
+ * See scripts/visualization/gen_individual_overview_scope_rows.py for
+ * a generator that emits this array from the construction monitoring
+ * form JSON.
  */
 export const PROJECT_SCOPE_ROWS = [
   {
+    key: "inspection_date",
+    label: "Inspection Date",
+    scope_value: null,
+    impl_group_id: null,
+    photo_qid: null,
+    photo_caption_qid: null,
+    question_id: 1749624452911,
+  },
+  {
+    key: "construction_start_date",
+    label: "Construction Start Date",
+    scope_value: null,
+    impl_group_id: null,
+    photo_qid: null,
+    photo_caption_qid: null,
+    question_id: 1749624452910,
+  },
+  {
+    key: "proposed_completion_date",
+    label: "Proposed Completion Date",
+    scope_value: null,
+    impl_group_id: null,
+    photo_qid: null,
+    photo_caption_qid: null,
+    question_id: 1749630516825,
+  },
+  {
+    key: "weather_conditions",
+    label: "Weather Conditions",
+    scope_value: null,
+    impl_group_id: null,
+    photo_qid: null,
+    photo_caption_qid: null,
+    question_id: 1749630701234,
+  },
+  {
     key: "concrete_base",
-    label: "Concrete Base",
-    status_qid: 1849633499999,
-    impl_qid: 1849633500001,
-    photo_qid: 1849633600001,
+    label: "Concrete Base Construction",
+    scope_value: "concrete_base_construction",
+    impl_group_id: 1749624600001,
+    photo_qid: 1849633500001,
+    photo_caption_qid: 1849633600001,
   },
   {
     key: "urf_tank",
-    label: "URF Tank",
-    status_qid: 1849633720001,
-    impl_qid: 1849633800001,
-    photo_qid: 1849633900001,
+    label: "URF Tank Implementation",
+    scope_value: "urf_tank_implementation",
+    impl_group_id: 1749624700001,
+    photo_qid: 1849633800001,
+    photo_caption_qid: 1849633900001,
   },
   {
     key: "eps_tank",
-    label: "EPS Tank",
-    status_qid: 1849633900003,
-    impl_qid: 1849634100001,
-    photo_qid: 1849634200001,
+    label: "EPS Tank Implementation",
+    scope_value: "eps_tank_implementation",
+    impl_group_id: 1749624800001,
+    photo_qid: 1849634100001,
+    photo_caption_qid: 1849634200001,
   },
   {
     key: "balance_tank",
-    label: "Balance Tank",
-    status_qid: 1849634300002,
-    impl_qid: 1849634400001,
-    photo_qid: 1849634500001,
+    label: "Balance Tank Implementation",
+    scope_value: "balance_tank_implementation",
+    impl_group_id: 1749624900001,
+    photo_qid: 1849634400001,
+    photo_caption_qid: 1849634500001,
   },
   {
     key: "storage_tank",
-    label: "Storage Tank",
-    status_qid: 1849634690001,
-    impl_qid: 1849634700001,
-    photo_qid: 1849634800001,
+    label: "Storage Tank Implementation",
+    scope_value: "storage_tank_implementation",
+    impl_group_id: 1749625000001,
+    photo_qid: 1849634700001,
+    photo_caption_qid: 1849634800001,
   },
   {
     key: "standpipes",
     label: "Standpipes",
-    status_qid: 1849635200001,
-    impl_qid: 1849635000001,
-    photo_qid: 1849635100001,
+    scope_value: "standpipes",
+    impl_group_id: 1749625100001,
+    photo_qid: 1849635000001,
+    photo_caption_qid: 1849635100001,
   },
   {
     key: "drainage",
     label: "Drainage",
-    status_qid: null,
-    impl_qid: 1849635300001,
-    photo_qid: 1849635400001,
+    scope_value: "drainage",
+    impl_group_id: 1749625200001,
+    photo_qid: 1849635300001,
+    photo_caption_qid: 1849635400001,
   },
   {
     key: "site_security",
-    label: "Site Security & Perimeter",
-    status_qid: 1849635500001,
-    impl_qid: 1849635600001,
-    photo_qid: 1849635700001,
+    label: "Site Security and Perimeter",
+    scope_value: "site_security_and_perimeter",
+    impl_group_id: 1749625300001,
+    photo_qid: 1849635600001,
+    photo_caption_qid: 1849635700001,
   },
 ];
 

--- a/frontend/src/components/dashboard/custom-components/individual-overview/shared/CharacteristicsTable.jsx
+++ b/frontend/src/components/dashboard/custom-components/individual-overview/shared/CharacteristicsTable.jsx
@@ -1,0 +1,93 @@
+import React, { useMemo } from "react";
+import PropTypes from "prop-types";
+import { Card, Empty, Table } from "antd";
+import { findAnswer, findQuestion, formatAnswerValue } from "./helpers";
+
+/**
+ * Two-column AntD <Table> rendering Question (window.forms label) /
+ * Answer (formatAnswerValue) for a list of question ids. Skips qids with
+ * no resolvable answer rather than rendering blank rows.
+ */
+const CharacteristicsTable = ({
+  title,
+  qids,
+  values,
+  bordered,
+  size,
+  emptyText,
+}) => {
+  const rows = useMemo(() => {
+    return (qids || [])
+      .map((qid) => {
+        const question = findQuestion(qid);
+        const answer = findAnswer(values, qid);
+        const display = formatAnswerValue(answer, question);
+        if (!question || display === null) {
+          return null;
+        }
+        return {
+          key: String(qid),
+          question: question.label || question.name || String(qid),
+          answer: display,
+        };
+      })
+      .filter(Boolean);
+  }, [qids, values]);
+
+  const columns = [
+    {
+      title: "Question",
+      dataIndex: "question",
+      key: "question",
+      width: "50%",
+    },
+    {
+      title: "Answer",
+      dataIndex: "answer",
+      key: "answer",
+    },
+  ];
+
+  const body =
+    rows.length === 0 ? (
+      <Empty description={emptyText} />
+    ) : (
+      <Table
+        columns={columns}
+        dataSource={rows}
+        pagination={false}
+        size={size}
+        bordered={bordered}
+        showHeader={false}
+      />
+    );
+
+  if (!title) {
+    return body;
+  }
+  return (
+    <Card title={title} bordered>
+      {body}
+    </Card>
+  );
+};
+
+CharacteristicsTable.propTypes = {
+  title: PropTypes.string,
+  qids: PropTypes.arrayOf(
+    PropTypes.oneOfType([PropTypes.number, PropTypes.string])
+  ).isRequired,
+  values: PropTypes.array,
+  bordered: PropTypes.bool,
+  size: PropTypes.oneOf(["small", "middle", "large"]),
+  emptyText: PropTypes.string,
+};
+
+CharacteristicsTable.defaultProps = {
+  values: [],
+  bordered: true,
+  size: "small",
+  emptyText: "No information available",
+};
+
+export default CharacteristicsTable;

--- a/frontend/src/components/dashboard/custom-components/individual-overview/shared/CharacteristicsTable.jsx
+++ b/frontend/src/components/dashboard/custom-components/individual-overview/shared/CharacteristicsTable.jsx
@@ -2,6 +2,7 @@ import React, { useMemo } from "react";
 import PropTypes from "prop-types";
 import { Card, Empty, Table } from "antd";
 import { findAnswer, findQuestion, formatAnswerValue } from "./helpers";
+import useAdministrationNames from "./useAdministrationNames";
 
 /**
  * Two-column AntD <Table> rendering Question (window.forms label) /
@@ -16,12 +17,14 @@ const CharacteristicsTable = ({
   size,
   emptyText,
 }) => {
+  const administrationLookup = useAdministrationNames(values);
   const rows = useMemo(() => {
+    const lookups = { administration: administrationLookup };
     return (qids || [])
       .map((qid) => {
         const question = findQuestion(qid);
         const answer = findAnswer(values, qid);
-        const display = formatAnswerValue(answer, question);
+        const display = formatAnswerValue(answer, question, lookups);
         if (!question || display === null) {
           return null;
         }
@@ -32,7 +35,7 @@ const CharacteristicsTable = ({
         };
       })
       .filter(Boolean);
-  }, [qids, values]);
+  }, [qids, values, administrationLookup]);
 
   const columns = [
     {

--- a/frontend/src/components/dashboard/custom-components/individual-overview/shared/HistoricalLineChart.jsx
+++ b/frontend/src/components/dashboard/custom-components/individual-overview/shared/HistoricalLineChart.jsx
@@ -1,0 +1,115 @@
+import React, { useMemo } from "react";
+import PropTypes from "prop-types";
+import { Card, Empty } from "antd";
+import { Line } from "akvo-charts";
+import { sortByDateAscending } from "./helpers";
+
+const baseConfig = {
+  horizontal: false,
+  legend: { show: false },
+  textStyle: { fontFamily: "Arial" },
+};
+
+const numericValue = (raw) => {
+  if (raw === null || typeof raw === "undefined" || raw === "") {
+    return null;
+  }
+  const n = Number(raw);
+  return Number.isNaN(n) ? null : n;
+};
+
+// pages/dashboard/style.scss applies `min-height: 320px` to every
+// akvo-charts `div[role="figure"]`, so we match the empty state to the
+// same floor — empty cards then align with chart cards in the same row.
+const FIGURE_MIN_HEIGHT = 320;
+
+/**
+ * akvo-charts <Line> wrapped with optional threshold band (markArea). Sorts
+ * data ascending by `label` (treated as a date string) before render.
+ */
+const HistoricalLineChart = ({
+  title,
+  data,
+  thresholdMin,
+  thresholdMax,
+  unit,
+}) => {
+  const sorted = useMemo(() => {
+    return sortByDateAscending(
+      (data || []).map((row) => ({ date: row?.label, ...row }))
+    );
+  }, [data]);
+
+  const seriesData = useMemo(() => {
+    return sorted
+      .map((row) => ({
+        label: row?.label,
+        value: numericValue(row?.value),
+      }))
+      .filter((row) => row.value !== null);
+  }, [sorted]);
+
+  const chartConfig = useMemo(() => {
+    // No `title` here — the AntD <Card> header already shows it. Height is
+    // driven by div[role="figure"]'s SCSS min-height.
+    const cfg = {
+      ...baseConfig,
+      xAxisLabel: "Date",
+      yAxisLabel: unit || "",
+    };
+    const hasMin = typeof thresholdMin === "number";
+    const hasMax = typeof thresholdMax === "number";
+    if (hasMin || hasMax) {
+      const lo = hasMin ? thresholdMin : -Infinity;
+      const hi = hasMax ? thresholdMax : Infinity;
+      cfg.rawConfig = {
+        markArea: {
+          itemStyle: { color: "rgba(82, 196, 26, 0.12)" },
+          data: [[{ yAxis: lo }, { yAxis: hi }]],
+        },
+      };
+    }
+    return cfg;
+  }, [unit, thresholdMin, thresholdMax]);
+
+  const body =
+    seriesData.length === 0 ? (
+      <div
+        style={{
+          minHeight: FIGURE_MIN_HEIGHT,
+          display: "flex",
+          alignItems: "center",
+          justifyContent: "center",
+        }}
+      >
+        <Empty description="No history yet" />
+      </div>
+    ) : (
+      <Line config={chartConfig} data={seriesData} />
+    );
+
+  return (
+    <Card title={title} size="small" bordered>
+      {body}
+    </Card>
+  );
+};
+
+HistoricalLineChart.propTypes = {
+  title: PropTypes.string.isRequired,
+  data: PropTypes.arrayOf(
+    PropTypes.shape({
+      label: PropTypes.string,
+      value: PropTypes.oneOfType([PropTypes.number, PropTypes.string]),
+    })
+  ),
+  thresholdMin: PropTypes.number,
+  thresholdMax: PropTypes.number,
+  unit: PropTypes.string,
+};
+
+HistoricalLineChart.defaultProps = {
+  data: [],
+};
+
+export default HistoricalLineChart;

--- a/frontend/src/components/dashboard/custom-components/individual-overview/shared/PhotoCaptionCard.jsx
+++ b/frontend/src/components/dashboard/custom-components/individual-overview/shared/PhotoCaptionCard.jsx
@@ -1,0 +1,63 @@
+import React from "react";
+import PropTypes from "prop-types";
+import { Card, Empty, Image, Typography } from "antd";
+
+const { Text } = Typography;
+
+/**
+ * Photo card with caption + AntD Image zoom. Renders <Empty> when no URL.
+ */
+const PhotoCaptionCard = ({
+  photoUrl,
+  caption,
+  alt = "Photo",
+  height = 240,
+  title,
+}) => {
+  const cover = photoUrl ? (
+    <Image
+      src={photoUrl}
+      alt={alt}
+      height={height}
+      style={{ objectFit: "cover", width: "100%" }}
+      preview
+    />
+  ) : (
+    <div
+      style={{
+        height,
+        display: "flex",
+        alignItems: "center",
+        justifyContent: "center",
+        background: "#fafafa",
+      }}
+    >
+      <Empty description="No photo available" />
+    </div>
+  );
+
+  return (
+    <Card title={title} cover={cover} bordered>
+      {caption ? (
+        <Text type="secondary">{caption}</Text>
+      ) : (
+        <Text type="secondary">No caption</Text>
+      )}
+    </Card>
+  );
+};
+
+PhotoCaptionCard.propTypes = {
+  photoUrl: PropTypes.string,
+  caption: PropTypes.string,
+  alt: PropTypes.string,
+  height: PropTypes.number,
+  title: PropTypes.string,
+};
+
+PhotoCaptionCard.defaultProps = {
+  photoUrl: null,
+  caption: null,
+};
+
+export default PhotoCaptionCard;

--- a/frontend/src/components/dashboard/custom-components/individual-overview/shared/__test__/helpers.test.js
+++ b/frontend/src/components/dashboard/custom-components/individual-overview/shared/__test__/helpers.test.js
@@ -1,5 +1,7 @@
 import {
+  collectAdministrationIds,
   collectGroupAnswers,
+  fetchAdministrationNames,
   findAnswer,
   findQuestion,
   findQuestionGroup,
@@ -7,7 +9,14 @@ import {
   extractPhotoUrl,
   resolveAnswerLabel,
   sortByDateAscending,
+  __resetAdministrationNameCache,
 } from "../helpers";
+import { api } from "../../../../../../lib";
+
+jest.mock("../../../../../../lib", () => ({
+  __esModule: true,
+  api: { get: jest.fn() },
+}));
 
 const originalForms = window.forms;
 
@@ -41,6 +50,7 @@ const FORMS_FIXTURE = [
             },
             { id: 104, label: "Coords", type: "geo" },
             { id: 105, label: "Photo", type: "photo" },
+            { id: 106, label: "Where", type: "administration" },
           ],
         },
         {
@@ -146,6 +156,39 @@ describe("formatAnswerValue", () => {
 
   test("falls back to String() for primitives", () => {
     expect(formatAnswerValue({ value: 42 }, { type: "number" })).toBe("42");
+  });
+
+  test("administration falls back to id when no lookup is provided", () => {
+    expect(formatAnswerValue({ value: 78 }, findQuestion(106))).toBe("78");
+  });
+
+  test("administration uses lookup map when entry exists", () => {
+    const lookups = {
+      administration: new Map([[78, "Fiji - Western - Ra - Saivou"]]),
+    };
+    expect(formatAnswerValue({ value: 78 }, findQuestion(106), lookups)).toBe(
+      "Fiji - Western - Ra - Saivou"
+    );
+  });
+
+  test("administration accepts numeric-string ids", () => {
+    const lookups = { administration: new Map([[78, "Saivou"]]) };
+    expect(formatAnswerValue({ value: "78" }, findQuestion(106), lookups)).toBe(
+      "Saivou"
+    );
+  });
+
+  test("administration joins resolved path entries with ' - '", () => {
+    const lookups = {
+      administration: new Map([
+        [1, "Fiji"],
+        [2, "Western"],
+        [78, "Saivou"],
+      ]),
+    };
+    expect(
+      formatAnswerValue({ value: [1, 2, 78] }, findQuestion(106), lookups)
+    ).toBe("Fiji - Western - Saivou");
   });
 });
 
@@ -268,5 +311,88 @@ describe("sortByDateAscending", () => {
 
   test("returns [] for non-array input", () => {
     expect(sortByDateAscending(null)).toEqual([]);
+  });
+});
+
+describe("collectAdministrationIds", () => {
+  test("returns numeric ids for administration-typed answers only", () => {
+    const values = [
+      { question: 101, value: "free text" },
+      { question: 106, value: 78 },
+      { question: 102, value: "yes" },
+    ];
+    expect(collectAdministrationIds(values)).toEqual([78]);
+  });
+
+  test("dedupes and accepts string ids and arrays", () => {
+    const values = [
+      { question: 106, value: "78" },
+      { question: 106, value: 78 },
+      { question: 106, value: [1, "2", 78] },
+    ];
+    const ids = collectAdministrationIds(values).sort((a, b) => a - b);
+    expect(ids).toEqual([1, 2, 78]);
+  });
+
+  test("ignores null/undefined entries and non-numeric values", () => {
+    const values = [
+      null,
+      { question: 106, value: null },
+      { question: 106, value: "not-a-number" },
+      { question: 106, value: 5 },
+    ];
+    expect(collectAdministrationIds(values)).toEqual([5]);
+  });
+
+  test("returns [] when values is not an array", () => {
+    expect(collectAdministrationIds(null)).toEqual([]);
+  });
+});
+
+describe("fetchAdministrationNames", () => {
+  beforeEach(() => {
+    __resetAdministrationNameCache();
+    api.get.mockReset();
+  });
+
+  test("returns Map of resolved names from /administration/<id>", async () => {
+    api.get.mockResolvedValueOnce({
+      data: {
+        id: 78,
+        full_name: "Fiji|Western|Ra|Saivou",
+        name: "Saivou",
+      },
+    });
+    const map = await fetchAdministrationNames([78]);
+    expect(api.get).toHaveBeenCalledWith("administration/78");
+    expect(map.get(78)).toBe("Fiji - Western - Ra - Saivou");
+  });
+
+  test("falls back to data.name when full_name is missing", async () => {
+    api.get.mockResolvedValueOnce({ data: { id: 5, name: "Fiji" } });
+    const map = await fetchAdministrationNames([5]);
+    expect(map.get(5)).toBe("Fiji");
+  });
+
+  test("caches resolved ids so a second fetch hits the network once", async () => {
+    api.get.mockResolvedValueOnce({
+      data: { id: 78, full_name: "Fiji|Saivou", name: "Saivou" },
+    });
+    await fetchAdministrationNames([78]);
+    await fetchAdministrationNames([78]);
+    expect(api.get).toHaveBeenCalledTimes(1);
+  });
+
+  test("omits ids that fail to resolve", async () => {
+    api.get.mockRejectedValueOnce(new Error("boom"));
+    const consoleSpy = jest.spyOn(console, "error").mockImplementation();
+    const map = await fetchAdministrationNames([99]);
+    expect(map.size).toBe(0);
+    consoleSpy.mockRestore();
+  });
+
+  test("returns empty Map for empty/missing input", async () => {
+    expect((await fetchAdministrationNames([])).size).toBe(0);
+    expect((await fetchAdministrationNames(null)).size).toBe(0);
   });
 });

--- a/frontend/src/components/dashboard/custom-components/individual-overview/shared/__test__/helpers.test.js
+++ b/frontend/src/components/dashboard/custom-components/individual-overview/shared/__test__/helpers.test.js
@@ -1,6 +1,8 @@
 import {
-  findQuestion,
+  collectGroupAnswers,
   findAnswer,
+  findQuestion,
+  findQuestionGroup,
   formatAnswerValue,
   extractPhotoUrl,
   resolveAnswerLabel,
@@ -15,6 +17,8 @@ const FORMS_FIXTURE = [
     content: {
       question_group: [
         {
+          id: 1001,
+          name: "basic_group",
           question: [
             { id: 101, label: "Free text", type: "input" },
             {
@@ -37,6 +41,24 @@ const FORMS_FIXTURE = [
             },
             { id: 104, label: "Coords", type: "geo" },
             { id: 105, label: "Photo", type: "photo" },
+          ],
+        },
+        {
+          id: 2001,
+          name: "scope_group",
+          question: [
+            {
+              id: 201,
+              label: "Current status",
+              type: "option",
+              option: [
+                { value: "ongoing", label: "Ongoing" },
+                { value: "completed", label: "Completed" },
+              ],
+            },
+            { id: 202, label: "Tank size", type: "input" },
+            { id: 203, label: "Scope photo", type: "photo" },
+            { id: 204, label: "Scope notes", type: "input" },
           ],
         },
       ],
@@ -155,6 +177,73 @@ describe("resolveAnswerLabel", () => {
 
   test("returns null when no answer", () => {
     expect(resolveAnswerLabel([], 101)).toBeNull();
+  });
+});
+
+describe("findQuestionGroup", () => {
+  test("returns the matching group by id", () => {
+    expect(findQuestionGroup(2001)).toMatchObject({
+      id: 2001,
+      name: "scope_group",
+    });
+  });
+
+  test("accepts string ids", () => {
+    expect(findQuestionGroup("2001")).toMatchObject({ id: 2001 });
+  });
+
+  test("returns null when not found", () => {
+    expect(findQuestionGroup(9999)).toBeNull();
+  });
+
+  test("returns null for null/undefined id", () => {
+    expect(findQuestionGroup(null)).toBeNull();
+  });
+
+  test("returns null when window.forms is missing", () => {
+    delete window.forms;
+    expect(findQuestionGroup(2001)).toBeNull();
+  });
+});
+
+describe("collectGroupAnswers", () => {
+  test("joins formatted non-photo answers from the group", () => {
+    const values = [
+      { question: 201, value: "ongoing" }, // option -> "Ongoing"
+      { question: 202, value: "2700L" }, // input
+      { question: 203, value: "http://x/y.jpg" }, // photo -> SKIPPED
+      { question: 204, value: "notes here" }, // input
+    ];
+    expect(collectGroupAnswers(2001, values)).toBe(
+      "Ongoing, 2700L, notes here"
+    );
+  });
+
+  test("skips answers that resolve to null/empty", () => {
+    const values = [
+      { question: 201, value: "completed" },
+      { question: 202, value: "" },
+      { question: 204, value: null },
+    ];
+    expect(collectGroupAnswers(2001, values)).toBe("Completed");
+  });
+
+  test("returns empty string when group is not found", () => {
+    expect(collectGroupAnswers(9999, [])).toBe("");
+  });
+
+  test("returns empty string when values is empty", () => {
+    expect(collectGroupAnswers(2001, [])).toBe("");
+  });
+
+  test("honours custom separator", () => {
+    const values = [
+      { question: 201, value: "ongoing" },
+      { question: 202, value: "2700L" },
+    ];
+    expect(collectGroupAnswers(2001, values, { separator: " | " })).toBe(
+      "Ongoing | 2700L"
+    );
   });
 });
 

--- a/frontend/src/components/dashboard/custom-components/individual-overview/shared/__test__/helpers.test.js
+++ b/frontend/src/components/dashboard/custom-components/individual-overview/shared/__test__/helpers.test.js
@@ -1,0 +1,183 @@
+import {
+  findQuestion,
+  findAnswer,
+  formatAnswerValue,
+  extractPhotoUrl,
+  resolveAnswerLabel,
+  sortByDateAscending,
+} from "../helpers";
+
+const originalForms = window.forms;
+
+const FORMS_FIXTURE = [
+  {
+    id: 1,
+    content: {
+      question_group: [
+        {
+          question: [
+            { id: 101, label: "Free text", type: "input" },
+            {
+              id: 102,
+              label: "Choice",
+              type: "option",
+              option: [
+                { value: "yes", label: "Yes" },
+                { value: "no", label: "No" },
+              ],
+            },
+            {
+              id: 103,
+              label: "Multi",
+              type: "multiple_option",
+              option: [
+                { value: "a", label: "Apple" },
+                { value: "b", label: "Banana" },
+              ],
+            },
+            { id: 104, label: "Coords", type: "geo" },
+            { id: 105, label: "Photo", type: "photo" },
+          ],
+        },
+      ],
+    },
+  },
+];
+
+beforeEach(() => {
+  window.forms = FORMS_FIXTURE;
+});
+
+afterAll(() => {
+  window.forms = originalForms;
+});
+
+describe("findQuestion", () => {
+  test("returns the matching question across forms", () => {
+    expect(findQuestion(101)).toMatchObject({ id: 101, label: "Free text" });
+  });
+
+  test("accepts string ids", () => {
+    expect(findQuestion("101")).toMatchObject({ id: 101 });
+  });
+
+  test("returns null when not found", () => {
+    expect(findQuestion(999)).toBeNull();
+  });
+
+  test("returns null when window.forms is empty", () => {
+    window.forms = [];
+    expect(findQuestion(101)).toBeNull();
+  });
+
+  test("returns null when window.forms is missing", () => {
+    delete window.forms;
+    expect(findQuestion(101)).toBeNull();
+  });
+});
+
+describe("findAnswer", () => {
+  test("finds the answer entry by question id", () => {
+    const values = [{ question: 101, value: "hello" }];
+    expect(findAnswer(values, 101)).toEqual({ question: 101, value: "hello" });
+  });
+
+  test("returns null for missing values", () => {
+    expect(findAnswer(null, 101)).toBeNull();
+  });
+
+  test("returns null when not found", () => {
+    expect(findAnswer([{ question: 999, value: "x" }], 101)).toBeNull();
+  });
+});
+
+describe("formatAnswerValue", () => {
+  test("returns null for empty answer", () => {
+    expect(formatAnswerValue(null, null)).toBeNull();
+  });
+
+  test("returns null for empty value", () => {
+    expect(formatAnswerValue({ value: "" }, { type: "input" })).toBeNull();
+  });
+
+  test("formats option using question.option labels", () => {
+    expect(formatAnswerValue({ value: "yes" }, findQuestion(102))).toBe("Yes");
+  });
+
+  test("formats multiple_option as comma-joined labels", () => {
+    expect(formatAnswerValue({ value: ["a", "b"] }, findQuestion(103))).toBe(
+      "Apple, Banana"
+    );
+  });
+
+  test("formats geo as 'lat, lng'", () => {
+    expect(
+      formatAnswerValue({ value: [-17.7, 178.0] }, findQuestion(104))
+    ).toBe("-17.7, 178");
+  });
+
+  test("joins arrays for non-option types", () => {
+    expect(formatAnswerValue({ value: ["a", "b"] }, { type: "input" })).toBe(
+      "a, b"
+    );
+  });
+
+  test("falls back to String() for primitives", () => {
+    expect(formatAnswerValue({ value: 42 }, { type: "number" })).toBe("42");
+  });
+});
+
+describe("extractPhotoUrl", () => {
+  test("returns the URL when value is a non-empty string", () => {
+    const values = [{ question: 105, value: "https://example.com/p.jpg" }];
+    expect(extractPhotoUrl(values, 105)).toBe("https://example.com/p.jpg");
+  });
+
+  test("returns null for empty string value", () => {
+    expect(extractPhotoUrl([{ question: 105, value: "  " }], 105)).toBeNull();
+  });
+
+  test("returns null when value is not a string", () => {
+    expect(extractPhotoUrl([{ question: 105, value: 42 }], 105)).toBeNull();
+  });
+
+  test("returns null when answer missing", () => {
+    expect(extractPhotoUrl([], 105)).toBeNull();
+  });
+});
+
+describe("resolveAnswerLabel", () => {
+  test("composes findAnswer + findQuestion + formatAnswerValue", () => {
+    expect(resolveAnswerLabel([{ question: 102, value: "no" }], 102)).toBe(
+      "No"
+    );
+  });
+
+  test("returns null when no answer", () => {
+    expect(resolveAnswerLabel([], 101)).toBeNull();
+  });
+});
+
+describe("sortByDateAscending", () => {
+  test("sorts ascending by date", () => {
+    const rows = [
+      { date: "2026-02-01", v: 2 },
+      { date: "2026-01-01", v: 1 },
+      { date: "2026-03-01", v: 3 },
+    ];
+    expect(sortByDateAscending(rows).map((r) => r.v)).toEqual([1, 2, 3]);
+  });
+
+  test("entries with null dates sort first, stable order", () => {
+    const rows = [
+      { date: null, v: "a" },
+      { date: "2026-01-01", v: "b" },
+      { date: null, v: "c" },
+    ];
+    expect(sortByDateAscending(rows).map((r) => r.v)).toEqual(["a", "c", "b"]);
+  });
+
+  test("returns [] for non-array input", () => {
+    expect(sortByDateAscending(null)).toEqual([]);
+  });
+});

--- a/frontend/src/components/dashboard/custom-components/individual-overview/shared/helpers.js
+++ b/frontend/src/components/dashboard/custom-components/individual-overview/shared/helpers.js
@@ -138,6 +138,65 @@ export const extractPhotoUrl = (values, questionId) => {
 };
 
 /**
+ * Find a question group definition by its id across every form in
+ * `window.forms`. Returns null when not found.
+ *
+ * @param {number|string} groupId
+ * @returns {object|null}
+ */
+export const findQuestionGroup = (groupId) => {
+  if (groupId === null || typeof groupId === "undefined") {
+    return null;
+  }
+  const target = toNumericId(groupId);
+  const forms = window.forms || [];
+  for (let i = 0; i < forms.length; i += 1) {
+    const groups = forms[i]?.content?.question_group || [];
+    const found = groups.find((g) => g?.id === target);
+    if (found) {
+      return found;
+    }
+  }
+  return null;
+};
+
+/**
+ * Walk every question in a question group, drop `type: "photo"`
+ * questions and any whose answer resolves to null/empty, then join the
+ * surviving formatted answers with `separator`. Used to combine all
+ * answers inside a scope question group into a single cell (e.g. the
+ * EPS Construction Information "Implementation / Construction" column).
+ *
+ * @param {number|string} groupId
+ * @param {Array} values
+ * @param {object} [options]
+ * @param {string} [options.separator=", "]
+ * @returns {string}            Empty string when the group is unknown
+ *                               or every answer is empty.
+ */
+export const collectGroupAnswers = (groupId, values, options) => {
+  const separator = options?.separator || ", ";
+  const group = findQuestionGroup(groupId);
+  if (!group) {
+    return "";
+  }
+  const questions = group.question || [];
+  const parts = [];
+  for (let i = 0; i < questions.length; i += 1) {
+    const q = questions[i];
+    if (!q || q.type === "photo") {
+      continue;
+    }
+    const answer = findAnswer(values, q.id);
+    const formatted = formatAnswerValue(answer, q);
+    if (formatted !== null && formatted !== "") {
+      parts.push(formatted);
+    }
+  }
+  return parts.join(separator);
+};
+
+/**
  * Convenience: findAnswer + findQuestion + formatAnswerValue.
  *
  * @param {Array} values

--- a/frontend/src/components/dashboard/custom-components/individual-overview/shared/helpers.js
+++ b/frontend/src/components/dashboard/custom-components/individual-overview/shared/helpers.js
@@ -1,0 +1,189 @@
+/**
+ * Pure lookup + formatting helpers for the Individual Overview pattern.
+ *
+ * Centralises every walk over `window.forms` and every transform applied to
+ * a `/data/<id>` answer payload, so shell components stay free of
+ * form-walking code.
+ */
+
+const toNumericId = (id) => {
+  if (typeof id === "number") {
+    return id;
+  }
+  const n = Number(id);
+  return Number.isNaN(n) ? id : n;
+};
+
+/**
+ * Find a question definition by id across every form in `window.forms`.
+ *
+ * `window.forms` shape (set at app startup):
+ *   [{ id, name, content: { question_group: [{ question: [{ id, label, type, option }] }] } }]
+ *
+ * @param {number|string} questionId
+ * @returns {object|null}
+ */
+export const findQuestion = (questionId) => {
+  if (questionId === null || typeof questionId === "undefined") {
+    return null;
+  }
+  const target = toNumericId(questionId);
+  const forms = window.forms || [];
+  for (let i = 0; i < forms.length; i += 1) {
+    const groups = forms[i]?.content?.question_group || [];
+    for (let j = 0; j < groups.length; j += 1) {
+      const questions = groups[j]?.question || [];
+      const found = questions.find((q) => q?.id === target);
+      if (found) {
+        return found;
+      }
+    }
+  }
+  return null;
+};
+
+/**
+ * Find an answer entry for `questionId` from a /data/<id> response.
+ *
+ * @param {Array} values
+ * @param {number|string} questionId
+ * @returns {object|null}
+ */
+export const findAnswer = (values, questionId) => {
+  if (
+    !Array.isArray(values) ||
+    questionId === null ||
+    typeof questionId === "undefined"
+  ) {
+    return null;
+  }
+  const target = toNumericId(questionId);
+  return values.find((v) => v?.question === target) || null;
+};
+
+const formatOptionAnswer = (value, question) => {
+  const options = question?.option || [];
+  const lookup = new Map(options.map((o) => [o?.value, o?.label || o?.value]));
+  const list = Array.isArray(value) ? value : [value];
+  return list
+    .filter((v) => v !== null && typeof v !== "undefined" && v !== "")
+    .map((v) => lookup.get(v) || v)
+    .join(", ");
+};
+
+const formatGeoAnswer = (value) => {
+  if (Array.isArray(value) && value.length >= 2) {
+    return `${value[0]}, ${value[1]}`;
+  }
+  if (value && typeof value === "object" && "lat" in value && "lng" in value) {
+    return `${value.lat}, ${value.lng}`;
+  }
+  return null;
+};
+
+/**
+ * Pretty-print an answer value for display in tables. Returns null for
+ * empty/missing values so callers can skip rendering.
+ *
+ * @param {object|null} answer
+ * @param {object|null} question
+ * @returns {string|null}
+ */
+export const formatAnswerValue = (answer, question) => {
+  if (!answer) {
+    return null;
+  }
+  const value = answer.value;
+  if (value === null || typeof value === "undefined" || value === "") {
+    return null;
+  }
+  const type = question?.type;
+  if (type === "option" || type === "multiple_option") {
+    const text = formatOptionAnswer(value, question);
+    return text || null;
+  }
+  if (type === "geo") {
+    return formatGeoAnswer(value);
+  }
+  if (Array.isArray(value)) {
+    const items = value.filter(
+      (v) => v !== null && typeof v !== "undefined" && v !== ""
+    );
+    if (!items.length) {
+      return null;
+    }
+    return items.join(", ");
+  }
+  return String(value);
+};
+
+/**
+ * Extract a photo URL from an answer. Photo answers store the URL directly
+ * in `value`. Non-string / blank values resolve to null.
+ *
+ * @param {Array} values
+ * @param {number|string} questionId
+ * @returns {string|null}
+ */
+export const extractPhotoUrl = (values, questionId) => {
+  const answer = findAnswer(values, questionId);
+  if (!answer) {
+    return null;
+  }
+  const v = answer.value;
+  if (typeof v === "string" && v.trim().length > 0) {
+    return v;
+  }
+  return null;
+};
+
+/**
+ * Convenience: findAnswer + findQuestion + formatAnswerValue.
+ *
+ * @param {Array} values
+ * @param {number|string} questionId
+ * @returns {string|null}
+ */
+export const resolveAnswerLabel = (values, questionId) => {
+  const answer = findAnswer(values, questionId);
+  if (!answer) {
+    return null;
+  }
+  const question = findQuestion(questionId);
+  return formatAnswerValue(answer, question);
+};
+
+/**
+ * Sort an array of `{ date, ...rest }` ascending by date. Stable; entries
+ * with null/missing dates sort first.
+ *
+ * @param {Array<{date: string|null}>} rows
+ * @returns {Array}
+ */
+export const sortByDateAscending = (rows) => {
+  if (!Array.isArray(rows)) {
+    return [];
+  }
+  return rows
+    .map((row, idx) => ({ row, idx }))
+    .sort((a, b) => {
+      const ad = a.row?.date;
+      const bd = b.row?.date;
+      if (!ad && !bd) {
+        return a.idx - b.idx;
+      }
+      if (!ad) {
+        return -1;
+      }
+      if (!bd) {
+        return 1;
+      }
+      const at = new Date(ad).getTime();
+      const bt = new Date(bd).getTime();
+      if (at === bt) {
+        return a.idx - b.idx;
+      }
+      return at - bt;
+    })
+    .map((entry) => entry.row);
+};

--- a/frontend/src/components/dashboard/custom-components/individual-overview/shared/helpers.js
+++ b/frontend/src/components/dashboard/custom-components/individual-overview/shared/helpers.js
@@ -6,6 +6,8 @@
  * form-walking code.
  */
 
+import { api } from "../../../../../lib";
+
 const toNumericId = (id) => {
   if (typeof id === "number") {
     return id;
@@ -81,15 +83,41 @@ const formatGeoAnswer = (value) => {
   return null;
 };
 
+const formatAdministrationAnswer = (value, lookups) => {
+  const map = lookups?.administration;
+  const list = Array.isArray(value) ? value : [value];
+  const items = list
+    .map((v) => {
+      if (v === null || typeof v === "undefined" || v === "") {
+        return null;
+      }
+      const id = toNumericId(v);
+      if (map && map.get(id)) {
+        return map.get(id);
+      }
+      return String(v);
+    })
+    .filter((s) => s !== null);
+  if (!items.length) {
+    return null;
+  }
+  return items.join(" - ");
+};
+
 /**
  * Pretty-print an answer value for display in tables. Returns null for
  * empty/missing values so callers can skip rendering.
  *
  * @param {object|null} answer
  * @param {object|null} question
+ * @param {object} [lookups]
+ * @param {Map<number,string>} [lookups.administration]
+ *   Resolved administration id → display name. When missing the helper
+ *   falls back to the raw id so callers that have not pre-fetched names
+ *   still render something.
  * @returns {string|null}
  */
-export const formatAnswerValue = (answer, question) => {
+export const formatAnswerValue = (answer, question, lookups) => {
   if (!answer) {
     return null;
   }
@@ -105,6 +133,9 @@ export const formatAnswerValue = (answer, question) => {
   if (type === "geo") {
     return formatGeoAnswer(value);
   }
+  if (["cascade", "administration"].includes(type)) {
+    return formatAdministrationAnswer(value, lookups);
+  }
   if (Array.isArray(value)) {
     const items = value.filter(
       (v) => v !== null && typeof v !== "undefined" && v !== ""
@@ -115,6 +146,103 @@ export const formatAnswerValue = (answer, question) => {
     return items.join(", ");
   }
   return String(value);
+};
+
+const administrationNameCache = new Map();
+const administrationInflight = new Map();
+
+const buildAdministrationDisplayName = (data) => {
+  if (!data) {
+    return null;
+  }
+  if (typeof data.full_name === "string" && data.full_name.length > 0) {
+    return data.full_name.split("|").join(" - ");
+  }
+  return data.name || null;
+};
+
+const fetchAdministrationName = (id) => {
+  if (administrationNameCache.has(id)) {
+    return Promise.resolve(administrationNameCache.get(id));
+  }
+  if (administrationInflight.has(id)) {
+    return administrationInflight.get(id);
+  }
+  const promise = api
+    .get(`administration/${id}`)
+    .then(({ data }) => {
+      const name = buildAdministrationDisplayName(data);
+      if (name) {
+        administrationNameCache.set(id, name);
+      }
+      administrationInflight.delete(id);
+      return name;
+    })
+    .catch((error) => {
+      administrationInflight.delete(id);
+      console.error(`fetchAdministrationName(${id}) failed`, error);
+      return null;
+    });
+  administrationInflight.set(id, promise);
+  return promise;
+};
+
+/**
+ * Walk a /data/<id> answer payload and collect every administration id
+ * that needs name resolution. IDs are returned as numbers; duplicates and
+ * non-numeric values are dropped.
+ *
+ * @param {Array} values
+ * @returns {Array<number>}
+ */
+export const collectAdministrationIds = (values) => {
+  if (!Array.isArray(values)) {
+    return [];
+  }
+  const ids = new Set();
+  values.forEach((entry) => {
+    if (!entry || entry.value === null || typeof entry.value === "undefined") {
+      return;
+    }
+    const question = findQuestion(entry.question);
+    if (!question || !["cascade", "administration"].includes(question.type)) {
+      return;
+    }
+    const list = Array.isArray(entry.value) ? entry.value : [entry.value];
+    list.forEach((v) => {
+      const num = toNumericId(v);
+      if (typeof num === "number" && Number.isFinite(num)) {
+        ids.add(num);
+      }
+    });
+  });
+  return Array.from(ids);
+};
+
+/**
+ * Resolve a list of administration ids to display names via the
+ * `/administration/<id>` API. Successful lookups are cached process-wide
+ * so subsequent calls for the same id are free.
+ *
+ * @param {Array<number>} ids
+ * @returns {Promise<Map<number,string>>}
+ */
+export const fetchAdministrationNames = async (ids) => {
+  if (!Array.isArray(ids) || ids.length === 0) {
+    return new Map();
+  }
+  const entries = await Promise.all(
+    ids.map(async (id) => {
+      const name = await fetchAdministrationName(id);
+      return [id, name];
+    })
+  );
+  return new Map(entries.filter(([, name]) => Boolean(name)));
+};
+
+export const __resetAdministrationNameCache = () => {
+  administrationNameCache.clear();
+  administrationInflight.clear();
 };
 
 /**

--- a/frontend/src/components/dashboard/custom-components/individual-overview/shared/useAdministrationNames.js
+++ b/frontend/src/components/dashboard/custom-components/individual-overview/shared/useAdministrationNames.js
@@ -1,0 +1,46 @@
+import { useEffect, useState } from "react";
+import { collectAdministrationIds, fetchAdministrationNames } from "./helpers";
+
+/**
+ * Resolve every administration-typed answer in `values` to a display name.
+ *
+ * Walks `values`, picks the ids whose corresponding question has
+ * `type === "administration"`, and pre-fetches their names through
+ * `fetchAdministrationNames` (process-wide cache). Returns an empty map
+ * synchronously on first render and re-renders once the API resolves so
+ * `<CharacteristicsTable>` can show "Fiji - Western - Ra - Saivou"
+ * instead of "78".
+ *
+ * @param {Array} values  /data/<id> answer payload
+ * @returns {Map<number,string>}
+ */
+const useAdministrationNames = (values) => {
+  const [lookup, setLookup] = useState(() => new Map());
+
+  useEffect(() => {
+    const ids = collectAdministrationIds(values);
+    if (ids.length === 0) {
+      return () => {};
+    }
+    let cancelled = false;
+    fetchAdministrationNames(ids).then((map) => {
+      if (cancelled || map.size === 0) {
+        return;
+      }
+      setLookup((prev) => {
+        const next = new Map(prev);
+        map.forEach((v, k) => {
+          next.set(k, v);
+        });
+        return next;
+      });
+    });
+    return () => {
+      cancelled = true;
+    };
+  }, [values]);
+
+  return lookup;
+};
+
+export default useAdministrationNames;

--- a/frontend/src/components/dashboard/custom-components/individual-overview/shared/useIndividualOverviewData.js
+++ b/frontend/src/components/dashboard/custom-components/individual-overview/shared/useIndividualOverviewData.js
@@ -1,0 +1,188 @@
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { api, store } from "../../../../../lib";
+
+const deepestSelectedAdmin = (admins) => {
+  if (!Array.isArray(admins) || admins.length < 2) {
+    return null;
+  }
+  return admins[admins.length - 1] || null;
+};
+
+/**
+ * Hook that drives the admin → datapoints → values fetch chain shared by
+ * every Individual Overview shell.
+ *
+ * @param {object} options
+ * @param {number} options.regFormId
+ * @param {Array<number>} options.monitoringFormIds
+ *
+ * @returns {{
+ *   loadingDataPoints: boolean,
+ *   dataPoints: Array,
+ *   selectedDataPoint: object|null,
+ *   setSelectedDataPoint: (dp: object|null) => void,
+ *   regValues: Array,
+ *   monitoringValues: { [formId: number]: Array },
+ *   loadingValues: boolean,
+ *   refetch: () => void,
+ * }}
+ */
+const useIndividualOverviewData = ({ regFormId, monitoringFormIds }) => {
+  const administration = store.useState((s) => s.administration);
+  const selectedLocation = useMemo(
+    () => deepestSelectedAdmin(administration),
+    [administration]
+  );
+
+  const [dataPoints, setDataPoints] = useState([]);
+  const [loadingDataPoints, setLoadingDataPoints] = useState(false);
+  const [selectedDataPoint, setSelectedDataPointState] = useState(null);
+  const [regValues, setRegValues] = useState([]);
+  const [monitoringValues, setMonitoringValues] = useState({});
+  const [loadingValues, setLoadingValues] = useState(false);
+  const [refetchToken, setRefetchToken] = useState(0);
+
+  const monitoringIdsKey = useMemo(
+    () => (monitoringFormIds || []).join(","),
+    [monitoringFormIds]
+  );
+
+  const mountedRef = useRef(true);
+  useEffect(() => {
+    mountedRef.current = true;
+    return () => {
+      mountedRef.current = false;
+    };
+  }, []);
+
+  const setSelectedDataPoint = useCallback((dp) => {
+    setSelectedDataPointState(dp || null);
+  }, []);
+
+  const refetch = useCallback(() => {
+    setRefetchToken((t) => t + 1);
+  }, []);
+
+  useEffect(() => {
+    if (!regFormId || !selectedLocation?.id) {
+      setDataPoints([]);
+      setSelectedDataPointState(null);
+      return;
+    }
+    let cancelled = false;
+    setLoadingDataPoints(true);
+    (async () => {
+      try {
+        const { data: apiData } = await api.get(
+          `/form-data/${regFormId}?administration=${selectedLocation.id}&sort_by=latest_activity&sort_type=descend`
+        );
+        if (cancelled || !mountedRef.current) {
+          return;
+        }
+        setDataPoints(apiData?.data || []);
+        setSelectedDataPointState(null);
+      } catch (error) {
+        if (cancelled || !mountedRef.current) {
+          return;
+        }
+        console.error(
+          "useIndividualOverviewData: dataPoints fetch failed",
+          error
+        );
+        setDataPoints([]);
+      } finally {
+        if (!cancelled && mountedRef.current) {
+          setLoadingDataPoints(false);
+        }
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [regFormId, selectedLocation?.id, refetchToken]);
+
+  useEffect(() => {
+    if (!selectedDataPoint?.id || !selectedDataPoint?.uuid) {
+      setRegValues([]);
+      setMonitoringValues({});
+      return;
+    }
+    let cancelled = false;
+    const ids = (monitoringIdsKey ? monitoringIdsKey.split(",") : [])
+      .map((s) => Number(s))
+      .filter((n) => Number.isFinite(n));
+
+    setLoadingValues(true);
+    (async () => {
+      try {
+        const regPromise = api
+          .get(`/data/${selectedDataPoint.id}`)
+          .then(({ data }) => data || [])
+          .catch((error) => {
+            console.error(
+              "useIndividualOverviewData: regValues fetch failed",
+              error
+            );
+            return [];
+          });
+
+        const monitoringPromise = Promise.all(
+          ids.map(async (formId) => {
+            try {
+              const { data: list } = await api.get(
+                `/form-data/${formId}?parent=${selectedDataPoint.uuid}`
+              );
+              const latest = list?.data?.[0];
+              if (!latest?.id) {
+                return [formId, []];
+              }
+              const { data: payload } = await api.get(`/data/${latest.id}`);
+              return [formId, payload || []];
+            } catch (error) {
+              console.error(
+                `useIndividualOverviewData: monitoringValues fetch failed (form ${formId})`,
+                error
+              );
+              return [formId, []];
+            }
+          })
+        );
+
+        const [reg, monitoringEntries] = await Promise.all([
+          regPromise,
+          monitoringPromise,
+        ]);
+        if (cancelled || !mountedRef.current) {
+          return;
+        }
+        setRegValues(reg);
+        setMonitoringValues(Object.fromEntries(monitoringEntries));
+      } finally {
+        if (!cancelled && mountedRef.current) {
+          setLoadingValues(false);
+        }
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [
+    selectedDataPoint?.id,
+    selectedDataPoint?.uuid,
+    monitoringIdsKey,
+    refetchToken,
+  ]);
+
+  return {
+    loadingDataPoints,
+    dataPoints,
+    selectedDataPoint,
+    setSelectedDataPoint,
+    regValues,
+    monitoringValues,
+    loadingValues,
+    refetch,
+  };
+};
+
+export default useIndividualOverviewData;

--- a/frontend/src/components/dashboard/custom-components/individual-overview/shared/useIndividualOverviewData.js
+++ b/frontend/src/components/dashboard/custom-components/individual-overview/shared/useIndividualOverviewData.js
@@ -1,20 +1,22 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
-import { api, store } from "../../../../../lib";
-
-const deepestSelectedAdmin = (admins) => {
-  if (!Array.isArray(admins) || admins.length < 2) {
-    return null;
-  }
-  return admins[admins.length - 1] || null;
-};
+import { api } from "../../../../../lib";
 
 /**
  * Hook that drives the admin → datapoints → values fetch chain shared by
  * every Individual Overview shell.
  *
+ * The `selectedLocation` is supplied by the caller (typically the parent
+ * component's local `useState` fed by an embedded admin dropdown), so
+ * this hook is location-agnostic and never reads the global Pullstate
+ * `store.administration`. That keeps the embedded selection from
+ * leaking into the dashboard-wide filter state.
+ *
  * @param {object} options
  * @param {number} options.regFormId
  * @param {Array<number>} options.monitoringFormIds
+ * @param {{ id: number } | null} [options.selectedLocation]
+ *   Deepest admin level the caller wants to scope to. `null` (or missing
+ *   `id`) clears the data-point list and selection.
  *
  * @returns {{
  *   loadingDataPoints: boolean,
@@ -27,13 +29,11 @@ const deepestSelectedAdmin = (admins) => {
  *   refetch: () => void,
  * }}
  */
-const useIndividualOverviewData = ({ regFormId, monitoringFormIds }) => {
-  const administration = store.useState((s) => s.administration);
-  const selectedLocation = useMemo(
-    () => deepestSelectedAdmin(administration),
-    [administration]
-  );
-
+const useIndividualOverviewData = ({
+  regFormId,
+  monitoringFormIds,
+  selectedLocation,
+}) => {
   const [dataPoints, setDataPoints] = useState([]);
   const [loadingDataPoints, setLoadingDataPoints] = useState(false);
   const [selectedDataPoint, setSelectedDataPointState] = useState(null);

--- a/frontend/src/components/dashboard/custom-components/individual-overview/shared/useMonitoringHistory.js
+++ b/frontend/src/components/dashboard/custom-components/individual-overview/shared/useMonitoringHistory.js
@@ -1,0 +1,105 @@
+import { useEffect, useRef, useState } from "react";
+import { api } from "../../../../../lib";
+
+const PAGE_SIZE = 20;
+
+const fetchAllPages = async (formId, parentUuid) => {
+  const collected = [];
+  const fetchPage = async (page) => {
+    const { data } = await api.get(
+      `/form-data/${formId}?parent=${parentUuid}&page=${page}&page_size=${PAGE_SIZE}&sort_by=latest_activity&sort_type=descend`
+    );
+    const rows = data?.data || [];
+    collected.push(...rows);
+    const total = data?.total ?? collected.length;
+    if (rows.length === PAGE_SIZE && collected.length < total) {
+      await fetchPage(page + 1);
+    }
+  };
+  await fetchPage(1);
+  return collected;
+};
+
+/**
+ * Fetch all monitoring submissions for a parent record, plus their answer
+ * payloads. Charts then project per-parameter without extra calls.
+ *
+ * @param {number} formId
+ * @param {string|null|undefined} parentUuid    Falsy disables the fetch.
+ *
+ * @returns {{
+ *   rows: Array<{ id: number, date: string|null, values: Array }>,
+ *   loading: boolean,
+ *   error: Error|null,
+ * }}
+ */
+const useMonitoringHistory = (formId, parentUuid) => {
+  const [rows, setRows] = useState([]);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState(null);
+
+  const mountedRef = useRef(true);
+  useEffect(() => {
+    mountedRef.current = true;
+    return () => {
+      mountedRef.current = false;
+    };
+  }, []);
+
+  useEffect(() => {
+    if (!formId || !parentUuid) {
+      setRows([]);
+      setError(null);
+      return;
+    }
+    let cancelled = false;
+    setLoading(true);
+    setError(null);
+    (async () => {
+      try {
+        const list = await fetchAllPages(formId, parentUuid);
+        const detail = await Promise.all(
+          list.map(async (entry) => {
+            try {
+              const { data: values } = await api.get(`/data/${entry.id}`);
+              return {
+                id: entry.id,
+                date:
+                  entry.created || entry.updated || entry.submitted_at || null,
+                values: values || [],
+              };
+            } catch (err) {
+              console.error(
+                `useMonitoringHistory: /data/${entry.id} failed`,
+                err
+              );
+              return { id: entry.id, date: null, values: [] };
+            }
+          })
+        );
+        if (cancelled || !mountedRef.current) {
+          return;
+        }
+        setRows(detail);
+      } catch (err) {
+        if (cancelled || !mountedRef.current) {
+          return;
+        }
+        console.error("useMonitoringHistory: list fetch failed", err);
+        setError(err);
+        setRows([]);
+      } finally {
+        if (!cancelled && mountedRef.current) {
+          setLoading(false);
+        }
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [formId, parentUuid]);
+
+  return { rows, loading, error };
+};
+
+export default useMonitoringHistory;

--- a/frontend/src/components/dashboard/widgets/CustomComponentWidget.jsx
+++ b/frontend/src/components/dashboard/widgets/CustomComponentWidget.jsx
@@ -1,0 +1,38 @@
+import React from "react";
+import PropTypes from "prop-types";
+import { Alert } from "antd";
+import * as customComponents from "../custom-components";
+
+/**
+ * Resolves an item with chart_type "custom_component" against the named-export
+ * registry in `custom-components/index.js`. Unknown names render an Alert and
+ * log to console.error rather than throwing, so a typo in the JSON config does
+ * not crash the rest of the dashboard.
+ */
+const CustomComponentWidget = ({ item }) => {
+  const Component = customComponents[item.component];
+
+  if (!Component) {
+    // eslint allows console.error
+    console.error(
+      `[CustomComponentWidget] Unknown component: "${item.component}" (id: ${item.id})`
+    );
+    return (
+      <Alert
+        type="warning"
+        message={`Custom component "${item.component}" not found`}
+      />
+    );
+  }
+
+  return <Component />;
+};
+
+CustomComponentWidget.propTypes = {
+  item: PropTypes.shape({
+    id: PropTypes.string.isRequired,
+    component: PropTypes.string.isRequired,
+  }).isRequired,
+};
+
+export default CustomComponentWidget;

--- a/frontend/src/components/dashboard/widgets/TabsWidget.jsx
+++ b/frontend/src/components/dashboard/widgets/TabsWidget.jsx
@@ -1,6 +1,7 @@
 import React from "react";
 import PropTypes from "prop-types";
 import { Card, Tabs } from "antd";
+import store from "../../../lib/store";
 
 /**
  * Renders a `tabs` container item as an Ant Design <Tabs> component.
@@ -10,22 +11,36 @@ import { Card, Tabs } from "antd";
  * is injected by `DashboardRenderer` to allow recursive rendering of each
  * pane's children.
  *
+ * Panes carrying `is_public: false` are rendered as disabled tabs when the
+ * viewer is anonymous (`UIState.isLoggedIn === false`). The default-active
+ * tab falls through to the first non-disabled pane so anonymous viewers do
+ * not land on a disabled tab on first paint. Combined with
+ * `destroyInactiveTabPane`, this guarantees the pane's children never mount
+ * (and so never fetch authenticated APIs) until the user is signed in and
+ * activates the tab.
+ *
  * @param {object}   item         A config item with chart_type "tabs" and items[]
  * @param {Function} renderItems  (items: Array) => ReactNode — provided by DashboardRenderer
  */
 const TabsWidget = ({ item, renderItems }) => {
+  const isLoggedIn = store.useState((s) => s.isLoggedIn);
   const panes = item.items || [];
+
+  const isPaneDisabled = (pane) => pane.is_public === false && !isLoggedIn;
 
   const tabItems = panes.map((pane) => ({
     key: pane.id,
     label: pane.label,
+    disabled: isPaneDisabled(pane),
     children: <div>{renderItems(pane.items || [])}</div>,
   }));
+
+  const firstEnabledKey = panes.find((pane) => !isPaneDisabled(pane))?.id;
 
   return (
     <Card className="tabs-card">
       <Tabs
-        defaultActiveKey={panes[0]?.id}
+        defaultActiveKey={firstEnabledKey}
         destroyInactiveTabPane
         items={tabItems}
       />
@@ -39,6 +54,7 @@ TabsWidget.propTypes = {
       PropTypes.shape({
         id: PropTypes.string.isRequired,
         label: PropTypes.string,
+        is_public: PropTypes.bool,
         items: PropTypes.array,
       })
     ),

--- a/frontend/src/components/dashboard/widgets/TabsWidget.jsx
+++ b/frontend/src/components/dashboard/widgets/TabsWidget.jsx
@@ -12,12 +12,13 @@ import store from "../../../lib/store";
  * pane's children.
  *
  * Panes carrying `is_public: false` are rendered as disabled tabs when the
- * viewer is anonymous (`UIState.isLoggedIn === false`). The default-active
- * tab falls through to the first non-disabled pane so anonymous viewers do
- * not land on a disabled tab on first paint. Combined with
- * `destroyInactiveTabPane`, this guarantees the pane's children never mount
- * (and so never fetch authenticated APIs) until the user is signed in and
- * activates the tab.
+ * viewer is anonymous (`isLoggedIn === false` in the Pullstate store at
+ * `lib/store.js`, read here via `store.useState((s) => s.isLoggedIn)`). The
+ * default-active tab falls through to the first non-disabled pane so
+ * anonymous viewers do not land on a disabled tab on first paint. Combined
+ * with `destroyInactiveTabPane`, this guarantees the pane's children never
+ * mount (and so never fetch authenticated APIs) until the user is signed in
+ * and activates the tab.
  *
  * @param {object}   item         A config item with chart_type "tabs" and items[]
  * @param {Function} renderItems  (items: Array) => ReactNode — provided by DashboardRenderer

--- a/frontend/src/components/filters/AdministrationDropdownLocal.js
+++ b/frontend/src/components/filters/AdministrationDropdownLocal.js
@@ -1,0 +1,178 @@
+import React, { useCallback, useEffect, useRef, useState } from "react";
+import PropTypes from "prop-types";
+import { Select, Space } from "antd";
+import { api, store } from "../../lib";
+
+/**
+ * Component-local cascading admin dropdown.
+ *
+ * Mirrors the visual cascade of `AdministrationDropdown` but owns its
+ * selection state in React `useState` instead of the global Pullstate
+ * `store.administration`. Designed for embedded use inside a single
+ * `custom_component` (e.g. IndividualEPSOverview) so picking an admin
+ * here does NOT trigger the dashboard-wide refetch ripple that the
+ * global dropdown causes via `DashboardFilters`.
+ *
+ * Lifecycle:
+ *   - On mount, fetches the user's root admin via `/administration/<id>`
+ *     and seeds `levels[0]`. Same payload shape as `store.administration`
+ *     entries: `{ id, name, level, children: [...] }`.
+ *   - Picking a child select fetches its full detail (so the next-level
+ *     children are available) and appends to `levels`.
+ *   - Clearing a select truncates `levels` to that index.
+ *   - After every change, `onChange(deepest)` fires with the deepest
+ *     non-root level (or `null` when only root remains, matching the
+ *     contract used by `useIndividualOverviewData`).
+ *
+ * Forbidden by design:
+ *   - No `store.update(...)` call. The component never writes to the
+ *     global store, so it cannot leak its selection to other widgets
+ *     on the page or to other pages reached via navigation.
+ *
+ * @param {object}   props
+ * @param {Function} props.onChange  (deepest: AdminLevel | null) => void
+ * @param {number}   [props.width]   px width applied to each select
+ * @param {boolean}  [props.loading] disables every select while true
+ */
+const AdministrationDropdownLocal = ({
+  onChange,
+  width = 160,
+  loading = false,
+}) => {
+  const user = store.useState((s) => s.user);
+
+  const [levels, setLevels] = useState([]);
+  const mountedRef = useRef(true);
+
+  useEffect(() => {
+    mountedRef.current = true;
+    return () => {
+      mountedRef.current = false;
+    };
+  }, []);
+
+  useEffect(() => {
+    if (!user?.administration?.id) {
+      return () => {};
+    }
+    let cancelled = false;
+    (async () => {
+      try {
+        const { data } = await api.get(
+          `administration/${user.administration.id}`
+        );
+        if (cancelled || !mountedRef.current) {
+          return;
+        }
+        setLevels([data]);
+      } catch (error) {
+        // eslint-disable-next-line no-console
+        console.error("AdministrationDropdownLocal: root fetch failed", error);
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [user?.administration?.id]);
+
+  // Replicates the role-based child filter from AdministrationDropdown.js
+  // so non-superusers only see admin units inside their assigned roles.
+  const filterChildren = useCallback(
+    (children) => {
+      if (!Array.isArray(children)) {
+        return [];
+      }
+      if (user?.is_superuser || !user?.roles?.length) {
+        return children;
+      }
+      return children.filter((c) =>
+        user.roles.some((role) => {
+          if (role?.administration?.level_id === c.level) {
+            return role.administration.id === c.id;
+          }
+          return true;
+        })
+      );
+    },
+    [user]
+  );
+
+  const emitDeepest = (next) => {
+    if (!onChange) {
+      return;
+    }
+    // Root (`levels.length === 1`) is the user's own scope — treat as
+    // "no embedded selection" so callers see `null`, matching the
+    // deepestSelectedAdmin contract in useIndividualOverviewData.
+    const deepest = next.length > 1 ? next[next.length - 1] : null;
+    onChange(deepest);
+  };
+
+  const handlePick = async (idx, childId) => {
+    if (!childId) {
+      return;
+    }
+    try {
+      const { data: child } = await api.get(`administration/${childId}`);
+      if (!mountedRef.current) {
+        return;
+      }
+      setLevels((prev) => {
+        const next = prev.slice(0, idx + 1).concat([child]);
+        emitDeepest(next);
+        return next;
+      });
+    } catch (error) {
+      // eslint-disable-next-line no-console
+      console.error("AdministrationDropdownLocal: child fetch failed", error);
+    }
+  };
+
+  const handleClear = (idx) => {
+    setLevels((prev) => {
+      const next = prev.slice(0, idx + 1);
+      emitDeepest(next);
+      return next;
+    });
+  };
+
+  return (
+    <Space style={{ width: "100%" }}>
+      {levels
+        .filter((lvl) => lvl?.children?.length)
+        .map((lvl, idx) => (
+          <div key={`adm-local-${idx}`}>
+            <Select
+              placeholder={`Select ${lvl?.children_level_name || ""}`}
+              style={{ width }}
+              value={levels[idx + 1]?.id || null}
+              onChange={(e) => handlePick(idx, e)}
+              onClear={() => handleClear(idx)}
+              getPopupContainer={(trigger) => trigger.parentNode}
+              dropdownMatchSelectWidth={false}
+              disabled={loading}
+              allowClear
+              showSearch
+              filterOption={true}
+              optionFilterProp="children"
+              className="custom-select"
+            >
+              {filterChildren(lvl.children).map((opt, optIdx) => (
+                <Select.Option key={`opt-${idx}-${optIdx}`} value={opt.id}>
+                  {opt.name}
+                </Select.Option>
+              ))}
+            </Select>
+          </div>
+        ))}
+    </Space>
+  );
+};
+
+AdministrationDropdownLocal.propTypes = {
+  onChange: PropTypes.func.isRequired,
+  width: PropTypes.number,
+  loading: PropTypes.bool,
+};
+
+export default AdministrationDropdownLocal;

--- a/frontend/src/components/filters/__test__/AdministrationDropdownLocal.test.js
+++ b/frontend/src/components/filters/__test__/AdministrationDropdownLocal.test.js
@@ -1,0 +1,185 @@
+import React from "react";
+import {
+  act,
+  cleanup,
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+} from "@testing-library/react";
+import AdministrationDropdownLocal from "../AdministrationDropdownLocal";
+import { api } from "../../../lib";
+import store from "../../../lib/store";
+
+jest.mock("../../../lib/api", () => ({
+  __esModule: true,
+  default: { get: jest.fn() },
+}));
+
+const ROOT_ADMIN = {
+  id: 1,
+  name: "Indonesia",
+  level: 0,
+  parent: null,
+  children_level_name: "Province",
+  children: [
+    { id: 11, name: "Jakarta", level: 1, parent: 1 },
+    { id: 12, name: "Bali", level: 1, parent: 1 },
+  ],
+};
+
+const PROVINCE_DETAIL = {
+  id: 11,
+  name: "Jakarta",
+  level: 1,
+  parent: 1,
+  children_level_name: "City",
+  children: [
+    { id: 111, name: "Jakarta Selatan", level: 2, parent: 11 },
+    { id: 112, name: "Jakarta Pusat", level: 2, parent: 11 },
+  ],
+};
+
+const seedUser = (overrides = {}) => {
+  act(() => {
+    store.update((s) => {
+      s.user = {
+        administration: { id: 1 },
+        is_superuser: true,
+        roles: [],
+        ...overrides,
+      };
+    });
+  });
+};
+
+describe("AdministrationDropdownLocal", () => {
+  beforeEach(() => {
+    api.get.mockReset();
+    act(() => {
+      store.update((s) => {
+        s.administration = [];
+        s.user = null;
+      });
+    });
+  });
+
+  afterEach(() => {
+    cleanup();
+  });
+
+  test("fetches root admin on mount and renders the first cascade <Select>", async () => {
+    seedUser();
+    api.get.mockImplementation((url) => {
+      if (url === "administration/1") {
+        return Promise.resolve({ data: ROOT_ADMIN });
+      }
+      return Promise.reject(new Error(`unexpected url: ${url}`));
+    });
+
+    render(<AdministrationDropdownLocal onChange={jest.fn()} />);
+
+    await waitFor(() => {
+      expect(api.get).toHaveBeenCalledWith("administration/1");
+    });
+    // The cascade renders one <Select> per level with children — the
+    // root admin has children, so we expect exactly one combobox here.
+    expect(await screen.findByRole("combobox")).toBeTruthy();
+  });
+
+  test("picking a child fetches its detail, appends to the cascade, and emits the deepest level via onChange", async () => {
+    seedUser();
+    const onChange = jest.fn();
+    api.get.mockImplementation((url) => {
+      if (url === "administration/1") {
+        return Promise.resolve({ data: ROOT_ADMIN });
+      }
+      if (url === "administration/11") {
+        return Promise.resolve({ data: PROVINCE_DETAIL });
+      }
+      return Promise.reject(new Error(`unexpected url: ${url}`));
+    });
+
+    render(<AdministrationDropdownLocal onChange={onChange} />);
+
+    await waitFor(() => {
+      expect(api.get).toHaveBeenCalledWith("administration/1");
+    });
+
+    const provinceCombobox = await screen.findByRole("combobox");
+    fireEvent.mouseDown(provinceCombobox);
+    const jakartaOption = await screen.findByText("Jakarta");
+    fireEvent.click(jakartaOption);
+
+    await waitFor(() => {
+      expect(api.get).toHaveBeenCalledWith("administration/11");
+    });
+    await waitFor(() => {
+      expect(onChange).toHaveBeenCalledWith(
+        expect.objectContaining({ id: 11, name: "Jakarta" })
+      );
+    });
+  });
+
+  test("never writes to store.administration during mount or selection", async () => {
+    seedUser();
+    api.get.mockImplementation((url) => {
+      if (url === "administration/1") {
+        return Promise.resolve({ data: ROOT_ADMIN });
+      }
+      if (url === "administration/11") {
+        return Promise.resolve({ data: PROVINCE_DETAIL });
+      }
+      return Promise.reject(new Error(`unexpected url: ${url}`));
+    });
+
+    const before = store.getRawState().administration;
+
+    render(<AdministrationDropdownLocal onChange={jest.fn()} />);
+
+    await waitFor(() => {
+      expect(api.get).toHaveBeenCalledWith("administration/1");
+    });
+
+    const provinceCombobox = await screen.findByRole("combobox");
+    fireEvent.mouseDown(provinceCombobox);
+    const jakartaOption = await screen.findByText("Jakarta");
+    fireEvent.click(jakartaOption);
+
+    await waitFor(() => {
+      expect(api.get).toHaveBeenCalledWith("administration/11");
+    });
+
+    // Interactions must NOT mutate the global admin state — the whole
+    // point of this component is to keep selection local.
+    expect(store.getRawState().administration).toBe(before);
+  });
+
+  test("non-superuser with role-scoped admins only sees children inside their assigned role", async () => {
+    seedUser({
+      is_superuser: false,
+      roles: [
+        {
+          administration: { level_id: 1, id: 11 },
+        },
+      ],
+    });
+    api.get.mockImplementation((url) => {
+      if (url === "administration/1") {
+        return Promise.resolve({ data: ROOT_ADMIN });
+      }
+      return Promise.reject(new Error(`unexpected url: ${url}`));
+    });
+
+    render(<AdministrationDropdownLocal onChange={jest.fn()} />);
+
+    await waitFor(() => {
+      expect(api.get).toHaveBeenCalledWith("administration/1");
+    });
+
+    const provinceCombobox = await screen.findByRole("combobox");
+    fireEvent.mouseDown(provinceCombobox);
+    expect(await screen.findByText("Jakarta")).toBeTruthy();
+    expect(screen.queryByText("Bali")).toBeNull();
+  });
+});

--- a/frontend/src/config/visualizations/1749623934933.json
+++ b/frontend/src/config/visualizations/1749623934933.json
@@ -1024,6 +1024,19 @@
               ]
             }
           ]
+        },
+        {
+          "id": "tab_individual_overview",
+          "is_public": false,
+          "label": "Individual Overview",
+          "items": [
+            {
+              "id": "individual_overview_component",
+              "chart_type": "custom_component",
+              "order": 1,
+              "component": "IndividualEPSOverview"
+            }
+          ]
         }
       ]
     }

--- a/frontend/src/config/visualizations/README.md
+++ b/frontend/src/config/visualizations/README.md
@@ -105,6 +105,7 @@ Only these six keys at the top level. Everything else is an item.
 | `filter_multi_option` | Multi-select dropdown | `key`, `question_id`, `form_id` |
 | `progress_definition` | Hidden definition | `key`, `components[]`, `api`, `start_date_question_id`, `deadline_question_id`, `scope_question_id` |
 | `water_quality_globals` | Hidden definition | `sample_question_id`, `test_method_question_id`, `monitoring_form_id` |
+| `custom_component` | Arbitrary React component from the custom-components registry | `component` (string, registry key) — see "Custom component escape hatch" below |
 
 `progress_definition` and `water_quality_globals` items must have `"hide": true`.
 The renderer always skips them; they exist solely to be resolved by id via
@@ -117,6 +118,21 @@ Tab panes are plain objects inside a `tabs` item's `items[]`. They have no
 
 ```json
 { "id": "tab_monitoring", "label": "Monitoring overview", "items": [ /* items */ ] }
+```
+
+**`is_public`** (optional, defaults to `true`) — when set to `false`, the tab
+is rendered **disabled** for anonymous viewers and only becomes clickable
+when `UIState.isLoggedIn` is `true`. Use this for tabs whose children fetch
+authenticated endpoints. Combined with `destroyInactiveTabPane`, the disabled
+tab's children never mount — no requests fire from anonymous sessions.
+
+```json
+{
+  "id": "tab_individual_overview",
+  "is_public": false,
+  "label": "Individual Overview",
+  "items": [ /* items */ ]
+}
 ```
 
 ### `col_span` semantics
@@ -203,6 +219,64 @@ and builds a stacked-bar chart client-side.
 
 ---
 
+## Custom component escape hatch
+
+Some dashboard tabs follow a **record-centric** pattern that does not fit the
+aggregate chart paradigm — the user picks one record and downstream widgets
+render details for that single record. Rather than extending the JSON schema
+with primitives that only make sense for these tabs (token templates,
+component dependencies, custom endpoints, named render registries), use the
+`custom_component` chart_type to delegate rendering to a freely authored React
+component.
+
+### When to reach for it
+
+- The interaction model is **record-centric**, not aggregate.
+- The tab needs internal state that is not expressible as a global filter.
+- The behavior is unique enough that no other dashboard would reuse it today.
+
+### When NOT to reach for it
+
+- The widget can be expressed as `card` / `bar` / `doughnut` / `table` etc.
+  with an `api` block — extend the existing schema instead.
+- Two or three other dashboards would benefit from the same widget — promote
+  it to a first-class `chart_type` rather than copying components.
+
+### Adding a custom component
+
+1. Create `frontend/src/components/dashboard/custom-components/<Name>.jsx`.
+2. Add a named export in [`custom-components/index.js`](../../components/dashboard/custom-components/index.js).
+3. Reference it from JSON:
+
+```json
+{
+  "id": "individual_overview_component",
+  "chart_type": "custom_component",
+  "order": 1,
+  "component": "<Name>"
+}
+```
+
+Unknown component names are not fatal — the renderer logs `console.error` and
+displays an `<Alert>` placeholder, so the rest of the dashboard keeps working.
+
+### What the component owns
+
+- Data fetching, including auth-aware error handling.
+- Loading, empty, and error UI states.
+- Internal selection state, drill-downs, sub-tabs.
+- Any internal filters (the dashboard's global filter bar is **not** piped in).
+
+### Stay specific until rule-of-three
+
+Do not generalize prematurely. The first per-dashboard custom component is
+fine as a one-off. When a third dashboard needs a similar pattern, refactor
+the common pieces into shared building-block components
+(`<RecordSelectorBar>`, `<RegistrationDetailTable>`, etc.) — not into a single
+mega-component driven by yet another schema.
+
+---
+
 ## Filter hints (frontend-expanded)
 
 These keys on an `api` block are expanded by the frontend before the request is
@@ -281,6 +355,7 @@ columns resolved by the renderer:
 - [`widgets/TabsWidget`](../../components/dashboard/widgets/TabsWidget.jsx) — tabs container
 - [`widgets/FilterBarWidget`](../../components/dashboard/widgets/FilterBarWidget.jsx) — filter bar container
 - [`widgets/SectionTitleWidget`](../../components/dashboard/widgets/SectionTitleWidget.jsx) — section heading
+- [`widgets/CustomComponentWidget`](../../components/dashboard/widgets/CustomComponentWidget.jsx) — registry-backed escape hatch (see "Custom component escape hatch")
 - [`DashboardFilters`](../../components/dashboard/DashboardFilters.jsx) — individual filter controls
 - [`DashboardMap`](../../components/dashboard/DashboardMap.jsx) — map widget
 - [`EscalationTable`](../../components/dashboard/EscalationTable.jsx) — escalation table

--- a/frontend/src/config/visualizations/README.md
+++ b/frontend/src/config/visualizations/README.md
@@ -275,6 +275,25 @@ the common pieces into shared building-block components
 (`<RecordSelectorBar>`, `<RegistrationDetailTable>`, etc.) — not into a single
 mega-component driven by yet another schema.
 
+### Worked example: the individual-overview pattern
+
+The record-centric "Individual Overview" tab on the EPS dashboard is the
+reference implementation of this escape hatch. It composes six reusable
+primitives out of
+[`custom-components/individual-overview/shared/`](../../components/dashboard/custom-components/individual-overview/shared/)
+(helpers, `<PhotoCaptionCard>`, `<CharacteristicsTable>`,
+`<HistoricalLineChart>`, `useIndividualOverviewData`, and
+`useMonitoringHistory`) plus per-dashboard constants in
+[`individual-overview/config/eps.js`](../../components/dashboard/custom-components/individual-overview/config/eps.js),
+so the shell itself stays a ~180-line orchestrator.
+
+Note the rule-of-three deviation: those primitives were extracted before
+three working consumers existed. The justification is that each primitive was
+designed against **two** concrete shell designs in hand (EPS and a planned
+RWS sibling) and appears ≥4× across them — past the rule-of-two threshold
+with concrete designs to validate against. For the full design rationale, see
+[`doc/claude/dashboard-individual-overview/`](../../../../doc/claude/dashboard-individual-overview/).
+
 ---
 
 ## Filter hints (frontend-expanded)

--- a/frontend/src/pages/dashboard/style.scss
+++ b/frontend/src/pages/dashboard/style.scss
@@ -58,6 +58,7 @@
       box-shadow: $box-shadow;
       padding: 0;
       text-align: left;
+      height: 100% !important;
 
       &.tabs-card {
         padding: 0;

--- a/frontend/src/util/__test__/useDashboardConfig.test.js
+++ b/frontend/src/util/__test__/useDashboardConfig.test.js
@@ -36,11 +36,18 @@ describe("config/visualizations registry", () => {
     expect(config).not.toBeNull();
     expect(config.name).toBe("EPS Overview");
     expect(config.parent_form_id).toBe(1749623934933);
-    // Flat schema: top-level `items[]` with a `tabs` container holding 3 panes.
+    // Flat schema: top-level `items[]` with a `tabs` container holding 4 panes
+    // (Monitoring overview, Water quality, Construction monitoring,
+    // Individual Overview — the latter is gated by `is_public: false`).
     expect(Array.isArray(config.items)).toBe(true);
     const tabsItem = config.items.find((it) => it.chart_type === "tabs");
     expect(tabsItem).toBeDefined();
-    expect(tabsItem.items).toHaveLength(3);
+    expect(tabsItem.items).toHaveLength(4);
+    const individualTab = tabsItem.items.find(
+      (pane) => pane.id === "tab_individual_overview"
+    );
+    expect(individualTab).toBeDefined();
+    expect(individualTab.is_public).toBe(false);
     // Collect every item id recursively, assert key KPI cards are present.
     const allIds = [];
     const walk = (items = []) => {


### PR DESCRIPTION
## Summary

Adds a record-centric **Individual Overview** tab to the EPS dashboard (`/dashboard/eps-overview`) where the user picks one EPS site and downstream widgets render details for that single record (latest
construction photo + EPS characteristics; Construction monitoring sub-tab with project completion progress, project-scope information table, and general remarks; Water quality monitoring sub-tab with last-monitoring
details, sampling-point card, operational status tag, and conditional Lab/CBT historical line charts).

To plug a record-centric React component into the JSON-driven aggregate dashboard schema without polluting the schema with primitives that only make sense for one tab (token templates, component dependencies, custom
endpoints, named render registries), this PR also introduces a generic **`custom_component` escape hatch** in the dashboard config. Tabs can mark themselves `is_public: false` to gate the pane behind `UIState.isLoggedIn` (rendered as disabled with `destroyInactiveTabPane` so anonymous viewers fire no requests).

The Individual Overview shell is built on six shared primitives under `custom-components/individual-overview/shared/`, designed against both the EPS shipping today and the planned RWS shell (separate branch) so a future "Individual X Overview" tab is also small.

## What's shipped

### Dashboard config schema — new `custom_component` chart type

- Tab pane example:
  ```json
  {
    "id": "tab_individual_overview",
    "is_public": false,
    "label": "Individual Overview",
    "items": [
      {
        "id": "individual_overview_component",
        "chart_type": "custom_component",
        "order": 1,
        "component": "IndividualEPSOverview"
      }
    ]
  }
  ```
- `is_public: false` on a tab pane disables the tab for anonymous
  viewers and falls `defaultActiveKey` through to the first enabled
  pane. Combined with AntD's existing `destroyInactiveTabPane`, the
  pane's children never mount — no API requests fire from anonymous
  sessions.
- Unknown `component` names are not fatal: the renderer logs to
  `console.error` and shows an `<Alert>` placeholder so the rest of
  the dashboard keeps working.

### `custom_component` dispatcher

- `widgets/CustomComponentWidget.jsx` — resolves `item.component`
  against the named-export registry in
  `custom-components/index.js` and falls back to `<Alert>` on miss.
- `widgets/TabsWidget.jsx` — reads `isLoggedIn` from the Pullstate
  store, marks panes whose `is_public === false` as `disabled` when
  not logged in, and falls `defaultActiveKey` through to the first
  enabled pane.
- `DashboardRenderer.jsx` — dispatches `chart_type: "custom_component"`
  to `<CustomComponentWidget>`.

### EPS Individual Overview tab

- `IndividualEPSOverview.jsx` — thin orchestrator (~390 lines)
  composing the six shared primitives + EPS-specific config. Renders:
  - Filter row: `<AdministrationDropdown>` + EPS `<Select>`
  - Top row (col 12 / col 12): `<PhotoCaptionCard>` (latest
    construction photo) + `<CharacteristicsTable>` (EPS Characteristics)
  - Tabs (`destroyInactiveTabPane`):
    - **Construction monitoring** — `<Progress>` for project
      completion, Construction Information `<Table>` driven by
      `PROJECT_SCOPE_ROWS`, General remarks card.
    - **Water quality monitoring** — Last Water Monitoring details
      table, sampling-point `<PhotoCaptionCard>` + operational status
      tag, conditional Microbial Lab card with 3
      `<HistoricalLineChart>` and CBT card with 1 chart (rendered only
      when the latest WQ submission's `water_testing_method` answer
      flags lab/cbt).
- `1749623934933.json` (EPS dashboard config) — adds the
  `tab_individual_overview` pane with `is_public: false` +
  `custom_component` delegation.

### Construction Information table — group-walk + project_scope gating

The Construction Information table supports two row variants matching
the EPS dashboard mockup:

- **Scope row** (`scope_value` + `impl_group_id` + `photo_qid` +
  `photo_caption_qid`): "In Scope?" cell renders a green Yes / red No
  tag based on whether `scope_value` appears in the construction
  monitoring form's `project_scope` answer. "Implementation /
  Construction" cell joins every non-photo answer in the row's
  question group via `collectGroupAnswers(impl_group_id, values)`.
  Photo cell shows a thumbnail from `photo_qid` plus a caption from
  `photo_caption_qid`.
- **Metadata row** (`question_id` only, all scope/group/photo fields
  null): single-qid lookup via `resolveAnswerLabel`; In Scope? and
  Photo cells render blank. Used for fixed project metadata fields
  (Inspection Date, Construction Start Date, Proposed Completion
  Date, Weather Conditions).

Fixes two latent wiring bugs at the same time: the previous shape's
`impl_qid` pointed at each group's `type: "photo"` question (so
`formatAnswerValue` rendered the URL as text in the Implementation
cell), and `photo_qid` pointed at the description text (so
`extractPhotoUrl` always returned null and no thumbnail rendered).

### Shared primitives (`custom-components/individual-overview/shared/`)

- `helpers.js` — pure lookup + formatting (no React):
  `findQuestion`, `findQuestionGroup`, `findAnswer`,
  `formatAnswerValue` (handles option / multiple_option / geo /
  arrays), `extractPhotoUrl`, `resolveAnswerLabel`,
  `collectGroupAnswers` (walks a question group, drops `type: "photo"`,
  joins surviving formatted answers), `sortByDateAscending`.
- `CharacteristicsTable.jsx` — two-column AntD `<Table>` rendering
  Question / Answer for a list of qids. Skips qids with no resolvable
  answer.
- `PhotoCaptionCard.jsx` — photo + caption with empty-state fallback.
- `HistoricalLineChart.jsx` — `<Line>` from akvo-charts wrapped in a
  `chart-card` that respects akvo-charts' `div[role="figure"]`
  min-height (320px) so the chart canvas never bleeds outside the
  bordered card. Optional shaded threshold band via `markArea`.
- `useIndividualOverviewData.js` — hook driving the
  admin → datapoints → reg/monitoring values fetch chain. Subscribes
  to `store.administration` for the deepest selected admin.
- `useMonitoringHistory.js` — paginated per-parent history fetcher
  feeding the line charts (N+1 round-trips, isolated for future
  backend swap).


### Scoped admin filter for the embedded dropdown

The dashboard's global `<AdministrationDropdown>` writes to
`store.administration` (Pullstate), and `<DashboardFilters>` subscribes
to that key to feed `filterState.administration_id` into every
`useDashboardValues` call. Mounting that dropdown inside a
`custom_component` would therefore make a per-component admin pick
trigger a refetch of every chart, table, KPI, and progress fetcher on
the page — direct violation of the "one tab's local state must not leak
to the rest of the dashboard" contract.

To keep the embedded admin selection scoped, the PR introduces a sibling
component:

- `AdministrationDropdownLocal.js` — cascading admin dropdown that owns
  its `levels[]` selection in component-local React state and never
  calls `store.update`. Same visual cascade as the existing
  `AdministrationDropdown` (root → province → district → … with
  per-level `/administration/<id>` fetches and the same role-scoped
  child filter for non-superusers), exposed via a single
  `onChange(deepest | null)` contract.
- `useIndividualOverviewData.js` migrates from
  `store.useState(s => s.administration)` to a `selectedLocation` prop
  consumed by the parent's `useState`, so the hook stays a pure
  consumer of the embedded dropdown's output.
- `IndividualEPSOverview.jsx` swaps `<AdministrationDropdown />` for
  `<AdministrationDropdownLocal onChange={setEmbeddedAdmin} />` and
  threads `selectedLocation: embeddedAdmin` into the hook.
---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1214122811191545