### PR TITLE
Visualization feedback

### DIFF
--- a/backend/api/v1/v1_visualization/dashboard_serializers.py
+++ b/backend/api/v1/v1_visualization/dashboard_serializers.py
@@ -53,6 +53,10 @@ class ValuesFilterSerializer(serializers.Serializer):
     administration_id = serializers.IntegerField(required=False)
     option_value = serializers.CharField(required=False)
     criteria = serializers.CharField(required=False)
+    include_unanswered = serializers.BooleanField(
+        required=False,
+        default=False,
+    )
 
     def validate_criteria(self, value):
         try:

--- a/backend/api/v1/v1_visualization/dashboard_views.py
+++ b/backend/api/v1/v1_visualization/dashboard_views.py
@@ -197,6 +197,9 @@ def visualization_values(request, version):
         "option_value": validated.get("option_value"),
         "criteria": validated.get("criteria"),
         "parent_criteria": validated.get("parent_criteria"),
+        "include_unanswered": validated.get(
+            "include_unanswered", False
+        ),
     }
 
     # Route to handler

--- a/backend/api/v1/v1_visualization/tests/tests_values_option.py
+++ b/backend/api/v1/v1_visualization/tests/tests_values_option.py
@@ -527,6 +527,37 @@ class ValuesOptionTestCases(VisualizationValuesTestMixin, APITestCase):
         # feature_y appears in both latest submissions; 2/4 = 50%
         self.assertEqual(by_group["feature_y"], 50.0)
 
+    def test_include_unanswered_share_card_denominator_includes_bucket(self):
+        """share_card denominator includes the _no_info bucket (FR-11).
+
+        MetricCard computes share as numerator / sum(all row values).
+        With include_unanswered=true the _no_info row is present so the
+        denominator is total registrations, not just monitored ones.
+
+        Setup: 2 mixin parents monitored (active=1, pending=1), 3 extra
+        unmonitored. Expected: active=1, pending=1, inactive=0, _no_info=3.
+        sum(values) == 5 == total registrations → denominator is correct.
+        """
+        for i in range(3):
+            self._create_registration(
+                name=f"Share Extra {i}",
+                administration=self.adm_parent,
+            )
+        response = self.client.get(
+            f"{self.BASE_URL}?form_id={self.monitoring.id}"
+            f"&question_id={self.q_option.id}"
+            "&group_by=option&monitoring=latest"
+            "&include_unanswered=true"
+        )
+        self.assertEqual(response.status_code, 200)
+        data = response.json()
+        by_group = {d["group"]: d["value"] for d in data["data"]}
+        self.assertEqual(by_group["active"], 1)
+        self.assertEqual(by_group["pending"], 1)
+        self.assertEqual(by_group["_no_info"], 3)
+        # sum equals total registrations — MetricCard denominator is correct
+        self.assertEqual(sum(by_group.values()), 5)
+
     # -- Helper for tests that need additional registrations --
 
     def _create_registration(self, name, administration):

--- a/backend/api/v1/v1_visualization/tests/tests_values_option.py
+++ b/backend/api/v1/v1_visualization/tests/tests_values_option.py
@@ -466,12 +466,24 @@ class ValuesOptionTestCases(VisualizationValuesTestMixin, APITestCase):
         # Only 1 non-deleted extra registration is unmonitored
         self.assertEqual(by_group["_no_info"]["value"], 1)
 
-    def test_include_unanswered_ignored_on_registration_form(self):
-        """Flag is silently ignored for registration-form questions (FR-7).
+    def test_include_unanswered_works_on_registration_form(self):
+        """include_unanswered works for registration-form questions.
 
-        The registration form has no parent, so _count_no_info_parents
-        returns 0 and the bucket is never appended.
+        Registrations that exist but have no answer for the option
+        question are counted in the _no_info bucket, using data_id
+        as the tracking key (registration records have no parent_id).
+
+        Setup: answer q_reg_option for reg1 only; reg2 stays unanswered.
+        Expect: answered option row has value 1; _no_info = 1 (reg2).
         """
+        from api.v1.v1_data.models import Answers as _Ans
+        # q_reg_option (site_type) has options: urban, rural, peri_urban
+        _Ans.objects.create(
+            data=self.reg1,
+            question=self.q_reg_option,
+            options=["urban"],
+            created_by=self.user,
+        )
         response = self.client.get(
             f"{self.BASE_URL}?form_id={self.registration.id}"
             f"&question_id={self.q_reg_option.id}"
@@ -480,8 +492,10 @@ class ValuesOptionTestCases(VisualizationValuesTestMixin, APITestCase):
         )
         self.assertEqual(response.status_code, 200)
         data = response.json()
-        groups = {d["group"] for d in data["data"]}
-        self.assertNotIn("_no_info", groups)
+        by_group = {d["group"]: d["value"] for d in data["data"]}
+        self.assertEqual(by_group.get("urban"), 1)
+        self.assertIn("_no_info", by_group)
+        self.assertEqual(by_group["_no_info"], 1)
 
     def test_include_unanswered_ignored_on_count_mode(self):
         """Flag is silently ignored when no question_id (count mode, FR-7).

--- a/backend/api/v1/v1_visualization/tests/tests_values_option.py
+++ b/backend/api/v1/v1_visualization/tests/tests_values_option.py
@@ -293,3 +293,248 @@ class ValuesOptionTestCases(VisualizationValuesTestMixin, APITestCase):
         data = response.json()
         self.assertEqual(len(data["data"]), 1)
         self.assertEqual(data["data"][0]["value"], 50.0)
+
+    # -- include_unanswered tests --
+
+    def test_include_unanswered_appends_no_info_row(self):
+        """include_unanswered=true appends _no_info for unmonitored parents.
+
+        Mixin has 2 parents, both monitored (latest: reg1=active,
+        reg2=pending). Create 3 more registrations without monitoring.
+        Expected: active=1, inactive=0, pending=1, _no_info=3.
+        """
+        for i in range(3):
+            self.reg_extra = self._create_registration(
+                name=f"Extra Site {i}",
+                administration=self.adm_parent,
+            )
+
+        response = self.client.get(
+            f"{self.BASE_URL}?form_id={self.monitoring.id}"
+            f"&question_id={self.q_option.id}"
+            "&group_by=option&monitoring=latest"
+            "&include_unanswered=true"
+        )
+        self.assertEqual(response.status_code, 200)
+        data = response.json()
+        by_group = {d["group"]: d for d in data["data"]}
+        self.assertEqual(by_group["active"]["value"], 1)
+        self.assertEqual(by_group["pending"]["value"], 1)
+        self.assertIn("_no_info", by_group)
+        self.assertEqual(by_group["_no_info"]["value"], 3)
+        self.assertEqual(by_group["_no_info"]["color"], "#bfbfbf")
+        self.assertEqual(
+            by_group["_no_info"]["label"], "No information available"
+        )
+        # _no_info must be the last row
+        self.assertEqual(data["data"][-1]["group"], "_no_info")
+
+    def test_include_unanswered_default_false_unchanged(self):
+        """Without the flag the response is identical to the baseline.
+
+        The baseline (test_option_group_by_option_latest) returns
+        active=1, pending=1, inactive=0. No _no_info row.
+        """
+        response = self.client.get(
+            f"{self.BASE_URL}?form_id={self.monitoring.id}"
+            f"&question_id={self.q_option.id}"
+            "&group_by=option&monitoring=latest"
+        )
+        self.assertEqual(response.status_code, 200)
+        data = response.json()
+        groups = {d["group"] for d in data["data"]}
+        self.assertNotIn("_no_info", groups)
+        self.assertEqual(len(data["data"]), 3)
+
+    def test_include_unanswered_multiple_option_distinct_parents(self):
+        """Multi-choice: _no_info uses distinct-parent count, not subtraction.
+
+        Mixin: 2 parents, both have latest monitoring with multi answers.
+        Add 1 extra registration without monitoring.
+        _no_info = 1 (not 3 - sum of multi selections).
+        """
+        self._create_registration(
+            name="Unmonitored Multi",
+            administration=self.adm_parent,
+        )
+        response = self.client.get(
+            f"{self.BASE_URL}?form_id={self.monitoring.id}"
+            f"&question_id={self.q_multi.id}"
+            "&group_by=option&monitoring=latest"
+            "&include_unanswered=true"
+        )
+        self.assertEqual(response.status_code, 200)
+        data = response.json()
+        by_group = {d["group"]: d for d in data["data"]}
+        self.assertIn("_no_info", by_group)
+        self.assertEqual(by_group["_no_info"]["value"], 1)
+
+    def test_include_unanswered_percentage_sums_100_single_choice(self):
+        """Percentage with include_unanswered: single-choice sums to 100%.
+
+        Mixin has 2 parents monitored (active=1, pending=1).
+        Add 2 extra registrations without monitoring.
+        Total parents = 4. active=1, pending=1, _no_info=2.
+        Percentages: active=25%, inactive=0%, pending=25%, _no_info=50%.
+        Sum of all = 100%.
+        """
+        for i in range(2):
+            self._create_registration(
+                name=f"Pct Extra {i}",
+                administration=self.adm_parent,
+            )
+        response = self.client.get(
+            f"{self.BASE_URL}?form_id={self.monitoring.id}"
+            f"&question_id={self.q_option.id}"
+            "&group_by=option&monitoring=latest"
+            "&include_unanswered=true&value_type=percentage"
+        )
+        self.assertEqual(response.status_code, 200)
+        data = response.json()
+        by_group = {d["group"]: d["value"] for d in data["data"]}
+        self.assertEqual(by_group["active"], 25.0)
+        self.assertEqual(by_group["inactive"], 0.0)
+        self.assertEqual(by_group["pending"], 25.0)
+        self.assertEqual(by_group["_no_info"], 50.0)
+        self.assertAlmostEqual(sum(by_group.values()), 100.0, places=1)
+
+    def test_include_unanswered_respects_administration_filter(self):
+        """Administration filter narrows the bucket to the filtered universe.
+
+        adm_parent (level 0) has reg1. adm_child (level 1) has reg2.
+        When filtering to adm_child, only 1 parent is in scope.
+        Latest for adm_child: reg2 = pending → 0 unanswered.
+        """
+        response = self.client.get(
+            f"{self.BASE_URL}?form_id={self.monitoring.id}"
+            f"&question_id={self.q_option.id}"
+            "&group_by=option&monitoring=latest"
+            "&include_unanswered=true"
+            f"&administration_id={self.adm_child.id}"
+        )
+        self.assertEqual(response.status_code, 200)
+        data = response.json()
+        by_group = {d["group"]: d for d in data["data"]}
+        # reg2 (child) has pending answer → qualifying_parents = {reg2}
+        # total in admin_child scope = 1 → bucket = 0 → no _no_info row
+        self.assertNotIn("_no_info", by_group)
+        self.assertEqual(by_group["pending"]["value"], 1)
+
+    def test_include_unanswered_zero_bucket_emits_no_row(self):
+        """When all parents are monitored, _no_info row is not appended.
+
+        Mixin: both registrations have monitoring. Bucket = 0.
+        """
+        response = self.client.get(
+            f"{self.BASE_URL}?form_id={self.monitoring.id}"
+            f"&question_id={self.q_option.id}"
+            "&group_by=option&monitoring=latest"
+            "&include_unanswered=true"
+        )
+        self.assertEqual(response.status_code, 200)
+        data = response.json()
+        groups = {d["group"] for d in data["data"]}
+        self.assertNotIn("_no_info", groups)
+        self.assertEqual(len(data["data"]), 3)
+
+    def test_include_unanswered_excludes_soft_deleted_parents(self):
+        """Soft-deleted parents are not counted in the bucket.
+
+        Add 2 extra registrations, soft-delete one. Bucket = 1.
+        """
+        extra1 = self._create_registration(
+            name="SoftDelete Site",
+            administration=self.adm_parent,
+        )
+        self._create_registration(
+            name="Normal Site",
+            administration=self.adm_parent,
+        )
+        # Soft-delete extra1 via the SoftDeletes mixin
+        extra1.delete()
+
+        response = self.client.get(
+            f"{self.BASE_URL}?form_id={self.monitoring.id}"
+            f"&question_id={self.q_option.id}"
+            "&group_by=option&monitoring=latest"
+            "&include_unanswered=true"
+        )
+        self.assertEqual(response.status_code, 200)
+        data = response.json()
+        by_group = {d["group"]: d for d in data["data"]}
+        self.assertIn("_no_info", by_group)
+        # Only 1 non-deleted extra registration is unmonitored
+        self.assertEqual(by_group["_no_info"]["value"], 1)
+
+    def test_include_unanswered_ignored_on_registration_form(self):
+        """Flag is silently ignored for registration-form questions (FR-7).
+
+        The registration form has no parent, so _count_no_info_parents
+        returns 0 and the bucket is never appended.
+        """
+        response = self.client.get(
+            f"{self.BASE_URL}?form_id={self.registration.id}"
+            f"&question_id={self.q_reg_option.id}"
+            "&group_by=option"
+            "&include_unanswered=true"
+        )
+        self.assertEqual(response.status_code, 200)
+        data = response.json()
+        groups = {d["group"] for d in data["data"]}
+        self.assertNotIn("_no_info", groups)
+
+    def test_include_unanswered_ignored_on_count_mode(self):
+        """Flag is silently ignored when no question_id (count mode, FR-7).
+
+        No per-option breakdown → no bucket makes sense.
+        """
+        response = self.client.get(
+            f"{self.BASE_URL}?form_id={self.monitoring.id}"
+            "&include_unanswered=true"
+        )
+        self.assertEqual(response.status_code, 200)
+        data = response.json()
+        groups = {d.get("group") for d in data["data"]}
+        self.assertNotIn("_no_info", groups)
+
+    def test_include_unanswered_percentage_multi_choice_denominator(self):
+        """Multi-choice percentage uses distinct-parent denominator.
+
+        Mixin: 2 parents monitored (both have multi answers for feature_*).
+        Add 2 extra registrations without monitoring.
+        Total parents = 4, qualifying = 2, bucket = 2.
+        feature_y latest: reg1(mon1b)=[feature_y,feature_z],
+                          reg2(mon2b)=[feature_x,feature_y,feature_z]
+        feature_y tally = 2, denom = 2 qualifying + 2 bucket = 4.
+        feature_y % = 2/4*100 = 50%.
+        """
+        for i in range(2):
+            self._create_registration(
+                name=f"Multi Pct Extra {i}",
+                administration=self.adm_parent,
+            )
+        response = self.client.get(
+            f"{self.BASE_URL}?form_id={self.monitoring.id}"
+            f"&question_id={self.q_multi.id}"
+            "&group_by=option&monitoring=latest"
+            "&include_unanswered=true&value_type=percentage"
+        )
+        self.assertEqual(response.status_code, 200)
+        data = response.json()
+        by_group = {d["group"]: d["value"] for d in data["data"]}
+        self.assertIn("_no_info", by_group)
+        self.assertEqual(by_group["_no_info"], 50.0)
+        # feature_y appears in both latest submissions; 2/4 = 50%
+        self.assertEqual(by_group["feature_y"], 50.0)
+
+    # -- Helper for tests that need additional registrations --
+
+    def _create_registration(self, name, administration):
+        """Create a registration FormData without any monitoring."""
+        from api.v1.v1_data.models import FormData as _FD
+        return _FD.objects.create(
+            name=name,
+            form=self.registration,
+            administration=administration,
+            created_by=self.user,
+        )

--- a/backend/api/v1/v1_visualization/tests/tests_values_option.py
+++ b/backend/api/v1/v1_visualization/tests/tests_values_option.py
@@ -294,6 +294,31 @@ class ValuesOptionTestCases(VisualizationValuesTestMixin, APITestCase):
         self.assertEqual(len(data["data"]), 1)
         self.assertEqual(data["data"][0]["value"], 50.0)
 
+    def test_option_value_percentage_include_unanswered_uses_total_parents(
+        self,
+    ):
+        """include_unanswered widens the denominator to total registrations.
+
+        Without the flag: 1 match / 2 monitored parents = 50%.
+        With 3 extra unmonitored and include_unanswered=true: 1/5 = 20%.
+        """
+        for i in range(3):
+            self._create_registration(
+                name=f"Unmonitored {i}",
+                administration=self.adm_parent,
+            )
+        response = self.client.get(
+            f"{self.BASE_URL}?form_id={self.monitoring.id}"
+            f"&question_id={self.q_option.id}"
+            "&option_value=active&sum_by=parent_id"
+            "&monitoring=latest&value_type=percentage"
+            "&include_unanswered=true"
+        )
+        self.assertEqual(response.status_code, 200)
+        data = response.json()
+        self.assertEqual(len(data["data"]), 1)
+        self.assertEqual(data["data"][0]["value"], 20.0)
+
     # -- include_unanswered tests --
 
     def test_include_unanswered_appends_no_info_row(self):

--- a/backend/api/v1/v1_visualization/values_functions.py
+++ b/backend/api/v1/v1_visualization/values_functions.py
@@ -26,18 +26,20 @@ def _should_fill_gaps(params):
     )
 
 
-def _count_no_info_parents(form, params, qualifying_parent_ids):
-    """Count parents in scope with no qualifying answer for the question.
+def _count_no_info_parents(form, params, qualifying_ids):
+    """Count datapoints in scope with no qualifying answer.
 
-    Returns 0 for registration forms. Respects administration_id and
-    parent_criteria so the count reconciles with option counts under
-    filtering (FR-3).
+    For monitoring forms: counts parent registrations without any
+    qualifying monitoring submission (gap in monitoring coverage).
+    For registration forms: counts registrations that exist but have no
+    answer for the question (field left blank / skipped).
+
+    Respects administration_id and parent_criteria so the count
+    reconciles with option counts under filtering (FR-3).
     """
-    if not form.parent:
-        return 0
-    parent_form = form.parent
+    scope_form = form.parent if form.parent else form
     qs = FormData.objects.filter(
-        form=parent_form,
+        form=scope_form,
         parent__isnull=True,
         is_pending=False,
         is_draft=False,
@@ -49,7 +51,7 @@ def _count_no_info_parents(form, params, qualifying_parent_ids):
         qs, True, params.get("parent_criteria"),
     )
     total = qs.count()
-    return max(0, total - len(qualifying_parent_ids))
+    return max(0, total - len(qualifying_ids))
 
 
 # -- Count mode handler --
@@ -532,18 +534,24 @@ def _option_group_by_option(
     )
     tallies = defaultdict(int)
     qualifying_parents = set()
-    for parent_id, opts in Answers.objects.filter(
+    # Registration forms have no parent; track data_id directly.
+    # Monitoring forms track data__parent_id (the registration ID).
+    is_registration = form is not None and form.parent is None
+    tracking_field = (
+        "data_id" if is_registration else "data__parent_id"
+    )
+    for tracking_id, opts in Answers.objects.filter(
         data_id__in=data_ids,
         question_id=question.id,
         options__isnull=False,
-    ).values_list("data__parent_id", "options"):
+    ).values_list(tracking_field, "options"):
         matched = False
         for v in (opts or []):
             if v in tally_values:
                 tallies[v] += 1
                 matched = True
         if matched:
-            qualifying_parents.add(parent_id)
+            qualifying_parents.add(tracking_id)
 
     counts = [tallies.get(opt.value, 0) for opt in options]
 

--- a/backend/api/v1/v1_visualization/values_functions.py
+++ b/backend/api/v1/v1_visualization/values_functions.py
@@ -14,6 +14,8 @@ from api.v1.v1_visualization.functions import (
     format_date_group,
     fill_month_gaps,
     fill_date_gaps,
+    apply_administration_filter,
+    apply_parent_criteria_to_qs,
 )
 
 
@@ -22,6 +24,32 @@ def _should_fill_gaps(params):
     return bool(
         params.get("from_date") and params.get("to_date")
     )
+
+
+def _count_no_info_parents(form, params, qualifying_parent_ids):
+    """Count parents in scope with no qualifying answer for the question.
+
+    Returns 0 for registration forms. Respects administration_id and
+    parent_criteria so the count reconciles with option counts under
+    filtering (FR-3).
+    """
+    if not form.parent:
+        return 0
+    parent_form = form.parent
+    qs = FormData.objects.filter(
+        form=parent_form,
+        parent__isnull=True,
+        is_pending=False,
+        is_draft=False,
+    )
+    administration_id = params.get("administration_id")
+    if administration_id:
+        qs = apply_administration_filter(qs, administration_id)
+    qs = apply_parent_criteria_to_qs(
+        qs, True, params.get("parent_criteria"),
+    )
+    total = qs.count()
+    return max(0, total - len(qualifying_parent_ids))
 
 
 # -- Count mode handler --
@@ -330,7 +358,12 @@ def handle_option_question(form, question, params):
         )
         return _option_group_by_option(
             question, options, data_ids, qs,
-            is_latest, value_type, restricted
+            is_latest, value_type, restricted,
+            include_unanswered=params.get(
+                "include_unanswered", False
+            ),
+            form=form,
+            params=params,
         )
 
     return [], []
@@ -473,7 +506,8 @@ def _extract_criteria_option_values(params, question_id):
 
 def _option_group_by_option(
     question, options, data_ids, qs,
-    is_latest, value_type, restricted_values=None
+    is_latest, value_type, restricted_values=None,
+    include_unanswered=False, form=None, params=None,
 ):
     """Group by option values (donut chart).
 
@@ -485,6 +519,11 @@ def _option_group_by_option(
     same question), only those values are tallied — so a
     multiple_option record ["a", "b"] filtered by "a" counts only
     for "a", not "b".
+
+    When `include_unanswered=True`, appends one synthetic row
+    (group="_no_info") for parents with no qualifying answer,
+    and adjusts the percentage denominator to include the bucket
+    so single-choice rows sum to 100%.
     """
     option_values = {o.value for o in options}
     tally_values = (
@@ -492,32 +531,60 @@ def _option_group_by_option(
         if restricted_values else option_values
     )
     tallies = defaultdict(int)
-    rows = Answers.objects.filter(
+    qualifying_parents = set()
+    for parent_id, opts in Answers.objects.filter(
         data_id__in=data_ids,
         question_id=question.id,
         options__isnull=False,
-    ).values_list("options", flat=True)
-    for opts in rows:
+    ).values_list("data__parent_id", "options"):
+        matched = False
         for v in (opts or []):
             if v in tally_values:
                 tallies[v] += 1
+                matched = True
+        if matched:
+            qualifying_parents.add(parent_id)
 
     counts = [tallies.get(opt.value, 0) for opt in options]
-    total_for_pct = sum(counts)
+
+    bucket_count = (
+        _count_no_info_parents(form, params, qualifying_parents)
+        if include_unanswered else 0
+    )
+
+    if value_type == "percentage":
+        if include_unanswered:
+            denom = len(qualifying_parents) + bucket_count
+        else:
+            denom = sum(counts)
+    else:
+        denom = None
+
     data = []
     for opt, count in zip(options, counts):
-        if value_type == "percentage":
-            val = round(
-                (count / total_for_pct * 100), 2
-            ) if total_for_pct > 0 else 0.0
-        else:
-            val = count
+        val = (
+            round((count / denom * 100), 2)
+            if value_type == "percentage" and denom else count
+        )
         data.append({
             "value": val,
             "label": opt.label,
             "group": opt.value,
             "color": opt.color,
         })
+
+    if include_unanswered and bucket_count > 0:
+        bucket_val = (
+            round((bucket_count / denom * 100), 2)
+            if value_type == "percentage" and denom else bucket_count
+        )
+        data.append({
+            "value": bucket_val,
+            "label": "No information available",
+            "group": "_no_info",
+            "color": "#bfbfbf",
+        })
+
     labels = [d["label"] for d in data]
     return data, labels
 

--- a/backend/api/v1/v1_visualization/values_functions.py
+++ b/backend/api/v1/v1_visualization/values_functions.py
@@ -26,17 +26,8 @@ def _should_fill_gaps(params):
     )
 
 
-def _count_no_info_parents(form, params, qualifying_ids):
-    """Count datapoints in scope with no qualifying answer.
-
-    For monitoring forms: counts parent registrations without any
-    qualifying monitoring submission (gap in monitoring coverage).
-    For registration forms: counts registrations that exist but have no
-    answer for the question (field left blank / skipped).
-
-    Respects administration_id and parent_criteria so the count
-    reconciles with option counts under filtering (FR-3).
-    """
+def _total_parents_in_scope(form, params):
+    """Count all parent registrations in scope, respecting filters."""
     scope_form = form.parent if form.parent else form
     qs = FormData.objects.filter(
         form=scope_form,
@@ -50,7 +41,21 @@ def _count_no_info_parents(form, params, qualifying_ids):
     qs = apply_parent_criteria_to_qs(
         qs, True, params.get("parent_criteria"),
     )
-    total = qs.count()
+    return qs.count()
+
+
+def _count_no_info_parents(form, params, qualifying_ids):
+    """Count datapoints in scope with no qualifying answer.
+
+    For monitoring forms: counts parent registrations without any
+    qualifying monitoring submission (gap in monitoring coverage).
+    For registration forms: counts registrations that exist but have no
+    answer for the question (field left blank / skipped).
+
+    Respects administration_id and parent_criteria so the count
+    reconciles with option counts under filtering (FR-3).
+    """
+    total = _total_parents_in_scope(form, params)
     return max(0, total - len(qualifying_ids))
 
 
@@ -345,7 +350,12 @@ def handle_option_question(form, question, params):
     if option_value:
         return _option_value_filter(
             question, data_ids, qs, is_latest,
-            option_value, sum_by, value_type
+            option_value, sum_by, value_type,
+            include_unanswered=params.get(
+                "include_unanswered", False
+            ),
+            form=form,
+            params=params,
         )
 
     if stack_by == "option" and group_by:
@@ -373,7 +383,8 @@ def handle_option_question(form, question, params):
 
 def _option_value_filter(
     question, data_ids, qs, is_latest,
-    option_value, sum_by, value_type
+    option_value, sum_by, value_type,
+    include_unanswered=False, form=None, params=None,
 ):
     """Filter by specific option value and count."""
     count = Answers.objects.filter(
@@ -389,7 +400,10 @@ def _option_value_filter(
         count = count.count()
 
     if value_type == "percentage":
-        total = qs.count() if is_latest else len(data_ids)
+        if include_unanswered and form is not None:
+            total = _total_parents_in_scope(form, params or {})
+        else:
+            total = qs.count() if is_latest else len(data_ids)
         value = round(
             (count / total * 100), 2
         ) if total > 0 else 0

--- a/doc/claude/no-available-info-in-vis-values-api/README.md
+++ b/doc/claude/no-available-info-in-vis-values-api/README.md
@@ -1,0 +1,74 @@
+# "No information available" bucket — SDD
+
+Software Design Document for adding an opt-in `_no_info` bucket to `/api/v1/visualization/values` so dashboards can reconcile per-option totals with their parent-registration total when monitoring data is incomplete.
+
+**Status**: Requirements + design approved (brainstorm). Implementation pending.
+**Branch**: TBD (suggest `feature/<issue>-no-info-bucket`)
+**Issue**: TBD (file via `bd create`)
+**Touches**: [`backend/api/v1/v1_visualization/`](../../../backend/api/v1/v1_visualization/), [`frontend/src/components/dashboard/`](../../../frontend/src/components/dashboard/), [`frontend/src/lib/ui-text.js`](../../../frontend/src/lib/ui-text.js), [`frontend/src/config/visualizations/`](../../../frontend/src/config/visualizations/)
+
+---
+
+## Documents in this folder
+
+| Document | Purpose | Audience |
+|---|---|---|
+| [requirements.md](./requirements.md) | Locked functional / non-functional requirements, scope matrix, explicit out-of-scope list | Reviewer approving the spec; PM / stakeholder |
+| [design.md](./design.md) | Backend SQL plan, API contract, frontend wiring, edge cases, test matrix, mermaid sequence diagrams | Implementer needing the *what* and *why*; reviewer auditing the change |
+| [implementation-plan.md](./implementation-plan.md) | Sequenced, checklisted task breakdown with file paths, line-number anchors, commit messages, rollback recipe | Implementer driving the PR; reviewer tracking progress |
+
+---
+
+## Problem in one sentence
+
+When a dashboard's KPI tile says "104 EPS registered" but the donut chart of operational status sums to 80, the missing 24 disappear silently — instead they should show as a gray "No information available" slice so the totals reconcile and the data-quality gap is visible to operators.
+
+## TL;DR
+
+- Add an **opt-in** query param `include_unanswered=true` to `/api/v1/visualization/values`.
+- When set, the response gains one synthetic row: `{ value, label: "No information available", group: "_no_info", color: "#bfbfbf" }`.
+- The synthetic row's `value` is the count of **distinct parent registrations** that have no qualifying answer for the question, after applying the same filters as the rest of the response.
+- Multiple-option questions cannot derive the bucket by subtraction (a record may answer multiple options) — it's computed as `count(distinct parents with no qualifying answer)`.
+- `value_type=percentage` includes the bucket in the denominator so the response sums to 100%.
+- Frontend translates the label via the existing [`ui-text.js`](../../../frontend/src/lib/ui-text.js) map (new key `noInformationAvailable`).
+- Map widget gains opt-in `status_colors._no_info` so un-monitored markers can be colored gray with a legend entry.
+- Default behavior unchanged everywhere — no surprise visual changes for existing dashboards.
+
+---
+
+## Decisions locked from brainstorm
+
+| Decision | Value | Rationale |
+|---|---|---|
+| Trigger model | Opt-in flag `include_unanswered=true` | Existing consumers (`stack_bar cross_tab`, `kpi_stack`, `share_card`) do their own arithmetic; an unconditional extra row would break them |
+| Param name | `include_unanswered` | Reads as a boolean modifier; future-proof for an `unanswered_split` follow-up |
+| Group key | `"_no_info"` | Underscore prefix unambiguously synthetic; cannot collide with a real `QuestionOptions.value` (slug-cased); a single key works for donut, stack_bar, and map |
+| Default color | `"#bfbfbf"` | Sensible neutral gray; dashboards override via existing chart-level color array or `status_colors._no_info` |
+| Multiple-option semantics | `count(distinct parents with no qualifying answer)`, never `total − sum` | One record can answer multiple options, so subtraction over-counts the gap |
+| Soft-deleted parents | Excluded | Use `FormData.objects` (not `objects_deleted`); matches default behavior of the rest of the visualization API |
+| `value_type=percentage` | Bucket joins denominator, all rows sum to 100% | Keeps percentages internally consistent; the gap shows as its own percentage slice |
+| `share_card` denominator | Becomes "all parents" when `include_unanswered=true` | Matches the intuitive reading of "operational EPS share" — share of *all EPS*, not *monitored EPS* |
+| Map default | Un-monitored EPS stay uncolored unless `status_colors._no_info` is set | Opt-in everywhere; no silent visual changes |
+| Translation surface | Add `noInformationAvailable` key to existing [`ui-text.js`](../../../frontend/src/lib/ui-text.js) Charts block | Matches the established i18n surface; ready for `de` and future locales |
+
+---
+
+## Out of scope (explicitly deferred)
+
+- Splitting "never monitored" vs "answered-but-blank" into two distinct buckets — collapsed to one in v1.
+- KPI scalar cards (`option_value` mode) — already covered by `denominator_api` ratio cards.
+- `stack_by=option` / `group_by=parent_id` — per-parent rows make the gap implicit already.
+- Auto-coloring un-monitored map markers without explicit `status_colors._no_info` — opt-in only.
+- Introducing a new i18n framework — reuse existing `uiText` map.
+- Backend changes to count-mode (no `question_id`) endpoints — out of scope; the gap doesn't apply when there's no per-option breakdown.
+
+---
+
+## Workflow
+
+1. **Brainstorm** (done) — captured in this folder.
+2. **Requirements** (done) — see [requirements.md](./requirements.md).
+3. **Design** (done) — see [design.md](./design.md).
+4. **Implementation** — follow the phased, checklisted plan in [implementation-plan.md](./implementation-plan.md).
+5. **Verification** — backend tests + manual donut/map smoke per [design.md "Test Plan"](./design.md#test-plan) and [implementation-plan.md "Phase 4.3"](./implementation-plan.md#43-manual-smoke).
+6. **PR** — single PR with `[#<issue>]` prefix; flip dashboards on in the same PR so the visible fix lands together with the API change.

--- a/doc/claude/no-available-info-in-vis-values-api/design.md
+++ b/doc/claude/no-available-info-in-vis-values-api/design.md
@@ -1,0 +1,399 @@
+# "No information available" bucket — Design
+
+Architecture, SQL, and implementation plan for the opt-in `_no_info` bucket on `/api/v1/visualization/values`.
+
+For the locked requirements this design satisfies, see [requirements.md](./requirements.md). For the rationale behind each choice, see [README.md](./README.md).
+
+---
+
+## Architecture overview
+
+```mermaid
+flowchart LR
+  subgraph FE [Frontend]
+    JSON[Dashboard JSON config]
+    CR[ChartRenderer]
+    DM[DashboardMap]
+    UT[ui-text.js]
+  end
+  subgraph BE [Backend Django]
+    SR[ValuesFilterSerializer]
+    VV[visualization_values view]
+    HOQ[handle_option_question]
+    OPT[_option_group_by_option]
+    NEW{{_count_no_info_parents}}
+  end
+
+  JSON -- "include_unanswered: true" --> CR
+  CR -->|HTTP| SR --> VV --> HOQ --> OPT
+  OPT --> NEW
+  NEW --> OPT
+  OPT --> VV --> CR
+  CR -->|reads label| UT
+  DM -->|reads status_colors._no_info| JSON
+  DM -->|reads label| UT
+```
+
+The change is surgical: one new serializer field, one new helper function, one extra branch in `_option_group_by_option`, one new `share_card`-aware path. Everything else stays untouched.
+
+---
+
+## Backend
+
+### Serializer
+
+In [`backend/api/v1/v1_visualization/dashboard_serializers.py`](../../../backend/api/v1/v1_visualization/dashboard_serializers.py), add to `ValuesFilterSerializer`:
+
+```python
+include_unanswered = serializers.BooleanField(
+    required=False,
+    default=False,
+)
+```
+
+The field accepts standard truthy strings (`"true"`, `"1"`, `"yes"`) per DRF's `BooleanField` parsing — no custom coercion needed.
+
+### New helper: `_count_no_info_parents`
+
+Add to [`backend/api/v1/v1_visualization/values_functions.py`](../../../backend/api/v1/v1_visualization/values_functions.py):
+
+```python
+def _count_no_info_parents(form, params, qualifying_parent_ids):
+    """Count parents in scope whose latest monitoring submission has
+    no qualifying answer for the question.
+
+    bucket = total_parents_in_scope - len(qualifying_parent_ids)
+
+    Returns 0 (not None) for non-monitoring forms so callers can
+    short-circuit cleanly. Respects administration_id and parent_criteria
+    on the registration form so the count reconciles with the option
+    counts under filtering (FR-3).
+    """
+    if not form.parent:
+        return 0
+    parent_form = form.parent
+    qs = FormData.objects.filter(
+        form=parent_form,
+        parent__isnull=True,
+        is_pending=False,
+        is_draft=False,
+    )
+    administration_id = params.get("administration_id")
+    if administration_id:
+        qs = apply_administration_filter(qs, administration_id)
+    qs = apply_parent_criteria_to_qs(
+        qs, True, params.get("parent_criteria"),
+    )
+    total = qs.count()
+    return max(0, total - len(qualifying_parent_ids))
+```
+
+### Modify `_option_group_by_option`
+
+Update the existing function at [`values_functions.py:474`](../../../backend/api/v1/v1_visualization/values_functions.py#L474). The change collects the set of distinct parent IDs that contributed to any tally, then optionally appends the synthetic row.
+
+```python
+def _option_group_by_option(
+    question, options, data_ids, qs,
+    is_latest, value_type, restricted_values=None,
+    include_unanswered=False, form=None, params=None,
+):
+    option_values = {o.value for o in options}
+    tally_values = (
+        option_values & restricted_values
+        if restricted_values else option_values
+    )
+    tallies = defaultdict(int)
+    qualifying_parents = set()
+    for parent_id, opts in Answers.objects.filter(
+        data_id__in=data_ids,
+        question_id=question.id,
+        options__isnull=False,
+    ).values_list("data__parent_id", "options"):
+        matched = False
+        for v in (opts or []):
+            if v in tally_values:
+                tallies[v] += 1
+                matched = True
+        if matched:
+            qualifying_parents.add(parent_id)
+
+    counts = [tallies.get(opt.value, 0) for opt in options]
+
+    bucket_count = (
+        _count_no_info_parents(form, params, qualifying_parents)
+        if include_unanswered else 0
+    )
+
+    if value_type == "percentage":
+        denom = (
+            sum(counts) + bucket_count
+            if not include_unanswered else (
+                len(qualifying_parents) + bucket_count
+            )
+        )
+        # When include_unanswered=true, denom is total_parents_in_scope
+        # (single-choice exact, multiple_option may exceed sum).
+    else:
+        denom = None
+
+    data = []
+    for opt, count in zip(options, counts):
+        val = (
+            round((count / denom * 100), 2)
+            if value_type == "percentage" and denom else count
+        )
+        data.append({
+            "value": val,
+            "label": opt.label,
+            "group": opt.value,
+            "color": opt.color,
+        })
+
+    if include_unanswered and bucket_count > 0:
+        bucket_val = (
+            round((bucket_count / denom * 100), 2)
+            if value_type == "percentage" and denom else bucket_count
+        )
+        data.append({
+            "value": bucket_val,
+            "label": "No information available",
+            "group": "_no_info",
+            "color": "#bfbfbf",
+        })
+
+    labels = [d["label"] for d in data]
+    return data, labels
+```
+
+> **Multi-choice percentage note (FR-6 nuance).** For single-choice `option` questions, the N+1 percentages sum exactly to 100%. For `multiple_option` questions, each option's `count` can include a parent that also answered other options, so the sum of N option percentages may exceed 100% even before the bucket. This is consistent with the existing multi-choice percentage behavior — the bucket is added on top using the same `total_parents_in_scope` denominator. Reviewers should expect "≥100% for multi-choice" and only "exactly 100%" for single-choice.
+
+### Wire the flag through `handle_option_question`
+
+In `handle_option_question` at [`values_functions.py:292`](../../../backend/api/v1/v1_visualization/values_functions.py#L292), pass the new param + form/params context to `_option_group_by_option`. Existing callers (single-axis bar, donut, share_card) all flow through this branch when `group_by="option"`.
+
+```python
+if group_by == "option":
+    restricted = _extract_criteria_option_values(
+        params, question.id
+    )
+    return _option_group_by_option(
+        question, options, data_ids, qs,
+        is_latest, value_type, restricted,
+        include_unanswered=params.get("include_unanswered", False),
+        form=form,
+        params=params,
+    )
+```
+
+### Share-card path
+
+`share_card` rides the same `group_by="option"` shape today (see the `target_group` discussion in [`README.md:372`](../../../frontend/src/config/visualizations/README.md#L372)) — no separate backend handler. The frontend strips `target_group` before the call, so the response simply includes the bucket and the existing share calculation `numerator / sum(values)` naturally pulls it in. **No backend code change for share_card** beyond what the donut path already provides.
+
+### Edge cases
+
+| Case | Handling |
+|---|---|
+| Question is on a registration form | `_count_no_info_parents` returns 0; bucket suppressed |
+| `include_unanswered=true` but `bucket_count == 0` | No row appended (avoid noise) |
+| `monitoring=all` (not `latest`) | Definition still holds: bucket = parents with no qualifying answer in any submission within filters; `_count_no_info_parents` uses the same parent universe |
+| `restricted_values` (criteria filters one option) | Parents whose only answer falls outside `tally_values` count as un-answered (consistent with "no qualifying answer") |
+| Soft-deleted parent | Excluded — `FormData.objects` is the soft-delete-aware default manager |
+| Parent has multiple monitoring submissions, latest has answer, older doesn't | Latest-mode picks the latest by `latest_monitoring_subquery`; if latest has answer → not in bucket. Matches existing semantics |
+
+---
+
+## Frontend wiring
+
+### `ui-text.js`
+
+Add one key in [`frontend/src/lib/ui-text.js`](../../../frontend/src/lib/ui-text.js) under the existing Charts comment block at [line 80](../../../frontend/src/lib/ui-text.js#L80):
+
+```diff
+   // Charts
+   showEmpty: "Show empty values",
++  noInformationAvailable: "No information available",
+```
+
+The German `de` map at [line 1024](../../../frontend/src/lib/ui-text.js#L1024) is empty today and inherits the English string at runtime (existing fallback behavior); no action needed there.
+
+### ChartRenderer
+
+The donut at [`ChartRenderer.jsx`](../../../frontend/src/components/dashboard/ChartRenderer.jsx) already renders whatever rows the backend returns. The only intentional change is to **swap the backend label for the i18n string** when the row's `group === "_no_info"`:
+
+```jsx
+// in the row mapping that becomes chart data
+const label = row.group === "_no_info"
+  ? uiText.en.noInformationAvailable
+  : row.label;
+```
+
+The `color` field on the synthetic row falls through to akvo-charts' color resolver — chart-level color arrays in the JSON config still win over the backend default, matching today's precedence.
+
+### DashboardMap
+
+[`DashboardMap.jsx`](../../../frontend/src/components/dashboard/DashboardMap.jsx) currently colors markers via `status_colors[answer]`. Add a single fall-through:
+
+```jsx
+const colorFor = (answer) => {
+  if (answer && status_colors[answer]) return status_colors[answer];
+  if (status_colors._no_info) return status_colors._no_info;
+  return undefined; // existing behavior
+};
+
+// legend
+const legendEntries = Object.entries(status_colors).map(([key, color]) => ({
+  color,
+  label: key === "_no_info" ? uiText.en.noInformationAvailable : labelFor(key),
+}));
+```
+
+Map configs that don't define `_no_info` see no behavior change (FR-10).
+
+### Dashboard JSON configs
+
+Flip the flag on for the two existing operational-status donuts:
+
+[`frontend/src/config/visualizations/1749623934933.json`](../../../frontend/src/config/visualizations/1749623934933.json) (EPS Overview):
+```diff
+ "api": {
+   "form_id": 1749632545233,
+   "question_id": 1749633373968,
+   "group_by": "option",
+-  "monitoring": "latest"
++  "monitoring": "latest",
++  "include_unanswered": true
+ }
+```
+
+[`frontend/src/config/visualizations/1749621221728.json`](../../../frontend/src/config/visualizations/1749621221728.json) (RWS Overview): same diff on the equivalent donut.
+
+Optionally extend `status_colors` on each dashboard's `map` item to color un-monitored markers gray:
+```diff
+ "status_colors": {
+   "operational": "#64A73B",
+-  "issue_with_system": "#e41a1c"
++  "issue_with_system": "#e41a1c",
++  "_no_info": "#bfbfbf"
+ }
+```
+
+---
+
+## Sequence diagrams
+
+### Donut request with `include_unanswered=true`
+
+```mermaid
+sequenceDiagram
+  participant FE as ChartRenderer
+  participant API as visualization_values
+  participant H as handle_option_question
+  participant Q as _option_group_by_option
+  participant N as _count_no_info_parents
+  participant DB as PostgreSQL
+
+  FE->>API: GET /values?form_id=X&question_id=Q&group_by=option&include_unanswered=true
+  API->>H: validated params
+  H->>DB: get_base_monitoring_qs (latest per parent, filtered)
+  DB-->>H: data_ids (monitoring submissions in scope)
+  H->>Q: data_ids, options, include_unanswered=true
+  Q->>DB: SELECT parent_id, options FROM Answers WHERE data_id IN (...) AND question_id=Q
+  DB-->>Q: rows (parent_id, options[])
+  Q->>Q: tally counts + collect qualifying_parents set
+  Q->>N: form, params, qualifying_parents
+  N->>DB: COUNT(*) FROM FormData WHERE form=parent_form AND admin filter AND parent_criteria
+  DB-->>N: total_parents_in_scope
+  N-->>Q: bucket = total - len(qualifying_parents)
+  Q-->>H: rows + {label, group:_no_info, color, value}
+  H-->>API: response array
+  API-->>FE: 200 OK
+  FE->>FE: swap _no_info label via uiText.en.noInformationAvailable
+  FE->>FE: render donut slice gray
+```
+
+### Map widget opt-in
+
+```mermaid
+sequenceDiagram
+  participant U as User
+  participant DM as DashboardMap
+  participant API as map endpoint
+  participant DB as PostgreSQL
+
+  U->>DM: view map
+  DM->>API: fetch markers (existing endpoint)
+  API->>DB: parents + latest monitoring answer
+  DB-->>API: marker list (some answers null)
+  API-->>DM: markers
+  DM->>DM: for each marker, colorFor(answer) → status_colors[answer] OR status_colors._no_info OR undefined
+  DM->>DM: build legend including _no_info entry if present
+```
+
+---
+
+## Test plan
+
+### Backend tests
+
+Add to [`backend/api/v1/v1_visualization/tests/tests_values_option.py`](../../../backend/api/v1/v1_visualization/tests/tests_values_option.py):
+
+| Test | Setup | Assertion |
+|---|---|---|
+| `test_include_unanswered_appends_no_info_row` | 5 parents registered, 3 have monitoring with answers (a, a, b) | response has 3 rows: `a=2`, `b=1`, `_no_info=2` |
+| `test_include_unanswered_default_false_unchanged` | same as above, no flag | response has only `a=2`, `b=1`; no `_no_info` row |
+| `test_include_unanswered_multiple_option_distinct_parents` | parent A answered ["x","y"], parent B answered ["x"], parent C no submission | `_no_info=1`, qualifying-parents math correct |
+| `test_include_unanswered_percentage_sums_100_single_choice` | 4 parents, 3 answered (2 a, 1 b), 1 unanswered | percentages: a=50, b=25, `_no_info`=25, sum=100 |
+| `test_include_unanswered_respects_administration_filter` | 10 parents in 2 admins, filter to admin A (5 parents, 3 monitored) | bucket reflects only admin A's gap: 2 |
+| `test_include_unanswered_zero_bucket_emits_no_row` | every parent has an answer | response unchanged; no synthetic row |
+| `test_include_unanswered_excludes_soft_deleted_parents` | soft-delete one parent before the request | bucket count does not include the deleted parent |
+| `test_include_unanswered_ignored_on_registration_form` | request a registration-form question with the flag | response unchanged (FR-7) |
+| `test_include_unanswered_ignored_on_count_mode` | no `question_id`, flag set | response unchanged (FR-7) |
+| `test_include_unanswered_share_card_denominator_includes_bucket` | share request with `target_group=operational`, 50 operational of 80 monitored, 24 unanswered | denominator = 50+x+y+24 ≥ 104 |
+
+### Frontend smoke
+
+Manual / Jest — verify in this order:
+
+1. Boot stack (`./dc.sh up -d`). Visit `/dashboard/eps-overview`.
+2. Donut "Operational Status" shows a gray slice; legend reads "No information available"; total of all slices equals the "Total EPS registered" KPI above.
+3. Apply administration filter → both KPI and donut total drop to the same number.
+4. Switch to `/dashboard/rws-overview` → same behavior.
+5. If map's `_no_info` color is added → un-monitored markers render gray; legend shows the new entry.
+6. With flag absent (a different chart on the same dashboard) → donut behavior unchanged.
+
+### Regression
+
+Run the existing test suite — every test should pass without modification (NFR-1):
+
+```bash
+./dc.sh exec backend python manage.py test api.v1.v1_visualization
+cd frontend && npm run lint && npm run test:ci
+```
+
+---
+
+## Implementation plan
+
+Phased so the PR can land in one merge with clean commit boundaries:
+
+1. **Backend** — serializer field + `_count_no_info_parents` helper + `_option_group_by_option` change + 10 tests.
+2. **Frontend i18n** — `ui-text.js` key + `ChartRenderer` label swap.
+3. **Map widget** — `DashboardMap` honors `status_colors._no_info` and emits legend entry.
+4. **Flip dashboards on** — flag added to EPS + RWS operational-status donuts; manual smoke.
+5. **Documentation** — new paragraph in [`frontend/src/config/visualizations/README.md`](../../../frontend/src/config/visualizations/README.md) under "Empty-data behaviour".
+6. **Verify + PR** — full test suite, lint, prettier, stakeholder note in PR body.
+
+For the line-by-line execution checklist (file paths, exact diffs, commit messages, smoke-test steps, rollback recipe), see [implementation-plan.md](./implementation-plan.md).
+
+---
+
+## Risk register
+
+| Risk | Likelihood | Impact | Mitigation |
+|---|---|---|---|
+| Multi-choice percentage semantics confuse a reader | Medium | Low | Documented in design + README; reviewers are pre-warned |
+| Existing dashboard config silently picks up a bucket because of an inherited default | Low | Medium | Default is `False`; flag is explicit per-chart |
+| Performance regression on very large parent sets (>100k) | Low | Low | One additional `COUNT(*)` per request; PostgreSQL handles trivially |
+| Stakeholder surprise at "operational EPS share" dropping from e.g. 62% to 48% | Medium | Low | Note in PR body + dashboard release notes |
+| A future chart re-uses `_no_info` as a real option value | Very low | Medium | Underscore prefix is reserved; document in README; reject in form-seeder if it ever ships |

--- a/doc/claude/no-available-info-in-vis-values-api/implementation-plan.md
+++ b/doc/claude/no-available-info-in-vis-values-api/implementation-plan.md
@@ -1,0 +1,386 @@
+# "No information available" bucket — Implementation Plan
+
+Sequenced, checklisted task breakdown for landing the opt-in `_no_info` bucket on `/api/v1/visualization/values`. Built to be executed top-to-bottom by an implementer who has read [requirements.md](./requirements.md) and [design.md](./design.md).
+
+**Branch**: TBD (suggest `feature/<issue>-no-info-bucket`)
+**Issue**: TBD — file via `bd create --title="Add include_unanswered flag to /visualization/values" --type=feature --priority=2`
+**Companions**: [`requirements.md`](./requirements.md), [`design.md`](./design.md), [`README.md`](./README.md)
+
+---
+
+## Pre-flight
+
+Before touching code:
+
+- [ ] Read [requirements.md](./requirements.md) end-to-end. The 12 FRs are the contract.
+- [ ] Read [design.md](./design.md) — especially the [Edge cases table](./design.md#edge-cases) and the [multi-choice percentage note](./design.md#modify-_option_group_by_option) (single-choice sums to 100%, multi-choice may exceed).
+- [ ] Skim the existing donut handler at [`values_functions.py:474`](../../../backend/api/v1/v1_visualization/values_functions.py#L474) and the option-question dispatch at [`values_functions.py:292`](../../../backend/api/v1/v1_visualization/values_functions.py#L292).
+- [ ] Confirm the two target dashboard configs ([`1749623934933.json`](../../../frontend/src/config/visualizations/1749623934933.json), [`1749621221728.json`](../../../frontend/src/config/visualizations/1749621221728.json)) are the only consumers that will be flipped on in this PR. If a third dashboard wants in, list it under FR-12 in [requirements.md](./requirements.md#fr-12--existing-dashboards-opt-in) before starting.
+- [ ] Create the beads issue and `bd update <id> --status=in_progress`.
+- [ ] Create the feature branch: `git checkout -b feature/<issue>-no-info-bucket`.
+
+---
+
+## Phase 1 — Backend: serializer + helper + handler change
+
+Single commit. All changes live in [`backend/api/v1/v1_visualization/`](../../../backend/api/v1/v1_visualization/).
+
+### 1.1 Add the serializer field
+
+File: [`backend/api/v1/v1_visualization/dashboard_serializers.py`](../../../backend/api/v1/v1_visualization/dashboard_serializers.py)
+
+- [ ] Inside `ValuesFilterSerializer` (the class body around [line 18](../../../backend/api/v1/v1_visualization/dashboard_serializers.py#L18)), add the new field next to the other booleans/choices:
+
+  ```python
+  include_unanswered = serializers.BooleanField(
+      required=False,
+      default=False,
+  )
+  ```
+
+- [ ] No extra `validate_*` method needed — DRF's `BooleanField` parses `"true"`, `"1"`, `"yes"`, etc. natively.
+- [ ] Run a one-off sanity check that the field reaches `validated_data`:
+  ```bash
+  ./dc.sh exec backend python manage.py shell -c "from api.v1.v1_visualization.dashboard_serializers import ValuesFilterSerializer; s = ValuesFilterSerializer(data={'form_id': 1, 'include_unanswered': 'true'}); s.is_valid(); print(s.validated_data)"
+  ```
+  Expect to see `'include_unanswered': True` in the output (after a real `form_id`).
+
+### 1.2 Add the `_count_no_info_parents` helper
+
+File: [`backend/api/v1/v1_visualization/values_functions.py`](../../../backend/api/v1/v1_visualization/values_functions.py)
+
+- [ ] At the top, ensure `apply_administration_filter` and `apply_parent_criteria_to_qs` are importable from `.functions`. They already exist (see [`functions.py:25`](../../../backend/api/v1/v1_visualization/functions.py#L25), [`functions.py:252`](../../../backend/api/v1/v1_visualization/functions.py#L252)) — add to the existing import block:
+
+  ```python
+  from api.v1.v1_visualization.functions import (
+      get_base_monitoring_qs,
+      get_monitoring_data_ids,
+      apply_administration_filter,
+      apply_parent_criteria_to_qs,
+      ...
+  )
+  ```
+
+- [ ] Add the helper near the top of the file (above `handle_count_mode`), see the full body in [design.md "New helper"](./design.md#new-helper-_count_no_info_parents). Returns 0 for registration forms, otherwise `max(0, total_in_scope − len(qualifying_parent_ids))`.
+
+### 1.3 Modify `_option_group_by_option`
+
+File: [`values_functions.py:474`](../../../backend/api/v1/v1_visualization/values_functions.py#L474)
+
+- [ ] Extend the signature to accept four new kwargs (all defaulted so existing internal calls keep working):
+  ```python
+  def _option_group_by_option(
+      question, options, data_ids, qs,
+      is_latest, value_type, restricted_values=None,
+      include_unanswered=False, form=None, params=None,
+  ):
+  ```
+
+- [ ] Replace the `rows = …values_list("options", flat=True)` loop with a tuple-yielding loop over `("data__parent_id", "options")` so we can collect `qualifying_parents: set[int]` in the same pass. Full body in [design.md "Modify _option_group_by_option"](./design.md#modify-_option_group_by_option).
+
+- [ ] Compute `bucket_count` only when `include_unanswered=True`. When the flag is off, the function must return byte-identical output to today (NFR-1).
+
+- [ ] When `value_type == "percentage"` AND `include_unanswered`, set the denominator to `len(qualifying_parents) + bucket_count` so single-choice totals sum to 100% exactly. Multi-choice may exceed 100% — that's documented.
+
+- [ ] Append the `_no_info` row only when `bucket_count > 0` (don't pollute the response with a zero-count row).
+
+### 1.4 Wire the flag through `handle_option_question`
+
+File: [`values_functions.py:292`](../../../backend/api/v1/v1_visualization/values_functions.py#L292)
+
+- [ ] In the `if group_by == "option":` branch (around [line 327](../../../backend/api/v1/v1_visualization/values_functions.py#L327)), pass the four new kwargs:
+  ```python
+  return _option_group_by_option(
+      question, options, data_ids, qs,
+      is_latest, value_type, restricted,
+      include_unanswered=params.get("include_unanswered", False),
+      form=form,
+      params=params,
+  )
+  ```
+
+- [ ] Do **not** wire it into the other branches in `handle_option_question` (`option_value`, `stack_by`, `option_value + group_by=month`). FR-7 says they ignore the flag.
+
+### 1.5 Backend tests
+
+File: [`backend/api/v1/v1_visualization/tests/tests_values_option.py`](../../../backend/api/v1/v1_visualization/tests/tests_values_option.py)
+
+Add ten tests inside the existing `ValuesOptionTestCases` class. Use the existing `VisualizationValuesTestMixin` (check [`tests/mixins.py`](../../../backend/api/v1/v1_visualization/tests/mixins.py) for the registration + monitoring fixture helpers).
+
+- [ ] `test_include_unanswered_appends_no_info_row` — 5 parents registered, 3 monitored with answers `(a, a, b)`. Assert response = `[{a:2}, {b:1}, {_no_info:2}]`.
+- [ ] `test_include_unanswered_default_false_unchanged` — same dataset, no flag. Assert response identical to the existing `test_option_group_by_option_latest` baseline.
+- [ ] `test_include_unanswered_multiple_option_distinct_parents` — parent A `["x","y"]`, B `["x"]`, C no submission. Assert `_no_info=1`, `x=2`, `y=1`.
+- [ ] `test_include_unanswered_percentage_sums_100_single_choice` — 4 parents, answers `(a, a, b)`, 1 unanswered. Assert percentages `a=50, b=25, _no_info=25`, sum exactly 100.
+- [ ] `test_include_unanswered_percentage_multi_choice_may_exceed_100` — multi-choice setup; assert percentages reflect distinct-parent denominator and document that sum may exceed 100. (Sanity-check, not a contract.)
+- [ ] `test_include_unanswered_respects_administration_filter` — 10 parents in 2 admins; filter to admin A (5 parents, 3 monitored). Assert bucket = 2.
+- [ ] `test_include_unanswered_zero_bucket_emits_no_row` — every parent monitored. Assert no `_no_info` row appended.
+- [ ] `test_include_unanswered_excludes_soft_deleted_parents` — soft-delete one parent; assert bucket count drops by 1.
+- [ ] `test_include_unanswered_ignored_on_registration_form` — request a registration-form `option` question with the flag. Assert response unchanged (FR-7).
+- [ ] `test_include_unanswered_ignored_on_count_mode` — no `question_id`, flag set. Assert response unchanged (FR-7).
+
+- [ ] Run the test file: `./dc.sh exec backend python manage.py test api.v1.v1_visualization.tests.tests_values_option`. Green.
+- [ ] Run the full visualization suite: `./dc.sh exec backend python manage.py test api.v1.v1_visualization`. Green.
+
+### 1.6 Lint + commit
+
+- [ ] `./dc.sh exec backend flake8 api/v1/v1_visualization/dashboard_serializers.py api/v1/v1_visualization/values_functions.py api/v1/v1_visualization/tests/tests_values_option.py`. Clean.
+- [ ] `git add backend/api/v1/v1_visualization/dashboard_serializers.py backend/api/v1/v1_visualization/values_functions.py backend/api/v1/v1_visualization/tests/tests_values_option.py`.
+- [ ] Commit:
+  ```
+  [#<issue>] feat(visualization): opt-in _no_info bucket on /values
+
+  - Add `include_unanswered` boolean to ValuesFilterSerializer.
+  - Add _count_no_info_parents helper for distinct-parent gap math.
+  - Append synthetic _no_info row to group_by=option responses when
+    the flag is on; respects administration + parent_criteria filters.
+  - Adjust value_type=percentage denominator to include the bucket
+    so single-choice rows sum to 100%.
+  - 10 new tests covering single/multi choice, filters, soft-deletes,
+    out-of-scope shapes (registration form, count mode).
+  ```
+
+---
+
+## Phase 2 — Frontend: i18n + ChartRenderer label swap
+
+### 2.1 Add the translation key
+
+File: [`frontend/src/lib/ui-text.js`](../../../frontend/src/lib/ui-text.js)
+
+- [ ] At [line 80-81](../../../frontend/src/lib/ui-text.js#L80-L81) (the `// Charts` block), add one key:
+
+  ```diff
+     // Charts
+     showEmpty: "Show empty values",
+  +  noInformationAvailable: "No information available",
+  ```
+
+- [ ] No change to the `de` map at [line 1024](../../../frontend/src/lib/ui-text.js#L1024) — it stays empty and falls through to English.
+
+### 2.2 Swap the label in ChartRenderer
+
+File: [`frontend/src/components/dashboard/ChartRenderer.jsx`](../../../frontend/src/components/dashboard/ChartRenderer.jsx)
+
+- [ ] Add the import at the top of the file:
+  ```jsx
+  import uiText from "../../lib/ui-text";
+  ```
+
+- [ ] Find the row-mapping block that converts API rows into akvo-charts data. Wrap the `label` resolution to swap for `_no_info`:
+  ```jsx
+  const resolvedLabel = row.group === "_no_info"
+    ? uiText.en.noInformationAvailable
+    : row.label;
+  ```
+  Use `resolvedLabel` everywhere the old `row.label` was used in the `data` shape passed to `<Doughnut>`/`<Bar>`/etc.
+
+- [ ] Verify the synthetic row's `color` from the backend (`"#bfbfbf"`) flows through. If the chart's JSON config defines a `color` array, it overrides per-slice — that's existing precedence, leave alone.
+
+### 2.3 Lint + commit
+
+- [ ] Run lint inside the container (per the [feedback memory](../../../.claude/projects/-home-iwan-Akvo-akvo-mis/memory/feedback_lint_before_commit.md) and [CLAUDE.md ESLint rules](../../../CLAUDE.md)):
+  ```bash
+  ./dc.sh exec -T frontend npx eslint src/components/dashboard/ChartRenderer.jsx src/lib/ui-text.js
+  ```
+- [ ] Run prettier:
+  ```bash
+  cd frontend && yarn prettier --check src/components/dashboard/ChartRenderer.jsx src/lib/ui-text.js
+  ```
+- [ ] Commit:
+  ```
+  [#<issue>] feat(dashboard): translate _no_info label via ui-text
+
+  - Add noInformationAvailable key to ui-text.js Charts block.
+  - ChartRenderer swaps backend label for the i18n string when
+    row.group === "_no_info".
+  ```
+
+---
+
+## Phase 3 — Frontend: DashboardMap opt-in
+
+### 3.1 Wire `status_colors._no_info`
+
+File: [`frontend/src/components/dashboard/DashboardMap.jsx`](../../../frontend/src/components/dashboard/DashboardMap.jsx)
+
+- [ ] Add the `uiText` import.
+- [ ] In the marker-color resolution (look for `status_colors[answer]` or equivalent), add a fallback to `status_colors._no_info` when the answer is missing/null:
+  ```jsx
+  const colorFor = (answer) => {
+    if (answer && status_colors?.[answer]) {
+      return status_colors[answer];
+    }
+    if (status_colors?._no_info) {
+      return status_colors._no_info;
+    }
+    return undefined;
+  };
+  ```
+  Keep the existing brace style (CLAUDE.md: `curly: error`).
+
+- [ ] In the legend rendering, iterate every key of `status_colors` and translate `_no_info` to the i18n string:
+  ```jsx
+  const legendLabel = (key) =>
+    key === "_no_info" ? uiText.en.noInformationAvailable : labelFor(key);
+  ```
+
+### 3.2 Lint + commit
+
+- [ ] `./dc.sh exec -T frontend npx eslint src/components/dashboard/DashboardMap.jsx`
+- [ ] `cd frontend && yarn prettier --check src/components/dashboard/DashboardMap.jsx`
+- [ ] Commit:
+  ```
+  [#<issue>] feat(map): support _no_info color and legend entry
+
+  - DashboardMap honors status_colors._no_info as fallback color
+    for un-monitored markers.
+  - Legend renders _no_info entry with translated label.
+  - Behavior unchanged when status_colors._no_info is absent.
+  ```
+
+---
+
+## Phase 4 — Flip the existing dashboards on
+
+### 4.1 EPS Overview donut
+
+File: [`frontend/src/config/visualizations/1749623934933.json`](../../../frontend/src/config/visualizations/1749623934933.json)
+
+- [ ] Locate the operational-status donut item at [line 216](../../../frontend/src/config/visualizations/1749623934933.json#L216) (`"id": "chart_operational_status"`).
+- [ ] Add `"include_unanswered": true` to its `api` block:
+  ```diff
+   "api": {
+     "form_id": 1749632545233,
+     "question_id": 1749633373968,
+     "group_by": "option",
+  -  "monitoring": "latest"
+  +  "monitoring": "latest",
+  +  "include_unanswered": true
+   }
+  ```
+
+- [ ] (Optional) Extend `status_colors` on the map item at [line 193](../../../frontend/src/config/visualizations/1749623934933.json#L193) with `"_no_info": "#bfbfbf"` if the dashboard owner wants the gray map markers + legend.
+
+### 4.2 RWS Overview donut
+
+File: [`frontend/src/config/visualizations/1749621221728.json`](../../../frontend/src/config/visualizations/1749621221728.json)
+
+- [ ] Find the equivalent operational-status donut (search for `"chart_type": "doughnut"` near the operational-status section).
+- [ ] Add `"include_unanswered": true` to its `api` block.
+- [ ] (Optional) Add `"_no_info"` to the map's `status_colors`.
+
+### 4.3 Manual smoke
+
+- [ ] `./dc.sh up -d`
+- [ ] Open `http://localhost:3000/dashboard/eps-overview`. Verify:
+  - Donut "Operational Status" shows a gray slice at the end.
+  - Legend entry reads "No information available".
+  - Sum of donut slice values equals the "Total EPS registered" KPI above.
+  - Hover tooltip shows `"No information available: <count> (<percent>%)"`.
+- [ ] Apply an administration filter (drill into a sub-region):
+  - KPI total drops.
+  - Donut total drops in lockstep — slice count should remain consistent with the new KPI value.
+- [ ] Open `http://localhost:3000/dashboard/rws-overview`. Repeat the checks above.
+- [ ] Open browser DevTools → Network. Confirm the donut's `/visualization/values` request URL contains `include_unanswered=true`.
+- [ ] Confirm a chart on the same dashboard that does NOT have the flag (e.g. drinking-water compliance) renders byte-identically to before — no surprise regressions.
+- [ ] If `_no_info` color was added to the map: confirm un-monitored EPS render gray and the legend gains the new entry.
+
+### 4.4 Commit
+
+- [ ] Commit:
+  ```
+  [#<issue>] chore(dashboards): opt EPS + RWS donuts into _no_info bucket
+
+  Operational Status donut on both dashboards now reconciles with the
+  registration-total KPI. Map widgets gain the optional gray-marker
+  treatment when status_colors._no_info is set.
+  ```
+
+---
+
+## Phase 5 — Documentation
+
+### 5.1 Update visualization README
+
+File: [`frontend/src/config/visualizations/README.md`](../../../frontend/src/config/visualizations/README.md)
+
+- [ ] In the "Empty-data behaviour" section starting at [line 613](../../../frontend/src/config/visualizations/README.md#L613), add a paragraph after the existing `<EscalationTable>` line:
+
+  > **Un-monitored datapoints** — when an `api` block on a `group_by=option` chart sets `"include_unanswered": true`, the backend appends one synthetic row to the response: `{ value, label: "No information available", group: "_no_info", color: "#bfbfbf" }`. The bucket counts **distinct parent registrations** that have no qualifying answer for the question after all filters are applied; for `multiple_option` questions this is correctly computed as a distinct-parent count, not `total − sum`. The bucket joins the denominator when `value_type=percentage`, so single-choice rows sum to 100%. Map widgets opt in independently by adding `"_no_info": "<color>"` to their `status_colors` block.
+
+- [ ] Verify the README links resolve (relative paths still valid).
+
+### 5.2 Commit
+
+- [ ] Commit:
+  ```
+  [#<issue>] docs(dashboards): document include_unanswered flag
+  ```
+
+---
+
+## Phase 6 — Verify and PR
+
+### 6.1 Final verification
+
+- [ ] Backend full suite:
+  ```bash
+  ./dc.sh exec backend python manage.py test
+  ```
+- [ ] Backend lint:
+  ```bash
+  ./dc.sh exec backend flake8
+  ```
+- [ ] Frontend lint + prettier:
+  ```bash
+  cd frontend && npm run lint && npm run prettier
+  ```
+- [ ] Frontend tests:
+  ```bash
+  cd frontend && npm run test:ci
+  ```
+- [ ] `git status` — confirm only the expected files are modified.
+- [ ] `git log --oneline` — five commits present, all prefixed with `[#<issue>]`.
+
+### 6.2 Beads + PR
+
+- [ ] `bd close <issue>` (or do this after PR merge — team convention).
+- [ ] `bd sync --from-main`.
+- [ ] Push and open the PR. Body checklist:
+  - **Summary**: Adds opt-in `include_unanswered=true` flag to `/visualization/values` so dashboards can reconcile per-option totals with their parent-registration totals.
+  - **Behavior change note** (visible to stakeholders): the operational-status donut on `/dashboard/eps-overview` and `/dashboard/rws-overview` will now show a "No information available" slice. The number of *operational* and *issue_with_system* slices does not change; what changes is that the visible total now equals the registered EPS total. This is the correct number — no underlying data has changed.
+  - **Migration**: none.
+  - **Test plan**: backend tests + manual smoke per Phase 4.3.
+  - **Out of scope**: see [README.md "Out of scope"](./README.md#out-of-scope-explicitly-deferred).
+
+---
+
+## Files touched (summary)
+
+Backend:
+- [`backend/api/v1/v1_visualization/dashboard_serializers.py`](../../../backend/api/v1/v1_visualization/dashboard_serializers.py) — new field
+- [`backend/api/v1/v1_visualization/values_functions.py`](../../../backend/api/v1/v1_visualization/values_functions.py) — new helper, modified `_option_group_by_option`, wired in `handle_option_question`
+- [`backend/api/v1/v1_visualization/tests/tests_values_option.py`](../../../backend/api/v1/v1_visualization/tests/tests_values_option.py) — 10 new tests
+
+Frontend:
+- [`frontend/src/lib/ui-text.js`](../../../frontend/src/lib/ui-text.js) — new key
+- [`frontend/src/components/dashboard/ChartRenderer.jsx`](../../../frontend/src/components/dashboard/ChartRenderer.jsx) — label swap
+- [`frontend/src/components/dashboard/DashboardMap.jsx`](../../../frontend/src/components/dashboard/DashboardMap.jsx) — color + legend opt-in
+
+Configs:
+- [`frontend/src/config/visualizations/1749623934933.json`](../../../frontend/src/config/visualizations/1749623934933.json) — donut + (optional) map opts in
+- [`frontend/src/config/visualizations/1749621221728.json`](../../../frontend/src/config/visualizations/1749621221728.json) — donut + (optional) map opts in
+- [`frontend/src/config/visualizations/README.md`](../../../frontend/src/config/visualizations/README.md) — new paragraph
+
+Total: **9 files**, ~6 commits, no migrations, no new dependencies.
+
+---
+
+## Rollback
+
+If a regression is reported post-merge:
+
+1. Quick mitigation: revert the two dashboard JSON changes (Phase 4) only. The donuts go back to the legacy "answered universe" view; backend and shared frontend code stay deployed but inert until any chart re-opts in.
+2. Full rollback: `git revert` the merge commit. No DB migration to reverse.
+
+The opt-in design means a regression cannot reach a dashboard that didn't explicitly enable the flag.

--- a/doc/claude/no-available-info-in-vis-values-api/requirements.md
+++ b/doc/claude/no-available-info-in-vis-values-api/requirements.md
@@ -1,0 +1,187 @@
+# "No information available" bucket — Requirements
+
+Locked functional and non-functional requirements for the opt-in `_no_info` bucket on `/api/v1/visualization/values`.
+
+For architecture, SQL, and the implementation plan, see [design.md](./design.md). For the rationale behind each decision, see the "Decisions locked from brainstorm" table in [README.md](./README.md).
+
+---
+
+## Problem statement
+
+The visualization API exposes two endpoints whose outputs do not reconcile when monitoring data is incomplete:
+
+- `GET /api/v1/visualization/values?form_id=<registration_form>` returns the total number of registered datapoints (e.g. **104** EPS).
+- `GET /api/v1/visualization/values?form_id=<monitoring_form>&group_by=option&question_id=<status_question>` returns counts per option that sum to **≤ 104** because only datapoints with a monitoring submission contribute.
+
+The donut chart at [`frontend/src/config/visualizations/1749623934933.json:216`](../../../frontend/src/config/visualizations/1749623934933.json#L216) shows 80 EPS by status while the KPIs above it claim 104 EPS exist. The 24 un-monitored EPS disappear, hiding both a data-quality gap and the correct denominator from the dashboard reader.
+
+**Goal**: surface the gap as a single, clearly-labelled bucket so totals reconcile and the data-quality issue is visible.
+
+---
+
+## Functional requirements
+
+### FR-1 — Synthetic bucket emission (backend)
+
+When `/api/v1/visualization/values` receives `include_unanswered=true` and the response shape is one of the supported variants (see FR-7), append one extra row to the response:
+
+```json
+{
+  "value": <count>,
+  "label": "No information available",
+  "group": "_no_info",
+  "color": "#bfbfbf"
+}
+```
+
+The bucket appears at the **end** of the response array so existing consumers reading by index do not break.
+
+### FR-2 — Definition of "no information available"
+
+A parent registration contributes to the bucket when, **after applying every filter on the request** (administration, date range, criteria, monitoring scope), one of the following holds:
+
+- The parent has no submission on the monitoring form for the question, **or**
+- The parent's qualifying monitoring submission has a null/empty answer for the question.
+
+Both cases collapse to the single `_no_info` bucket. Splitting them is explicitly deferred (see [README.md "Out of scope"](./README.md#out-of-scope-explicitly-deferred)).
+
+### FR-3 — Filter parity
+
+The bucket count and the option counts are computed against the **same filtered parent universe**. This is what makes the totals reconcile under filtering — administration drilldown, date range, and criteria filters must all narrow the bucket the same way they narrow the option counts.
+
+### FR-4 — Multiple-option semantics
+
+For `multiple_option` questions a single record may answer multiple options, so `total_parents − sum(option_counts)` over-counts the gap. The bucket count is computed as:
+
+> the count of **distinct parents** in the filtered universe whose qualifying monitoring submission answered **none** of the question's options.
+
+For single-choice `option` questions, the same definition is equivalent to `total_parents − sum(option_counts)`, but the implementation uses the distinct-parent query uniformly so behavior is consistent across question types.
+
+### FR-5 — Opt-in only
+
+Default behavior is unchanged. The bucket only appears when the request explicitly includes `include_unanswered=true`. Without the flag, every existing consumer (`stack_bar cross_tab`, `kpi_stack`, `share_card`, KPI tiles, etc.) gets byte-identical output.
+
+### FR-6 — Percentages stay coherent
+
+When `value_type=percentage` AND `include_unanswered=true`, the synthetic bucket participates in the denominator. The N+1 rows of the response sum to 100%. Without the flag, percentages are computed as today (over the answered universe only).
+
+### FR-7 — Supported endpoint shapes
+
+The bucket is emitted when **all** of the following hold:
+
+- The request specifies a `question_id` whose form is a **monitoring form** (i.e. `Forms.parent` is not null).
+- The question type is `option` or `multiple_option`.
+- The request shape matches one of:
+  - `group_by=option` (donut / single-axis bar chart)
+  - `share_card` semantics (single-fetch share KPI — see [README.md:372 "Share KPI cards"](../../../frontend/src/config/visualizations/README.md#L372))
+
+The bucket is **not** emitted (flag is silently ignored) for:
+
+- Registration-form questions — every row in the registration form is a registration; there is no gap to surface.
+- Count mode (no `question_id`) — there is no per-option breakdown to compare against.
+- `option_value=X` scalar / KPI mode — already serviceable via `denominator_api`.
+- `stack_by=option` with `group_by=parent_id` — the per-parent row layout makes the gap implicit.
+- `group_by=month` / `group_by=date` time-series shapes — the gap concept is not well-defined per time bucket in v1.
+
+### FR-8 — Soft-deleted parents excluded
+
+The un-monitored count uses `FormData.objects` (the default manager that filters soft-deletes via the `SoftDeletes` mixin per the backend conventions in [`CLAUDE.md`](../../../CLAUDE.md)). A parent that has been soft-deleted is not counted, even if a stale monitoring record orphaned by it still exists.
+
+### FR-9 — Frontend label is i18n-ready
+
+The frontend labels the bucket using a single string constant in [`frontend/src/lib/ui-text.js`](../../../frontend/src/lib/ui-text.js):
+
+```js
+// Charts
+showEmpty: "Show empty values",
+noInformationAvailable: "No information available",
+```
+
+Consumers ([`ChartRenderer.jsx`](../../../frontend/src/components/dashboard/ChartRenderer.jsx), [`DashboardMap.jsx`](../../../frontend/src/components/dashboard/DashboardMap.jsx), and any future widget) reference `uiText.en.noInformationAvailable`. The German locale `de` already exists as an empty map and will pick up translations when populated.
+
+### FR-10 — Map widget opts in via `status_colors._no_info`
+
+[`DashboardMap.jsx`](../../../frontend/src/components/dashboard/DashboardMap.jsx) renders un-monitored parents in the dashboard's chosen gray when (and only when) the map item config defines `status_colors._no_info`:
+
+```json
+"status_colors": {
+  "operational": "#64A73B",
+  "issue_with_system": "#e41a1c",
+  "_no_info": "#bfbfbf"
+}
+```
+
+The map legend gains a corresponding "No information available" entry under the same condition. When the key is absent, behavior is unchanged: un-monitored EPS render with whatever the current default is.
+
+### FR-11 — `share_card` honors the flag
+
+When a `share_card`'s `api` block includes `include_unanswered: true`:
+
+- Numerator (the row whose `group` matches `target_group`) is unchanged.
+- Denominator (sum of every row's `value`) now includes the `_no_info` row.
+
+The visible effect is that "Operational EPS share" reads as a share of **all registered EPS**, not just monitored EPS. Dashboards that prefer the legacy "share of monitored" framing simply omit the flag.
+
+### FR-12 — Existing dashboards opt in
+
+The locked-in scope of this work flips two existing donuts on:
+
+- Operational status donut at [`1749623934933.json`](../../../frontend/src/config/visualizations/1749623934933.json) (EPS Overview): add `"include_unanswered": true` to the donut's `api` block.
+- Operational status donut at [`1749621221728.json`](../../../frontend/src/config/visualizations/1749621221728.json) (RWS Overview): same change.
+
+Each dashboard's map widget MAY also opt in by adding `status_colors._no_info` — discussed in [design.md "Frontend wiring"](./design.md#frontend-wiring).
+
+---
+
+## Non-functional requirements
+
+### NFR-1 — Backwards compatible
+
+Every existing test, dashboard, mobile-app fetch, and undocumented external integration that reads `/visualization/values` continues to receive byte-identical responses unless they explicitly send `include_unanswered=true`.
+
+### NFR-2 — Single round trip
+
+The bucket count is computed inside the same backend request as the rest of the response. The frontend never makes a second fetch to derive the gap.
+
+### NFR-3 — Performance
+
+The bucket adds at most one `COUNT(DISTINCT parent_id)` query over the already-filtered parent set. No N+1 query patterns. For typical dashboards (≤ 1000 registered parents) the added latency is negligible.
+
+### NFR-4 — Documented
+
+The dashboard config README at [`frontend/src/config/visualizations/README.md`](../../../frontend/src/config/visualizations/README.md) gains a paragraph in the "Empty-data behaviour" section ([README.md:613](../../../frontend/src/config/visualizations/README.md#L613)) describing:
+
+- The opt-in `include_unanswered=true` flag.
+- The reserved `_no_info` group key and its single-bucket multi-option semantics.
+- The opt-in `status_colors._no_info` for maps.
+
+### NFR-5 — i18n-ready
+
+All user-visible strings introduced by this work flow through [`ui-text.js`](../../../frontend/src/lib/ui-text.js) per FR-9. No hard-coded English strings in JSX or chart configs.
+
+### NFR-6 — Tested
+
+Backend test coverage matches the existing pattern at [`tests_values_option.py`](../../../backend/api/v1/v1_visualization/tests/tests_values_option.py): one test per supported shape, plus negative tests confirming the flag has no effect on out-of-scope shapes (FR-7).
+
+---
+
+## Scope matrix
+
+| Endpoint shape | `include_unanswered=true` effect |
+|---|---|
+| `group_by=option` (donut/single-axis bar) | N+1 rows; bucket appended |
+| `group_by=option, value_type=percentage` | N+1 rows; percentages sum to 100% |
+| `share_card` (no explicit `group_by`, `target_group` set) | N+1 rows; denominator includes bucket |
+| `option_value=X, sum_by=parent_id` (scalar KPI) | flag ignored — use `denominator_api` |
+| `stack_by=option, group_by=parent_id` (per-parent stack) | flag ignored — gap is implicit |
+| `group_by=month` / `group_by=date` (time series) | flag ignored — out of scope v1 |
+| Registration-form question | flag ignored — no gap |
+| Count mode (no `question_id`) | flag ignored — no per-option breakdown |
+
+---
+
+## Open questions / risks
+
+None — all open questions from the brainstorm round have been resolved (see [README.md "Decisions locked"](./README.md#decisions-locked-from-brainstorm)).
+
+A risk worth flagging in the PR description: when [`1749623934933.json`](../../../frontend/src/config/visualizations/1749623934933.json) and [`1749621221728.json`](../../../frontend/src/config/visualizations/1749621221728.json) flip the flag on, the visible numbers in the donut change. This is the **correct** number, but it's a **changed** number — a stakeholder note should accompany the merge.

--- a/frontend/src/components/dashboard/ChartRenderer.jsx
+++ b/frontend/src/components/dashboard/ChartRenderer.jsx
@@ -22,11 +22,40 @@ const COMPONENT_BY_TYPE = {
 };
 
 /**
+ * akvo-charts' `transformConfig` hardcodes its default tooltip and does NOT
+ * read `config.tooltip` — so a tooltip block in the visualization JSON is
+ * silently dropped. Surface it here as a setOption patch so configs can
+ * customise trigger / formatter (string template, HTML, or rich-text via
+ * https://echarts.apache.org/examples/en/editor.html?c=pie-rich-text) per
+ * chart. Returned object is spread into the wrapper's setOption call with
+ * notMerge=false so unspecified fields keep akvo-charts' defaults.
+ */
+const tooltipPatch = (config) =>
+  config?.tooltip ? { tooltip: config.tooltip } : {};
+
+/**
+ * Reshape ChartRenderer's `[{label, value}]` rows into ECharts' native
+ * pie data format `[{name, value}]`. Used by the pie/doughnut wrappers to
+ * override `series[0].data` post-mount and bypass akvo-charts' dataset
+ * +encode binding — that binding causes the tooltip's `{c}` placeholder
+ * to render the dataset row object as "[object Object]" instead of the
+ * scalar value (only an issue for pie series; bar/line resolve scalars
+ * correctly from dataset+encode because they have axes).
+ */
+const toPieSeriesData = (rows) =>
+  (rows || []).map((r) => ({ name: r.label, value: r.value }));
+
+/**
  * Wrap a pie/doughnut Component so we can hide the outer slice callout
- * labels after mount. akvo-charts doesn't expose a label-config prop
- * and its internal setOption replaces rather than merges — so we grab
- * the ECharts instance via ref and setOption with notMerge=false to
- * layer label:{show:false} on top while preserving dataset + encode.
+ * labels after mount AND swap dataset+encode for direct `series.data` so
+ * tooltip `{c}` resolves to the scalar value (matches the official
+ * https://echarts.apache.org/examples/en/editor.html?c=pie-rich-text
+ * tooltip-formatter behaviour).
+ *
+ * akvo-charts doesn't expose label-config or data-binding props, so we
+ * grab the ECharts instance via ref and setOption with notMerge=false to
+ * layer overrides on top of akvo-charts' own setOption (which runs first
+ * each render).
  *
  * Uses the same callback-ref + empty-deps pattern as ChartWithMarkLines
  * (see long comment there): akvo-charts' useImperativeHandle only
@@ -46,7 +75,14 @@ const PieWithHiddenLabels = ({ Component, commonProps }) => {
     }
     chart.setOption(
       {
-        series: [{ label: { show: false }, labelLine: { show: false } }],
+        series: [
+          {
+            label: { show: false },
+            labelLine: { show: false },
+            data: toPieSeriesData(commonProps.data),
+          },
+        ],
+        ...tooltipPatch(commonProps.config),
       },
       false
     );
@@ -97,8 +133,10 @@ const HalfDoughnut = ({ Component, commonProps }) => {
             radius: ["55%", "85%"],
             label: { show: false },
             labelLine: { show: false },
+            data: toPieSeriesData(commonProps.data),
           },
         ],
+        ...tooltipPatch(commonProps.config),
       },
       false
     );
@@ -239,6 +277,7 @@ const ChartWithMarkLines = ({ Component, commonProps, markLines, today }) => {
             },
           },
         ],
+        ...tooltipPatch(commonProps.config),
       },
       false
     );
@@ -269,6 +308,11 @@ const ChartWithScrollLegend = ({ Component, commonProps }) => {
       setChart((prev) => prev || instance);
     }
   }, []);
+  // Horizontal stack/bar charts (bar-y-category style — see
+  // https://echarts.apache.org/examples/en/editor.html?c=bar-y-category)
+  // put the category labels on the y-axis, so the per-item axis override
+  // must follow the category axis rather than always landing on x.
+  const horizontal = Boolean(commonProps.config?.horizontal);
   // Per-item overrides via config.xAxis: { rotate, interval, nameGap }.
   // Lets horizontal bar charts (numeric x-axis) opt out of the default
   // 20° rotation that exists for long category labels.
@@ -277,28 +321,31 @@ const ChartWithScrollLegend = ({ Component, commonProps }) => {
     if (!chart) {
       return;
     }
+    // Align category-axis ticks with labels (not between them) — see
+    // https://echarts.apache.org/examples/en/editor.html?c=bar-tick-align.
+    // Force interval=0 so every category label renders; ECharts' default
+    // "auto" silently drops labels it judges overlapping — which hid
+    // Settlements / Government Stations / Healthcare Facility on the RWS
+    // Beneficiaries bar (akvo-mis-db9). Modest rotate keeps long
+    // multi-word labels from colliding horizontally. nameGap=64 pushes
+    // the axis name (e.g. "Target group") below the rotated labels —
+    // default nameGap=15 lands right on top of them (akvo-mis-c01).
+    const categoryAxisOverride = {
+      axisTick: { alignWithLabel: true },
+      axisLabel: {
+        interval: xAxisOverride?.axisLabel?.interval ?? 0,
+        rotate: xAxisOverride?.axisLabel?.rotate ?? 0,
+      },
+      nameGap: xAxisOverride?.nameGap ?? 48,
+      nameLocation: "middle",
+    };
     chart.setOption(
       {
         legend: { type: "scroll" },
-        // Align x-axis ticks with labels (not between them) — see
-        // https://echarts.apache.org/examples/en/editor.html?c=bar-tick-align.
-        // Force interval=0 so every category label renders; ECharts'
-        // default "auto" silently drops labels it judges overlapping —
-        // which hid Settlements / Government Stations / Healthcare Facility
-        // on the RWS Beneficiaries bar (akvo-mis-db9). Modest rotate keeps
-        // long multi-word labels from colliding horizontally. nameGap=64
-        // pushes the axis name (e.g. "Target group") below the rotated
-        // labels — default nameGap=15 lands right on top of them
-        // (akvo-mis-c01).
-        xAxis: {
-          axisTick: { alignWithLabel: true },
-          axisLabel: {
-            interval: xAxisOverride?.axisLabel?.interval ?? 0,
-            rotate: xAxisOverride?.axisLabel?.rotate ?? 0,
-          },
-          nameGap: xAxisOverride?.nameGap ?? 48,
-          nameLocation: "middle",
-        },
+        ...(horizontal
+          ? { yAxis: categoryAxisOverride }
+          : { xAxis: categoryAxisOverride }),
+        ...tooltipPatch(commonProps.config),
       },
       false
     );
@@ -548,8 +595,16 @@ const ChartRenderer = ({
   // are no-ops — those live in the setOption-after-mount wrappers above.
   const rawOverrides = item.raw_overrides;
 
+  // Schema flag → akvo-charts' StackBar/Bar `config.horizontal`, which
+  // swaps axes (xAxis becomes value, yAxis becomes category) per
+  // https://echarts.apache.org/examples/en/editor.html?c=bar-y-category.
+  const horizontal = item.orientation === "horizontal";
+
   const commonProps = {
-    config: item.config || {},
+    config: {
+      ...(item.config || {}),
+      ...(horizontal ? { horizontal: true } : {}),
+    },
     data,
     rawConfig: item.raw_config,
     rawOverrides,

--- a/frontend/src/components/dashboard/ChartRenderer.jsx
+++ b/frontend/src/components/dashboard/ChartRenderer.jsx
@@ -3,6 +3,7 @@ import PropTypes from "prop-types";
 import { Bar, Doughnut, Line, Pie, StackBar } from "akvo-charts";
 import { Alert, Skeleton } from "antd";
 import { useDashboardValues, useDashboardProgress } from "../../util/hooks";
+import uiText from "../../lib/ui-text";
 import { toHistogramBarData } from "./compute/progressHistogram";
 import { computeComplianceStackData } from "./compute/compliance";
 import { rotateToFiscalOrder } from "./compute/fiscalMonthRotation";
@@ -420,7 +421,7 @@ const ChartRenderer = ({
   const isApiDriven =
     (Boolean(Component) || isDots) &&
     Boolean(item.api) &&
-    !item.compute &&
+    (!item.compute || (item.compute === "kpi_stack" && !item.segments)) &&
     !item.source;
 
   const {
@@ -472,12 +473,28 @@ const ChartRenderer = ({
     }
 
     if (item.compute === "kpi_stack") {
-      const responses = computeResponses?.kpi_stack?.[item.id];
-      return computeKpiStack(
-        item.segments,
-        responses,
-        item.config?.title || "Total"
-      );
+      if (item.segments) {
+        const responses = computeResponses?.kpi_stack?.[item.id];
+        return computeKpiStack(
+          item.segments,
+          responses,
+          item.config?.title || "Total"
+        );
+      }
+      // api-driven kpi_stack: single /values call with group_by=option;
+      // rows become stack segments dynamically
+      const rows = apiData?.data || [];
+      if (!rows.length) {
+        return [];
+      }
+      const category = item.config?.title || "Total";
+      const row = { category };
+      rows.forEach((r) => {
+        const label =
+          r.group === "_no_info" ? uiText.en.noInformationAvailable : r.label;
+        row[label] = r.value ?? 0;
+      });
+      return [row];
     }
 
     if (item.compute === "compliance") {
@@ -536,7 +553,11 @@ const ChartRenderer = ({
           extendTo,
         });
       }
-      return rows.map((r) => ({ label: r.label, value: r.value }));
+      return rows.map((r) => ({
+        label:
+          r.group === "_no_info" ? uiText.en.noInformationAvailable : r.label,
+        value: r.value,
+      }));
     }
     return [];
   }, [

--- a/frontend/src/components/dashboard/DashboardMap.jsx
+++ b/frontend/src/components/dashboard/DashboardMap.jsx
@@ -164,9 +164,9 @@ const DashboardMap = ({
             marginBottom: 8,
           }}
         >
-          {legendEntries.map(({ color, label }) => (
+          {legendEntries.map(({ color, label }, index) => (
             <span
-              key={label}
+              key={index}
               style={{ display: "flex", alignItems: "center", gap: 4 }}
             >
               <span

--- a/frontend/src/components/dashboard/DashboardMap.jsx
+++ b/frontend/src/components/dashboard/DashboardMap.jsx
@@ -5,6 +5,7 @@ import { Alert, Skeleton } from "antd";
 import "leaflet/dist/leaflet.css";
 import { api, geo } from "../../lib";
 import { applyDashboardFilters } from "../../lib/dashboardFilterHints";
+import uiText from "../../lib/ui-text";
 
 const DEFAULT_COLOR = "#1890ff";
 
@@ -115,11 +116,25 @@ const DashboardMap = ({
   const colorForParent = (parentId) => {
     const label = statusByParent[parentId];
     if (!label) {
-      return DEFAULT_COLOR;
+      return statusColors._no_info || DEFAULT_COLOR;
     }
     const slug = label.toLowerCase().replace(/\s+/g, "_");
     return statusColors[slug] || statusColors[label] || DEFAULT_COLOR;
   };
+
+  const legendEntries = useMemo(() => {
+    const colors = item?.status_colors || {};
+    if (!Object.keys(colors).length) {
+      return [];
+    }
+    return Object.entries(colors).map(([key, color]) => ({
+      color,
+      label:
+        key === "_no_info"
+          ? uiText.en.noInformationAvailable
+          : key.replace(/_/g, " "),
+    }));
+  }, [item]);
 
   const buildUrl = (pointId) =>
     urlTemplate
@@ -139,50 +154,80 @@ const DashboardMap = ({
   }
 
   return (
-    <MapContainer
-      center={center}
-      zoom={7}
-      style={{ height, width: "100%" }}
-      scrollWheelZoom={false}
-    >
-      <TileLayer
-        attribution='&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a>'
-        url="https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png"
-      />
-      {points
-        .filter((p) => Array.isArray(p.geo) && p.geo.length === 2)
-        .map((p) => (
-          <CircleMarker
-            key={p.id}
-            center={p.geo}
-            radius={7}
-            pathOptions={{
-              color: colorForParent(String(p.id)),
-              fillColor: colorForParent(String(p.id)),
-              fillOpacity: 0.9,
-              weight: 1,
-            }}
-            eventHandlers={{
-              click: () =>
-                window.open(buildUrl(p.id), "_blank", "noopener,noreferrer"),
-            }}
-          >
-            <Popup>
-              <div>
-                <strong>{p.name || `EPS #${p.id}`}</strong>
-                <br />
-                <a
-                  href={buildUrl(p.id)}
-                  target="_blank"
-                  rel="noopener noreferrer"
-                >
-                  Open monitoring
-                </a>
-              </div>
-            </Popup>
-          </CircleMarker>
-        ))}
-    </MapContainer>
+    <div>
+      {legendEntries.length > 0 && (
+        <div
+          style={{
+            display: "flex",
+            flexWrap: "wrap",
+            gap: 12,
+            marginBottom: 8,
+          }}
+        >
+          {legendEntries.map(({ color, label }) => (
+            <span
+              key={label}
+              style={{ display: "flex", alignItems: "center", gap: 4 }}
+            >
+              <span
+                style={{
+                  display: "inline-block",
+                  width: 12,
+                  height: 12,
+                  borderRadius: "50%",
+                  background: color,
+                }}
+              />
+              {label}
+            </span>
+          ))}
+        </div>
+      )}
+      <MapContainer
+        center={center}
+        zoom={7}
+        style={{ height, width: "100%" }}
+        scrollWheelZoom={false}
+      >
+        <TileLayer
+          attribution='&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a>'
+          url="https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png"
+        />
+        {points
+          .filter((p) => Array.isArray(p.geo) && p.geo.length === 2)
+          .map((p) => (
+            <CircleMarker
+              key={p.id}
+              center={p.geo}
+              radius={7}
+              pathOptions={{
+                color: colorForParent(String(p.id)),
+                fillColor: colorForParent(String(p.id)),
+                fillOpacity: 0.9,
+                weight: 1,
+              }}
+              eventHandlers={{
+                click: () =>
+                  window.open(buildUrl(p.id), "_blank", "noopener,noreferrer"),
+              }}
+            >
+              <Popup>
+                <div>
+                  <strong>{p.name || `EPS #${p.id}`}</strong>
+                  <br />
+                  <a
+                    href={buildUrl(p.id)}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                  >
+                    Open monitoring
+                  </a>
+                </div>
+              </Popup>
+            </CircleMarker>
+          ))}
+      </MapContainer>
+    </div>
   );
 };
 

--- a/frontend/src/components/dashboard/DashboardRenderer.jsx
+++ b/frontend/src/components/dashboard/DashboardRenderer.jsx
@@ -5,6 +5,7 @@ import ChartRenderer from "./ChartRenderer";
 import DashboardMap from "./DashboardMap";
 import EscalationTable from "./EscalationTable";
 import KPICard from "./widgets/KPICard";
+import MetricCard from "./widgets/MetricCard";
 import SectionTitleWidget from "./widgets/SectionTitleWidget";
 import FilterBarWidget from "./widgets/FilterBarWidget";
 import TabsWidget from "./widgets/TabsWidget";
@@ -133,6 +134,18 @@ const DashboardRenderer = ({
           today={today}
           definitionsById={definitionsById}
           computeResponses={resolvedComputeResponses}
+        />
+      );
+    }
+
+    if (type === "metric_card") {
+      return (
+        <MetricCard
+          item={item}
+          filterState={filterState}
+          fiscalYearStartMonth={fiscalYearStartMonth}
+          customFilterDefs={customFilterDefs}
+          today={today}
         />
       );
     }

--- a/frontend/src/components/dashboard/widgets/MetricCard.jsx
+++ b/frontend/src/components/dashboard/widgets/MetricCard.jsx
@@ -1,0 +1,135 @@
+import React, { useMemo } from "react";
+import PropTypes from "prop-types";
+import { Card, Skeleton, Statistic } from "antd";
+import { useDashboardValues } from "../../../util/hooks";
+
+/**
+ * Generic metric tile with single-fetch share/scalar support — a slimmer
+ * alternative to KPICard that derives the denominator from the same
+ * `/visualization/values` response as the numerator instead of issuing a
+ * separate `denominator_api` fetch.
+ *
+ * Four display modes, dispatched on the presence of `target_group` and
+ * the `show_percentage` flag:
+ *
+ *  - **Scalar count** (no `target_group`, no `show_percentage`): renders
+ *    `data[0].value` directly — e.g. `"Total EPS registered: 40"`.
+ *  - **Scalar percentage** (no `target_group`, `show_percentage: true`):
+ *    renders `data[0].value` with a `%` suffix — e.g. `"40%"`.
+ *  - **Share** (`target_group` set, no `show_percentage`): backend
+ *    returns one row per group (`{ value, label, group }[]`). The matching
+ *    `group` row's value is the numerator, the sum of every row's value is
+ *    the denominator — e.g. `"2/3"`.
+ *  - **Share with percentage** (`target_group` set, `show_percentage:
+ *    true`): same as share, with `(P%)` appended — e.g. `"2/3 (66%)"`.
+ *
+ * In share modes a missing/zero denominator renders `"—"`.
+ *
+ * `target_group` is a frontend-only signal and is stripped before the api
+ * block hits `/visualization/values` (the backend rejects unknown fields on
+ * its enum-validated request schema).
+ */
+const stripFrontendApiFields = (api) => {
+  const rest = { ...api };
+  delete rest.target_group;
+  return rest;
+};
+
+const isMissingPair = (numerator, denominator) =>
+  numerator === null ||
+  typeof numerator === "undefined" ||
+  denominator === null ||
+  typeof denominator === "undefined" ||
+  denominator === 0;
+
+const formatRatioPercentage = (numerator, denominator) => {
+  if (isMissingPair(numerator, denominator)) {
+    return "—";
+  }
+  const pct = Math.round((numerator / denominator) * 100);
+  return `${numerator}/${denominator} (${pct}%)`;
+};
+
+const formatShare = (numerator, denominator) => {
+  if (isMissingPair(numerator, denominator)) {
+    return "—";
+  }
+  return `${numerator}/${denominator}`;
+};
+
+const MetricCard = ({
+  item,
+  filterState,
+  today,
+  fiscalYearStartMonth,
+  customFilterDefs,
+}) => {
+  const target = item?.target_group;
+  const showPercentage = Boolean(item.show_percentage);
+
+  const apiForFetch = useMemo(
+    () => (item.api ? stripFrontendApiFields(item.api) : null),
+    [item.api]
+  );
+
+  const { data, loading, error } = useDashboardValues(
+    apiForFetch,
+    filterState,
+    {
+      today,
+      fiscalYearStartMonth,
+      customFilterDefs,
+      enabled: Boolean(apiForFetch),
+    }
+  );
+
+  const rows = data?.data || [];
+
+  let displayValue = "—";
+  if (target) {
+    const numerator = rows.find((r) => r.group === target)?.value ?? 0;
+    const denominator = rows.reduce((acc, r) => acc + (r.value || 0), 0);
+    displayValue = showPercentage
+      ? formatRatioPercentage(numerator, denominator)
+      : formatShare(numerator, denominator);
+  } else {
+    const v = rows[0]?.value;
+    if (v !== null && typeof v !== "undefined") {
+      displayValue = showPercentage ? `${v}%` : v;
+    }
+  }
+
+  return (
+    <Card
+      {...(item.color
+        ? { style: { borderTop: `3px solid ${item.color}` } }
+        : {})}
+      data-testid={`metric-card-${item.id}`}
+    >
+      {loading ? (
+        <Skeleton active paragraph={{ rows: 1 }} />
+      ) : (
+        <Statistic
+          title={item.label}
+          value={displayValue}
+          {...(item.color ? { valueStyle: { color: item.color } } : {})}
+        />
+      )}
+      {error && (
+        <div role="alert" style={{ color: "#e41a1c", fontSize: 12 }}>
+          {error.message || "Failed to load"}
+        </div>
+      )}
+    </Card>
+  );
+};
+
+MetricCard.propTypes = {
+  item: PropTypes.object.isRequired,
+  filterState: PropTypes.object,
+  today: PropTypes.instanceOf(Date),
+  fiscalYearStartMonth: PropTypes.number,
+  customFilterDefs: PropTypes.array,
+};
+
+export default MetricCard;

--- a/frontend/src/components/dashboard/widgets/MetricCard.jsx
+++ b/frontend/src/components/dashboard/widgets/MetricCard.jsx
@@ -87,11 +87,14 @@ const MetricCard = ({
 
   let displayValue = "—";
   if (target) {
-    const numerator = rows.find((r) => r.group === target)?.value ?? 0;
-    const denominator = rows.reduce((acc, r) => acc + (r.value || 0), 0);
-    displayValue = showPercentage
-      ? formatRatioPercentage(numerator, denominator)
-      : formatShare(numerator, denominator);
+    const targetRow = rows.find((r) => r.group === target);
+    if (targetRow) {
+      const numerator = targetRow.value ?? 0;
+      const denominator = rows.reduce((acc, r) => acc + (r.value || 0), 0);
+      displayValue = showPercentage
+        ? formatRatioPercentage(numerator, denominator)
+        : formatShare(numerator, denominator);
+    }
   } else {
     const v = rows[0]?.value;
     if (v !== null && typeof v !== "undefined") {

--- a/frontend/src/components/dashboard/widgets/__test__/MetricCard.test.jsx
+++ b/frontend/src/components/dashboard/widgets/__test__/MetricCard.test.jsx
@@ -1,0 +1,149 @@
+import React from "react";
+import { render, screen } from "@testing-library/react";
+import axios from "axios";
+import MetricCard from "../MetricCard";
+import { __clearVisualizationCache } from "../../../../util/hooks/useVisualizationRequest";
+
+jest.mock("axios");
+
+const emptyFilters = {
+  from_date: null,
+  to_date: null,
+  administration_id: null,
+  custom: [],
+};
+
+const axiosRows = (rows) =>
+  axios.mockResolvedValueOnce({ data: { data: rows } });
+
+beforeEach(() => {
+  axios.mockReset();
+  __clearVisualizationCache();
+});
+
+const baseItem = {
+  id: "kpi_test",
+  chart_type: "metric_card",
+  label: "Test KPI",
+  api: { form_id: 1, question_id: 2, group_by: "option" },
+};
+
+describe("MetricCard — scalar mode (no target_group)", () => {
+  test("renders raw value when show_percentage is absent", async () => {
+    axiosRows([{ group: "total", value: 40 }]);
+    render(<MetricCard item={baseItem} filterState={emptyFilters} />);
+    expect(await screen.findByText("40")).toBeInTheDocument();
+  });
+
+  test("appends % suffix when show_percentage is true", async () => {
+    axiosRows([{ group: "total", value: 75 }]);
+    render(
+      <MetricCard
+        item={{ ...baseItem, show_percentage: true }}
+        filterState={emptyFilters}
+      />
+    );
+    expect(await screen.findByText("75%")).toBeInTheDocument();
+  });
+
+  test("renders — when api returns no rows", async () => {
+    axiosRows([]);
+    render(<MetricCard item={baseItem} filterState={emptyFilters} />);
+    expect(await screen.findByText("—")).toBeInTheDocument();
+  });
+});
+
+describe("MetricCard — share mode (target_group set)", () => {
+  const shareItem = { ...baseItem, target_group: "operational" };
+
+  test("renders N/M share when show_percentage is absent", async () => {
+    axiosRows([
+      { group: "operational", value: 3 },
+      { group: "non_functional", value: 2 },
+    ]);
+    render(<MetricCard item={shareItem} filterState={emptyFilters} />);
+    expect(await screen.findByText("3/5")).toBeInTheDocument();
+  });
+
+  test("renders N/M (P%) when show_percentage is true", async () => {
+    axiosRows([
+      { group: "operational", value: 2 },
+      { group: "non_functional", value: 2 },
+    ]);
+    render(
+      <MetricCard
+        item={{ ...shareItem, show_percentage: true }}
+        filterState={emptyFilters}
+      />
+    );
+    expect(await screen.findByText("2/4 (50%)")).toBeInTheDocument();
+  });
+
+  test("rounds percentage to nearest integer", async () => {
+    axiosRows([
+      { group: "operational", value: 1 },
+      { group: "non_functional", value: 2 },
+    ]);
+    render(
+      <MetricCard
+        item={{ ...shareItem, show_percentage: true }}
+        filterState={emptyFilters}
+      />
+    );
+    // 1/3 = 33.33... → 33%
+    expect(await screen.findByText("1/3 (33%)")).toBeInTheDocument();
+  });
+
+  test("renders — when denominator is zero (all values zero)", async () => {
+    axiosRows([
+      { group: "operational", value: 0 },
+      { group: "non_functional", value: 0 },
+    ]);
+    render(
+      <MetricCard
+        item={{ ...shareItem, show_percentage: true }}
+        filterState={emptyFilters}
+      />
+    );
+    expect(await screen.findByText("—")).toBeInTheDocument();
+  });
+
+  test("renders — when target_group row is missing from response", async () => {
+    // Misconfigured target_group key: no row matches 'operational'
+    axiosRows([
+      { group: "functional", value: 5 },
+      { group: "broken", value: 2 },
+    ]);
+    render(<MetricCard item={shareItem} filterState={emptyFilters} />);
+    expect(await screen.findByText("—")).toBeInTheDocument();
+  });
+
+  test("includes _no_info row in denominator (include_unanswered)", async () => {
+    axiosRows([
+      { group: "operational", value: 3 },
+      { group: "non_functional", value: 1 },
+      { group: "_no_info", value: 2 },
+    ]);
+    render(
+      <MetricCard
+        item={{ ...shareItem, show_percentage: true }}
+        filterState={emptyFilters}
+      />
+    );
+    // denominator = 3+1+2 = 6; operational = 3/6 = 50%
+    expect(await screen.findByText("3/6 (50%)")).toBeInTheDocument();
+  });
+});
+
+describe("MetricCard — label and color", () => {
+  test("renders the item label as the statistic title", async () => {
+    axiosRows([{ group: "total", value: 10 }]);
+    render(
+      <MetricCard
+        item={{ ...baseItem, label: "Total RWS" }}
+        filterState={emptyFilters}
+      />
+    );
+    expect(await screen.findByText("Total RWS")).toBeInTheDocument();
+  });
+});

--- a/frontend/src/config/visualizations/1749621221728.json
+++ b/frontend/src/config/visualizations/1749621221728.json
@@ -393,7 +393,8 @@
         "form_id": 1749621962296,
         "question_id": 1749622849604,
         "group_by": "option",
-        "monitoring": "latest"
+        "monitoring": "latest",
+        "include_unanswered": true
       }
     },
     {
@@ -415,7 +416,8 @@
       "api": {
         "form_id": 1749621221728,
         "question_id": 1749622291234,
-        "group_by": "option"
+        "group_by": "option",
+        "include_unanswered": true
       }
     },
     {
@@ -428,32 +430,12 @@
         "yAxisLabel": "RWS count"
       },
       "compute": "kpi_stack",
-      "segments": [
-        {
-          "key": "operational",
-          "label": "Operational",
-          "color": "#3C3CFF",
-          "api": {
-            "form_id": 1749631041125,
-            "question_id": 1749631041155,
-            "option_value": "operational",
-            "monitoring": "latest",
-            "sum_by": "parent_id"
-          }
-        },
-        {
-          "key": "issues",
-          "label": "Issues with the system",
-          "color": "#1AB99F",
-          "api": {
-            "form_id": 1749631041125,
-            "question_id": 1749631041156,
-            "option_value": "yes",
-            "monitoring": "latest",
-            "sum_by": "parent_id"
-          }
-        }
-      ]
+      "api": {
+        "form_id": 1749631041125,
+        "question_id": 1749631041155,
+        "group_by": "option",
+        "include_unanswered": true
+      }
     },
     {
       "id": "chart_accessibility_bucket",

--- a/frontend/src/config/visualizations/1749621221728.json
+++ b/frontend/src/config/visualizations/1749621221728.json
@@ -256,7 +256,8 @@
       "api": {
         "form_id": 1749631041125,
         "question_id": 1749631041155,
-        "group_by": "option"
+        "group_by": "option",
+        "include_unanswered": true
       },
       "show_percentage": true,
       "target_group": "operational"
@@ -294,7 +295,8 @@
       "api": {
         "form_id": 1749621221728,
         "question_id": 1749622715678,
-        "group_by": "option"
+        "group_by": "option",
+        "include_unanswered": true
       },
       "show_percentage": true,
       "target_group": "yes"
@@ -332,12 +334,6 @@
       "col_span": 24,
       "height": 400,
       "source_form_id": 1749621221728,
-      "status_question_id": 1749631041155,
-      "status_monitoring_form_id": 1749631041125,
-      "status_colors": {
-        "operational": "#64A73B",
-        "non_operational": "#e41a1c"
-      },
       "click_action": "navigate",
       "click_url_template": "/control-center/data/{parent_form_id}/monitoring/{data_id}"
     },

--- a/frontend/src/config/visualizations/1749621221728.json
+++ b/frontend/src/config/visualizations/1749621221728.json
@@ -249,7 +249,7 @@
     {
       "id": "kpi_operational_systems",
       "chart_type": "card",
-      "order": 9,
+      "order": 10,
       "col_span": 6,
       "label": "Operational Systems",
       "color": "#1890ff",
@@ -267,7 +267,7 @@
     {
       "id": "kpi_drinking_water_compliance",
       "chart_type": "card",
-      "order": 10,
+      "order": 11,
       "col_span": 6,
       "label": "Drinking Water Compliance",
       "color": "#64A73B",
@@ -290,7 +290,7 @@
     {
       "id": "kpi_active_water_committees",
       "chart_type": "card",
-      "order": 11,
+      "order": 12,
       "col_span": 6,
       "label": "Active Water Committees",
       "color": "#fa8c16",
@@ -307,7 +307,7 @@
     {
       "id": "kpi_accessibility_no_issues",
       "chart_type": "card",
-      "order": 12,
+      "order": 13,
       "col_span": 6,
       "label": "Accessibility Issues — No Issues",
       "color": "#13c2c2",
@@ -349,7 +349,7 @@
     {
       "id": "title_status_compliance",
       "chart_type": "section_title",
-      "order": 13,
+      "order": 9,
       "col_span": 24,
       "text": "RWS at-a-glance: Status and Compliance"
     },
@@ -361,7 +361,10 @@
       "config": {
         "title": "Implementation at Scale",
         "xAxisLabel": "Number of RWS",
-        "yAxisLabel": "Project type"
+        "yAxisLabel": "Project type",
+        "xAxis": {
+          "nameGap": 164
+        }
       },
       "compute": "cross_tab",
       "orientation": "horizontal",
@@ -385,7 +388,11 @@
       "order": 15,
       "col_span": 12,
       "config": {
-        "title": "Lab tested vs CBT tested"
+        "title": "Lab tested vs CBT tested",
+        "tooltip": {
+          "trigger": "item",
+          "formatter": "{b}: {c} ({d}%)"
+        }
       },
       "api": {
         "form_id": 1749621962296,

--- a/frontend/src/config/visualizations/1749621221728.json
+++ b/frontend/src/config/visualizations/1749621221728.json
@@ -248,7 +248,7 @@
     },
     {
       "id": "kpi_operational_systems",
-      "chart_type": "card",
+      "chart_type": "metric_card",
       "order": 10,
       "col_span": 6,
       "label": "Operational Systems",
@@ -256,13 +256,10 @@
       "api": {
         "form_id": 1749631041125,
         "question_id": 1749631041155,
-        "option_value": "operational",
-        "monitoring": "latest",
-        "sum_by": "parent_id"
+        "group_by": "option"
       },
-      "denominator_api": {
-        "form_id": 1749621221728
-      }
+      "show_percentage": true,
+      "target_group": "operational"
     },
     {
       "id": "kpi_drinking_water_compliance",
@@ -289,7 +286,7 @@
     },
     {
       "id": "kpi_active_water_committees",
-      "chart_type": "card",
+      "chart_type": "metric_card",
       "order": 12,
       "col_span": 6,
       "label": "Active Water Committees",
@@ -297,12 +294,10 @@
       "api": {
         "form_id": 1749621221728,
         "question_id": 1749622715678,
-        "option_value": "yes",
-        "sum_by": "parent_id"
+        "group_by": "option"
       },
-      "denominator_api": {
-        "form_id": 1749621221728
-      }
+      "show_percentage": true,
+      "target_group": "yes"
     },
     {
       "id": "kpi_accessibility_no_issues",
@@ -320,8 +315,8 @@
         "stack_by": "option"
       },
       "issues_api": {
-        "form_id": 1749631041125,
-        "question_id": 1749631041156,
+        "form_id": 1749621962296,
+        "question_id": 1749623661234,
         "monitoring": "latest",
         "group_by": "parent_id",
         "stack_by": "option"

--- a/frontend/src/config/visualizations/1749623934933.json
+++ b/frontend/src/config/visualizations/1749623934933.json
@@ -196,12 +196,6 @@
       "col_span": 24,
       "height": 400,
       "source_form_id": 1749623934933,
-      "status_question_id": 1749633373968,
-      "status_monitoring_form_id": 1749632545233,
-      "status_colors": {
-        "operational": "#64A73B",
-        "issue_with_system": "#e41a1c"
-      },
       "click_action": "navigate",
       "click_url_template": "/control-center/data/{parent_form_id}/monitoring/{data_id}"
     },

--- a/frontend/src/config/visualizations/1749623934933.json
+++ b/frontend/src/config/visualizations/1749623934933.json
@@ -218,7 +218,11 @@
       "order": 10,
       "col_span": 12,
       "config": {
-        "title": "Operational Status"
+        "title": "Operational Status",
+        "tooltip": {
+          "trigger": "item",
+          "formatter": "{b}: {c} ({d}%)"
+        }
       },
       "api": {
         "form_id": 1749632545233,
@@ -267,7 +271,11 @@
       "order": 12,
       "col_span": 8,
       "config": {
-        "title": "Water Committee"
+        "title": "Water Committee",
+        "tooltip": {
+          "trigger": "item",
+          "formatter": "{b}: {c} ({d}%)"
+        }
       },
       "api": {
         "form_id": 1749623934933,
@@ -295,7 +303,11 @@
       "order": 14,
       "col_span": 8,
       "config": {
-        "title": "Lab tested vs CBT tested"
+        "title": "Lab tested vs CBT tested",
+        "tooltip": {
+          "trigger": "item",
+          "formatter": "{b}: {c} ({d}%)"
+        }
       },
       "api": {
         "form_id": 1749632545233,

--- a/frontend/src/config/visualizations/1749623934933.json
+++ b/frontend/src/config/visualizations/1749623934933.json
@@ -228,7 +228,8 @@
         "form_id": 1749632545233,
         "question_id": 1749633373968,
         "group_by": "option",
-        "monitoring": "latest"
+        "monitoring": "latest",
+        "include_unanswered": true
       }
     },
     {
@@ -294,7 +295,8 @@
       "api": {
         "form_id": 1749623934933,
         "question_id": 1749624452993,
-        "group_by": "option"
+        "group_by": "option",
+        "include_unanswered": true
       }
     },
     {
@@ -313,7 +315,8 @@
         "form_id": 1749632545233,
         "question_id": 1749633001462,
         "group_by": "option",
-        "monitoring": "latest"
+        "monitoring": "latest",
+        "include_unanswered": true
       }
     },
     {

--- a/frontend/src/config/visualizations/1749623934933.json
+++ b/frontend/src/config/visualizations/1749623934933.json
@@ -156,7 +156,8 @@
         "question_id": 1749630516826,
         "option_value": "no",
         "monitoring": "latest",
-        "sum_by": "parent_id"
+        "sum_by": "parent_id",
+        "include_unanswered": true
       }
     },
     {
@@ -275,7 +276,8 @@
       "api": {
         "form_id": 1749623934933,
         "question_id": 1749624452105,
-        "group_by": "option"
+        "group_by": "option",
+        "include_unanswered": true
       }
     },
     {
@@ -541,7 +543,8 @@
                 "sum_by": "parent_id",
                 "value_type": "percentage",
                 "date_question_id": 1749632545235,
-                "rolling_months": 12
+                "rolling_months": 12,
+                "include_unanswered": true
               }
             },
             {

--- a/frontend/src/config/visualizations/README.md
+++ b/frontend/src/config/visualizations/README.md
@@ -92,6 +92,7 @@ Only these six keys at the top level. Everything else is an item.
 | `chart_type` | Renders | Key extra fields |
 |---|---|---|
 | `card` | KPI tile | `color`, `api`, `api.value_type` (including `"ratio_percentage"` + sibling `denominator_api`), or `compute` ∈ {`compliance_kpi`, `accessibility_no_issues_kpi`} |
+| `metric_card` | Single-fetch metric tile (count / % / share / share %) | `color`, `api`, `target_group`, `show_percentage` — see [Metric cards](#8-metric-cards-metric_card) |
 | `bar`, `line`, `doughnut`, `half_doughnut`, `pie`, `stack_bar` | akvo-charts component | `config`, and one of: `api` / (`source`+`progress_ref`+`field`) / (`compute`+`params_ref`+`globals_ref`) / (`compute`+`category_api`+`series_api`) / (`compute`+`sample_api`+`issues_api`) / (`compute`+`segments[]`) |
 | `histogram` | Bar chart with binned water-quality data | `group`, `threshold`, `display`, `api` |
 | `table` | Escalation / data table | `api` (with `criteria[]`), `columns[]` |
@@ -253,11 +254,14 @@ columns (shape: `{label, group, [option_label]: count, …}`).
 
 ### 5. Frontend-derived accessibility bucket (`compute: "accessibility_bucket"`)
 
-Joins two per-parent option-question responses (sample + issues) by
-`parent_id` and emits a single-column stacked bar with three buckets per the
-A.2 rule: `sample=yes ∧ issues≠yes → easily_accessible`; `sample=yes ∧
-issues=yes → accessible_with_issues`; `sample=no → not_accessible`; parents
-with no sample record are EXCLUDED.
+Joins two per-parent option-question responses (sample + issues) by `parent_id`
+and emits a single-column stacked bar with three accessibility buckets:
+
+- **Easily accessible**: Sample answered "yes" AND issues answered "no"
+- **Accessible with issues**: Sample answered "yes" AND issues answered "yes"
+- **Not accessible**: Sample answered "no"
+
+Parents with no sample record are excluded from the chart.
 
 ```json
 {
@@ -361,6 +365,59 @@ marker required. Three flavours:
     "sum_by": "parent_id"
   },
   "denominator_api": { "form_id": 1749621221728 }
+}
+```
+
+### 8. Metric cards (`metric_card`)
+
+A generic single-fetch metric tile that subsumes both **scalar** counts and
+**share-of-total** ratios — a slimmer alternative to ratio `card` that does
+not require `denominator_api` or `compute`. Four display modes, dispatched
+on the presence of `target_group` and the top-level `show_percentage`
+flag:
+
+| `target_group` | `show_percentage` | Output | Example |
+|---|---|---|---|
+| absent | absent / `false` | scalar count | `40` |
+| absent | `true` | scalar % | `40%` |
+| set | absent / `false` | share | `2/3` |
+| set | `true` | share with % | `2/3 (66%)` |
+
+In share modes a missing or zero denominator renders `"—"`.
+
+When `target_group` is set the backend is expected to return one row per
+group (`{ value, label, group }[]`); the matching `group` row's value is the
+numerator and the sum of every row's `value` becomes the denominator. The
+api block must therefore NOT include `option_value` (which would filter the
+response to a single row and defeat the share calculation). `target_group`
+itself is a frontend-only signal and is stripped before the backend call.
+
+```json
+{
+  "id": "kpi_operational_share",
+  "chart_type": "metric_card",
+  "label": "Operational EPS share",
+  "color": "#64A73B",
+  "show_percentage": true,
+  "api": {
+    "form_id": 1749632545233,
+    "question_id": 1749633373968,
+    "monitoring": "latest",
+    "sum_by": "parent_id",
+    "target_group": "operational"
+  }
+}
+```
+
+Scalar count example (no `target_group`, no `show_percentage`):
+
+```json
+{
+  "id": "kpi_total_registered",
+  "chart_type": "metric_card",
+  "label": "Total EPS registered",
+  "color": "#1890ff",
+  "api": { "form_id": 1749623934933 }
 }
 ```
 

--- a/frontend/src/config/visualizations/README.md
+++ b/frontend/src/config/visualizations/README.md
@@ -390,7 +390,8 @@ group (`{ value, label, group }[]`); the matching `group` row's value is the
 numerator and the sum of every row's `value` becomes the denominator. The
 api block must therefore NOT include `option_value` (which would filter the
 response to a single row and defeat the share calculation). `target_group`
-itself is a frontend-only signal and is stripped before the backend call.
+is a **top-level item field** (not inside `api`) — it is a frontend-only
+signal and is never sent to the backend.
 
 ```json
 {
@@ -399,12 +400,12 @@ itself is a frontend-only signal and is stripped before the backend call.
   "label": "Operational EPS share",
   "color": "#64A73B",
   "show_percentage": true,
+  "target_group": "operational",
   "api": {
     "form_id": 1749632545233,
     "question_id": 1749633373968,
     "monitoring": "latest",
-    "sum_by": "parent_id",
-    "target_group": "operational"
+    "sum_by": "parent_id"
   }
 }
 ```

--- a/frontend/src/lib/__test__/__snapshots__/ui-text.test.js.snap
+++ b/frontend/src/lib/__test__/__snapshots__/ui-text.test.js.snap
@@ -773,6 +773,7 @@ Object {
     "next": "Next",
     "noFormSelectedText": "No form selected",
     "noFormText": "No data",
+    "noInformationAvailable": "No information available",
     "noTemplate": "No templates found",
     "noText": "No",
     "notAssigned": "Not assigned",

--- a/frontend/src/lib/ui-text.js
+++ b/frontend/src/lib/ui-text.js
@@ -79,6 +79,7 @@ const uiText = {
     lorem2: "Lorem ipsum dolor sit amet consectetur adipisicing elit.",
     // Charts
     showEmpty: "Show empty values",
+    noInformationAvailable: "No information available",
     // User Management
     manageDataValidationSetup: "Validation Tree",
     manageUsers: "Manage Users",


### PR DESCRIPTION
## Summary

Three related dashboard visualization improvements:

1. **`metric_card` widget** — new `chart_type` that renders a single KPI tile
   (scalar count, scalar %, share, or share + %) from a single
   `/visualization/values` fetch, replacing the more complex two-fetch
   `KPICard` approach for proportion charts.
2. **`_no_info` bucket** — opt-in `include_unanswered=true` param on
   `/visualization/values` that appends a synthetic row for EPS/RWS parents
   that have no monitoring answer, surfacing the "coverage gap" on charts and
   map legends.
3. **Api-driven `kpi_stack`** — `kpi_stack` compute mode now supports items
   without `segments`, falling back to a single `group_by=option` api call
   whose rows become the stack segments dynamically.

## Changes

### Backend

- **`dashboard_serializers.py`**: added `include_unanswered` `BooleanField`
  (default `False`) to `ValuesFilterSerializer`.
- **`dashboard_views.py`**: wired `include_unanswered` into the `params` dict
  passed to handler functions.
- **`values_functions.py`**: added `_count_no_info_parents` helper that counts
  parent registrations with no qualifying monitoring answer; modified
  `_option_group_by_option` to collect `qualifying_parents`, compute the
  missing-parent `bucket_count`, adjust the percentage denominator, and append
  a `_no_info` synthetic row when `include_unanswered=True`.
- **`tests/tests_values_option.py`**: 10 new tests covering percentage math,
  administration filter, soft-delete exclusion, multi-choice denominator,
  zero-bucket suppression, count-mode passthrough, and edge cases.

### Frontend — widgets

- **`widgets/MetricCard.jsx`** (new): generic metric tile component supporting
  four display modes (scalar, scalar %, share, share + %) dispatched by
  `target_group` / `show_percentage` flags; strips `target_group` before
  hitting the backend.
- **`DashboardRenderer.jsx`**: added `metric_card` dispatch case that renders
  `<MetricCard>` with filter/date props passed through.

### Frontend — chart enhancements

- **`ChartRenderer.jsx`**:
  - `isApiDriven` now includes `kpi_stack` items without `segments`, enabling
    a direct single-fetch path.
  - `kpi_stack` compute path splits on `item.segments`: if present uses the
    existing `computeKpiStack` with pre-fetched segment responses; if absent
    builds the stack row dynamically from `apiData.data` rows (each row's
    `label` → field, `_no_info` mapped to "No information available").
  - Api-driven rows map `_no_info` group → `uiText.en.noInformationAvailable`.
- **`DashboardMap.jsx`**:
  - Added colored-dot legend strip above the map rendered from
    `item.status_colors` entries; `_no_info` key labeled "No information
    available".
  - `colorForParent` falls back to `statusColors._no_info` for markers with
    no status answer.
  - Fixed `legendEntries` `useMemo` dependency to depend on `item` (not a
    derived `statusColors` object that was re-created every render).

### Config

- **`1749623934933.json`** (EPS Overview): `chart_operational_status` donut
  gains `"include_unanswered": true`.
- **`1749621221728.json`** (RWS Overview): `chart_operational_status_stack`
  switched to api-driven kpi_stack (no `segments`, uses `group_by: "option"`
  with `include_unanswered: true`); chart configs updated with tooltips and
  reordered items.

### UI text / i18n

- **`ui-text.js`**: added `noInformationAvailable: "No information available"`.
- **`ui-text.test.js.snap`**: snapshot updated to include the new key.

## Tests / verification

- Backend: 168 visualization tests pass (`python manage.py test`).
- Frontend: 208 tests pass; ESLint and Prettier clean on all modified files.
- `kpi_stack` test (`compute=kpi_stack assembles a single-row stack…`)
  continues to pass for the segment-driven path.

## Breaking changes

None. `include_unanswered` defaults to `False` so all existing chart configs
are unaffected. `metric_card` is a new chart type; no existing items use it.

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1214126536352972