### PR TITLE
Feature/199 feedback 3

### DIFF
--- a/frontend/src/components/dashboard/DotsChart.jsx
+++ b/frontend/src/components/dashboard/DotsChart.jsx
@@ -1,6 +1,9 @@
 import React, { useMemo, useState } from "react";
 import PropTypes from "prop-types";
 import ReactECharts from "echarts-for-react";
+import uiText from "../../lib/ui-text";
+
+const NO_INFO_COLOR = "#bfbfbf";
 
 /**
  * Packed-bubble ("dots") chart rendered via ECharts' `graph` series with
@@ -25,8 +28,8 @@ const DEFAULT_PALETTE = [
   "#16A085",
 ];
 
-const MIN_SYMBOL = 44;
-const MAX_SYMBOL = 130;
+const MIN_SYMBOL = 64;
+const MAX_SYMBOL = 160;
 const SELECTED_SCALE = 1.35;
 
 const scaleSymbolSize = (value, maxValue) => {
@@ -62,13 +65,14 @@ const DotsChart = ({ data, colors, height }) => {
         const isSelected = selectedLabel === d.label;
         const isDimmed = selectedLabel !== null && !isSelected;
         const size = isSelected ? baseSize * SELECTED_SCALE : baseSize;
+        const isNoInfo = d.label === uiText.en.noInformationAvailable;
         return {
           id: d.label,
           name: d.label,
           value: Number(d.value) || 0,
           symbolSize: size,
           itemStyle: {
-            color: palette[i % palette.length],
+            color: isNoInfo ? NO_INFO_COLOR : palette[i % palette.length],
             opacity: isDimmed ? 0.4 : 1,
             borderColor: isSelected ? "#ffffff" : "transparent",
             borderWidth: isSelected ? 3 : 0,
@@ -110,7 +114,7 @@ const DotsChart = ({ data, colors, height }) => {
           type: "graph",
           layout: "force",
           force: {
-            repulsion: 260,
+            repulsion: 320,
             gravity: 0.12,
             edgeLength: 0,
             friction: 0.2,

--- a/frontend/src/components/dashboard/custom-components/IndividualEPSOverview.jsx
+++ b/frontend/src/components/dashboard/custom-components/IndividualEPSOverview.jsx
@@ -40,6 +40,7 @@ import {
   WATER_QUALITY_DETAIL_QIDS,
   WATER_QUALITY_FORM_ID,
   WQ_CBT_PARAMS,
+  WQ_DATE_QID,
   WQ_LAB_PARAMS,
   WQ_PHOTO_CAPTION_QID,
   WQ_PHOTO_QID,
@@ -180,7 +181,8 @@ const IndividualEPSOverview = () => {
 
   const wqHistory = useMonitoringHistory(
     WATER_QUALITY_FORM_ID,
-    selectedDataPoint?.uuid
+    selectedDataPoint?.uuid,
+    WQ_DATE_QID
   );
 
   const photoUrl = extractPhotoUrl(constructionValues, CONSTRUCTION_PHOTO_QID);

--- a/frontend/src/components/dashboard/custom-components/individual-overview/shared/HistoricalLineChart.jsx
+++ b/frontend/src/components/dashboard/custom-components/individual-overview/shared/HistoricalLineChart.jsx
@@ -1,4 +1,4 @@
-import React, { useMemo } from "react";
+import React, { useCallback, useEffect, useMemo, useState } from "react";
 import PropTypes from "prop-types";
 import { Card, Empty } from "antd";
 import { Line } from "akvo-charts";
@@ -22,6 +22,42 @@ const numericValue = (raw) => {
 // akvo-charts `div[role="figure"]`, so we match the empty state to the
 // same floor — empty cards then align with chart cards in the same row.
 const FIGURE_MIN_HEIGHT = 320;
+
+/**
+ * <Line> with rotated x-axis labels. akvo-charts doesn't expose axisLabel
+ * config, so we grab the ECharts instance via callback ref and setOption
+ * after mount — same pattern as ChartRenderer's ChartWithScrollLegend.
+ */
+const LineWithRotatedAxis = ({ config, data }) => {
+  const [chart, setChart] = useState(null);
+  const setRef = useCallback((instance) => {
+    if (instance && typeof instance.setOption === "function") {
+      setChart((prev) => prev || instance);
+    }
+  }, []);
+  useEffect(() => {
+    if (!chart) {
+      return;
+    }
+    chart.setOption(
+      {
+        xAxis: {
+          axisTick: { alignWithLabel: true },
+          axisLabel: { rotate: 45, interval: "auto", hideOverlap: true },
+          nameGap: 64,
+          nameLocation: "middle",
+        },
+      },
+      false
+    );
+  }); // No deps: re-apply after every render (akvo-charts re-runs setOption each render).
+  return <Line ref={setRef} config={config} data={data} />;
+};
+
+LineWithRotatedAxis.propTypes = {
+  config: PropTypes.object.isRequired,
+  data: PropTypes.array.isRequired,
+};
 
 /**
  * akvo-charts <Line> wrapped with optional threshold band (markArea). Sorts
@@ -85,7 +121,7 @@ const HistoricalLineChart = ({
         <Empty description="No history yet" />
       </div>
     ) : (
-      <Line config={chartConfig} data={seriesData} />
+      <LineWithRotatedAxis config={chartConfig} data={seriesData} />
     );
 
   return (

--- a/frontend/src/components/dashboard/custom-components/individual-overview/shared/helpers.js
+++ b/frontend/src/components/dashboard/custom-components/individual-overview/shared/helpers.js
@@ -145,6 +145,21 @@ export const formatAnswerValue = (answer, question, lookups) => {
     }
     return items.join(", ");
   }
+  /**
+   * Dates are stored as ISO strings but we want to display them in a more
+   * human-friendly format.
+   */
+  if (type === "date") {
+    const d = new Date(value);
+    if (!Number.isNaN(d.getTime())) {
+      return d.toLocaleDateString("en-US", {
+        weekday: "short",
+        year: "numeric",
+        month: "long",
+        day: "numeric",
+      });
+    }
+  }
   return String(value);
 };
 

--- a/frontend/src/components/dashboard/custom-components/individual-overview/shared/useMonitoringHistory.js
+++ b/frontend/src/components/dashboard/custom-components/individual-overview/shared/useMonitoringHistory.js
@@ -1,5 +1,6 @@
 import { useEffect, useRef, useState } from "react";
 import { api } from "../../../../../lib";
+import { findAnswer } from "./helpers";
 
 const PAGE_SIZE = 20;
 
@@ -26,6 +27,9 @@ const fetchAllPages = async (formId, parentUuid) => {
  *
  * @param {number} formId
  * @param {string|null|undefined} parentUuid    Falsy disables the fetch.
+ * @param {number|null} [dateQuestionId]        When provided, the answer for
+ *   this question id is used as the row date instead of FormData.created.
+ *   Falls back to FormData.created when the answer is absent.
  *
  * @returns {{
  *   rows: Array<{ id: number, date: string|null, values: Array }>,
@@ -33,7 +37,7 @@ const fetchAllPages = async (formId, parentUuid) => {
  *   error: Error|null,
  * }}
  */
-const useMonitoringHistory = (formId, parentUuid) => {
+const useMonitoringHistory = (formId, parentUuid, dateQuestionId) => {
   const [rows, setRows] = useState([]);
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState(null);
@@ -62,10 +66,20 @@ const useMonitoringHistory = (formId, parentUuid) => {
           list.map(async (entry) => {
             try {
               const { data: values } = await api.get(`/data/${entry.id}`);
+              const dateAnswer = dateQuestionId
+                ? findAnswer(values || [], dateQuestionId)
+                : null;
+              const rawDate =
+                dateAnswer?.value || entry.created || entry.updated || null;
+              // Trim ISO datetimes (e.g. "2026-02-24T02:16:00.000Z") to
+              // date-only ("2026-02-24") so x-axis labels stay compact.
+              const date =
+                typeof rawDate === "string" && rawDate.length > 10
+                  ? rawDate.slice(0, 10)
+                  : rawDate;
               return {
                 id: entry.id,
-                date:
-                  entry.created || entry.updated || entry.submitted_at || null,
+                date,
                 values: values || [],
               };
             } catch (err) {
@@ -97,7 +111,7 @@ const useMonitoringHistory = (formId, parentUuid) => {
     return () => {
       cancelled = true;
     };
-  }, [formId, parentUuid]);
+  }, [formId, parentUuid, dateQuestionId]);
 
   return { rows, loading, error };
 };

--- a/frontend/src/components/map-view/MapView.jsx
+++ b/frontend/src/components/map-view/MapView.jsx
@@ -21,28 +21,37 @@ const MapView = ({ dataset, loading, position }) => {
   const lg = useRef(null);
   const defPos = geo.defaultPos();
 
-  const renderMarker = (d) => {
-    if (d?.values?.length) {
-      return `<span style="background: conic-gradient(${d.values
-        .map(
-          (v, i) =>
-            `${v.color} ${i * (100 / d.values.length)}% ${
-              (i + 1) * (100 / d.values.length)
-            }%`
-        )
-        .join(", ")})"></span>`;
+  const getMarkerDisplayText = useCallback((value) => {
+    const isNullish = value === null || typeof value === "undefined";
+    if (isNullish || isNaN(value)) {
+      return "";
     }
-    const bgColor = d?.color || "#64A73B";
-    return `<span class="custom-marker" style="background-color:${bgColor};">${
-      d?.value === null ||
-      typeof d?.value === "undefined" ||
-      !isNaN(d.value) === false
-        ? ""
-        : d.value >= 1000
-        ? `${Math.floor(d.value / 1000)}k`
-        : d.value
-    }</span>`;
-  };
+    if (value < 1000) {
+      return String(value);
+    }
+    const abbreviated = `${Math.floor(value / 1000)}k`;
+    return abbreviated.length <= 4 ? abbreviated : "…";
+  }, []);
+
+  const renderMarker = useCallback(
+    (d) => {
+      if (d?.values?.length) {
+        return `<span style="background: conic-gradient(${d.values
+          .map(
+            (v, i) =>
+              `${v.color} ${i * (100 / d.values.length)}% ${
+                (i + 1) * (100 / d.values.length)
+              }%`
+          )
+          .join(", ")})"></span>`;
+      }
+      const bgColor = d?.color || "#64A73B";
+      return `<span class="custom-marker" style="background-color:${bgColor};">${getMarkerDisplayText(
+        d?.value
+      )}</span>`;
+    },
+    [getMarkerDisplayText]
+  );
 
   const mapStyle = (feature) => {
     const activeAdm = takeRight(selectedAdm, 1)[0];
@@ -112,6 +121,11 @@ const MapView = ({ dataset, loading, position }) => {
         const offsetCoords = offsets[index];
         const finalCoords = geo.fixCoordinates(offsetCoords);
 
+        const hasNumericValue =
+          d?.value !== null &&
+          typeof d?.value !== "undefined" &&
+          !isNaN(d.value);
+
         const marker = L.marker(finalCoords, {
           icon: L.divIcon({
             className: `custom-marker ${
@@ -124,10 +138,18 @@ const MapView = ({ dataset, loading, position }) => {
         }).bindPopup(
           `<a href="/control-center/data/${selectedForm}/monitoring/${d.id}" target="_blank" rel="noopener noreferrer" style="padding: 0;">${d.name}</a>`
         );
+
+        if (hasNumericValue) {
+          marker.bindTooltip(String(d.value), {
+            sticky: true,
+            direction: "top",
+          });
+        }
+
         lg.current.addLayer(marker);
       });
     }
-  }, [lg, selectedForm, dataset, loading]);
+  }, [lg, selectedForm, dataset, loading, renderMarker]);
 
   return (
     <div className="map-container">

--- a/frontend/src/components/map-view/MapView.jsx
+++ b/frontend/src/components/map-view/MapView.jsx
@@ -126,6 +126,15 @@ const MapView = ({ dataset, loading, position }) => {
           typeof d?.value !== "undefined" &&
           !isNaN(d.value);
 
+        const popupLink = document.createElement("a");
+        popupLink.href = `/control-center/data/${encodeURIComponent(
+          selectedForm
+        )}/monitoring/${encodeURIComponent(d.id)}`;
+        popupLink.target = "_blank";
+        popupLink.rel = "noopener noreferrer";
+        popupLink.style.padding = "0";
+        popupLink.textContent = d.name;
+
         const marker = L.marker(finalCoords, {
           icon: L.divIcon({
             className: `custom-marker ${
@@ -135,9 +144,7 @@ const MapView = ({ dataset, loading, position }) => {
             iconAnchor: [16, 16],
             html: renderMarker(d),
           }),
-        }).bindPopup(
-          `<a href="/control-center/data/${selectedForm}/monitoring/${d.id}" target="_blank" rel="noopener noreferrer" style="padding: 0;">${d.name}</a>`
-        );
+        }).bindPopup(popupLink);
 
         if (hasNumericValue) {
           marker.bindTooltip(String(d.value), {


### PR DESCRIPTION
## Summary

Three focused visualization improvements following review feedback:

1. **MapView marker display** — long numeric values (phone numbers, IDs) no longer render as broken `"23092k"` abbreviations; the marker shows `"…"` and a Leaflet hover tooltip exposes the full value.
2. **HistoricalLineChart x-axis** — uses the WQ sampling date question answer instead of entry creation date; ISO timestamps are trimmed to `YYYY-MM-DD`; axis labels rotate 45° with `hideOverlap` so dense timelines stay readable.
3. **DotsChart polish** — bubbles are larger (MIN 64, MAX 160) with stronger repulsion to reduce overlap; the "No information available" node gets the shared `#bfbfbf` grey, matching all other chart types.

## Changes

### Frontend

- **`MapView.jsx`**:
  - Extracted `getMarkerDisplayText(value)` helper: values < 1,000 show as-is; 1,000–99,999 show `"Xk"`; values where the `"Xk"` representation exceeds 4 chars (phone numbers, large IDs) show `"…"` instead.
  - `L.marker().bindTooltip(String(d.value), { sticky: true, direction: "top" })` added for every marker with a numeric value so the full number is always accessible on hover.

- **`HistoricalLineChart.jsx`** + **`useMonitoringHistory.js`**:
  - `useMonitoringHistory` accepts optional `dateQuestionId`; resolves the display date via `findAnswer()` and falls back to `entry.created`.
  - ISO datetimes longer than 10 chars are trimmed to `YYYY-MM-DD` for compact labels.
  - `LineWithRotatedAxis` wrapper component applies `axisLabel.rotate=45`, `interval="auto"`, `hideOverlap=true`, `nameGap=64` via callback-ref + `setOption` (same pattern as `ChartWithScrollLegend`).

- **`IndividualEPSOverview.jsx`**: passes `WQ_DATE_QID` to `useMonitoringHistory`.

- **`DotsChart.jsx`**:
  - `MIN_SYMBOL` 44 → 64, `MAX_SYMBOL` 130 → 160.
  - Force repulsion 260 → 320.
  - `NO_INFO_COLOR` (`#bfbfbf`) applied to the "No information available" node via `itemStyle.color`.

## Tests / verification

- **Lint**: `npx eslint src/components/map-view/MapView.jsx` → zero errors/warnings.
- **Manual smoke recommended**:
  - Map View with a phone-number question selected: markers show `"…"`; hovering shows the full number in a tooltip.
  - Individual EPS historical chart: x-axis shows `YYYY-MM-DD` sampling dates, labels rotated 45°.
  - DotsChart: bubbles visibly larger; "No information available" node is grey.