### PR TITLE
feat(visualization): dot strip chart, chemical/physical WQ params, include_empty API (#199)

### DIFF
--- a/backend/api/v1/v1_visualization/dashboard_serializers.py
+++ b/backend/api/v1/v1_visualization/dashboard_serializers.py
@@ -57,6 +57,10 @@ class ValuesFilterSerializer(serializers.Serializer):
         required=False,
         default=False,
     )
+    include_empty = serializers.BooleanField(
+        required=False,
+        default=False,
+    )
 
     def validate_criteria(self, value):
         try:

--- a/backend/api/v1/v1_visualization/dashboard_views.py
+++ b/backend/api/v1/v1_visualization/dashboard_views.py
@@ -200,6 +200,9 @@ def visualization_values(request, version):
         "include_unanswered": validated.get(
             "include_unanswered", False
         ),
+        "include_empty": validated.get(
+            "include_empty", False
+        ),
     }
 
     # Route to handler

--- a/backend/api/v1/v1_visualization/tests/tests_values_option.py
+++ b/backend/api/v1/v1_visualization/tests/tests_values_option.py
@@ -297,10 +297,14 @@ class ValuesOptionTestCases(VisualizationValuesTestMixin, APITestCase):
     def test_option_value_percentage_include_unanswered_uses_total_parents(
         self,
     ):
-        """include_unanswered widens the denominator to total registrations.
+        """include_unanswered adds unanswered to numerator and denominator.
 
-        Without the flag: 1 match / 2 monitored parents = 50%.
-        With 3 extra unmonitored and include_unanswered=true: 1/5 = 20%.
+        Mixin:
+        reg1=active(latest), reg2=pending(latest), both answered q_option.
+        3 extra unmonitored → total=5,
+        all_answered={reg1,reg2}=2, unanswered=3.
+        Without flag: 1/2 monitored = 50%.
+        With flag: (1+3)/5 = 80%.
         """
         for i in range(3):
             self._create_registration(
@@ -317,7 +321,93 @@ class ValuesOptionTestCases(VisualizationValuesTestMixin, APITestCase):
         self.assertEqual(response.status_code, 200)
         data = response.json()
         self.assertEqual(len(data["data"]), 1)
-        self.assertEqual(data["data"][0]["value"], 20.0)
+        self.assertEqual(data["data"][0]["value"], 80.0)
+
+    def test_option_value_count_include_unanswered(self):
+        """
+        option_value + include_unanswered adds unanswered parents to count.
+        Mixin:
+        reg1=active(latest), reg2=pending(latest), both answered q_option.
+        2 extra unmonitored → total=4, all_answered=2, unanswered=2.
+        option_value=active: count=1, unanswered=2 → value=3.
+        """
+        for i in range(2):
+            self._create_registration(
+                name=f"Unmonitored {i}",
+                administration=self.adm_parent,
+            )
+        response = self.client.get(
+            f"{self.BASE_URL}?form_id={self.monitoring.id}"
+            f"&question_id={self.q_option.id}"
+            "&option_value=active&sum_by=parent_id"
+            "&monitoring=latest&include_unanswered=true"
+        )
+        self.assertEqual(response.status_code, 200)
+        data = response.json()
+        self.assertEqual(len(data["data"]), 1)
+        self.assertEqual(data["data"][0]["value"], 3)
+
+    def test_option_value_include_unanswered_backward_compat(self):
+        """Without the flag, count is unchanged even with extra registrations.
+
+        Same setup as test_option_value_count_include_unanswered but without
+        include_unanswered=true — value must remain 1 (only matched parents).
+        """
+        for i in range(2):
+            self._create_registration(
+                name=f"Unmonitored {i}",
+                administration=self.adm_parent,
+            )
+        response = self.client.get(
+            f"{self.BASE_URL}?form_id={self.monitoring.id}"
+            f"&question_id={self.q_option.id}"
+            "&option_value=active&sum_by=parent_id"
+            "&monitoring=latest"
+        )
+        self.assertEqual(response.status_code, 200)
+        data = response.json()
+        self.assertEqual(len(data["data"]), 1)
+        self.assertEqual(data["data"][0]["value"], 1)
+
+    def test_option_value_include_unanswered_all_unanswered(self):
+        """When no parent answered option_value, count = total unanswered.
+
+        Mixin: neither reg1 nor reg2 answered "inactive" in latest monitoring
+        (reg1=active, reg2=pending). Neither has unanswered; count_inactive=0.
+        1 extra unmonitored → unanswered=1.
+        Result = 0 + 1 = 1.
+        """
+        self._create_registration(
+            name="Unmonitored",
+            administration=self.adm_parent,
+        )
+        response = self.client.get(
+            f"{self.BASE_URL}?form_id={self.monitoring.id}"
+            f"&question_id={self.q_option.id}"
+            "&option_value=inactive&sum_by=parent_id"
+            "&monitoring=latest&include_unanswered=true"
+        )
+        self.assertEqual(response.status_code, 200)
+        data = response.json()
+        self.assertEqual(len(data["data"]), 1)
+        self.assertEqual(data["data"][0]["value"], 1)
+
+    def test_option_value_include_unanswered_no_unmonitored(self):
+        """When all parents are monitored and answered, unanswered=0.
+
+        Mixin: reg1=active(latest), reg2=pending(latest) — both answered.
+        option_value=active: count=1, unanswered=0 → value=1.
+        """
+        response = self.client.get(
+            f"{self.BASE_URL}?form_id={self.monitoring.id}"
+            f"&question_id={self.q_option.id}"
+            "&option_value=active&sum_by=parent_id"
+            "&monitoring=latest&include_unanswered=true"
+        )
+        self.assertEqual(response.status_code, 200)
+        data = response.json()
+        self.assertEqual(len(data["data"]), 1)
+        self.assertEqual(data["data"][0]["value"], 1)
 
     # -- include_unanswered tests --
 
@@ -608,3 +698,91 @@ class ValuesOptionTestCases(VisualizationValuesTestMixin, APITestCase):
             administration=administration,
             created_by=self.user,
         )
+
+    # -- include_empty tests --
+
+    def test_include_empty_count_adds_never_monitored(self):
+        """include_empty adds parents with zero monitoring submissions.
+
+        Mixin: reg1=active(latest), reg2=pending(latest), both monitored.
+        2 extra unmonitored → total=4, monitored=2, never_monitored=2.
+        option_value=active: count=1, empty=2 → value=3.
+        """
+        for i in range(2):
+            self._create_registration(
+                name=f"NeverMonitored {i}",
+                administration=self.adm_parent,
+            )
+        response = self.client.get(
+            f"{self.BASE_URL}?form_id={self.monitoring.id}"
+            f"&question_id={self.q_option.id}"
+            "&option_value=active&sum_by=parent_id"
+            "&monitoring=latest&include_empty=true"
+        )
+        self.assertEqual(response.status_code, 200)
+        data = response.json()
+        self.assertEqual(len(data["data"]), 1)
+        self.assertEqual(data["data"][0]["value"], 3)
+
+    def test_include_empty_percentage_uses_total_registered(self):
+        """include_empty percentage: numerator=matched+empty, denom=total.
+
+        Mixin: reg1=active, reg2=pending, both monitored.
+        2 extra unmonitored → total=4, monitored=2, never_monitored=2.
+        option_value=active: count=1, empty=2 → (1+2)/4 × 100 = 75.0%.
+        """
+        for i in range(2):
+            self._create_registration(
+                name=f"NeverMonitored {i}",
+                administration=self.adm_parent,
+            )
+        response = self.client.get(
+            f"{self.BASE_URL}?form_id={self.monitoring.id}"
+            f"&question_id={self.q_option.id}"
+            "&option_value=active&sum_by=parent_id"
+            "&monitoring=latest&value_type=percentage"
+            "&include_empty=true"
+        )
+        self.assertEqual(response.status_code, 200)
+        data = response.json()
+        self.assertEqual(len(data["data"]), 1)
+        self.assertEqual(data["data"][0]["value"], 75.0)
+
+    def test_include_empty_no_unmonitored_parents(self):
+        """include_empty with all parents monitored: empty=0, value unchanged.
+
+        Mixin: reg1=active, reg2=pending — both monitored. No extra regs.
+        total=2, monitored=2, never_monitored=0.
+        option_value=active: count=1, empty=0 → value=1.
+        """
+        response = self.client.get(
+            f"{self.BASE_URL}?form_id={self.monitoring.id}"
+            f"&question_id={self.q_option.id}"
+            "&option_value=active&sum_by=parent_id"
+            "&monitoring=latest&include_empty=true"
+        )
+        self.assertEqual(response.status_code, 200)
+        data = response.json()
+        self.assertEqual(len(data["data"]), 1)
+        self.assertEqual(data["data"][0]["value"], 1)
+
+    def test_include_empty_backward_compat(self):
+        """Without include_empty, never-monitored parents are ignored.
+
+        2 extra unmonitored present but flag absent → value still 1.
+        """
+        for i in range(2):
+            self._create_registration(
+                name=f"NeverMonitored {i}",
+                administration=self.adm_parent,
+            )
+        response = self.client.get(
+            f"{self.BASE_URL}?form_id={self.monitoring.id}"
+            f"&question_id={self.q_option.id}"
+            "&option_value=active&sum_by=parent_id"
+            "&monitoring=latest"
+        )
+        self.assertEqual(response.status_code, 200)
+        data = response.json()
+        self.assertEqual(len(data["data"]), 1)
+        self.assertEqual(data["data"][0]["value"], 1)

--- a/backend/api/v1/v1_visualization/values_functions.py
+++ b/backend/api/v1/v1_visualization/values_functions.py
@@ -356,6 +356,7 @@ def handle_option_question(form, question, params):
             ),
             form=form,
             params=params,
+            include_empty=params.get("include_empty", False),
         )
 
     if stack_by == "option" and group_by:
@@ -385,8 +386,18 @@ def _option_value_filter(
     question, data_ids, qs, is_latest,
     option_value, sum_by, value_type,
     include_unanswered=False, form=None, params=None,
+    include_empty=False,
 ):
-    """Filter by specific option value and count."""
+    """Filter by specific option value and count.
+
+    include_unanswered=True: parents with no answer for the question
+    (monitored but null options) are added to the count.
+
+    include_empty=True: parents with zero monitoring submissions
+    (never visited) are added to the count. Takes precedence over
+    include_unanswered when both are set, as the coverage-gap count
+    already subsumes the answer-gap count.
+    """
     count = Answers.objects.filter(
         data_id__in=data_ids,
         question_id=question.id,
@@ -399,16 +410,42 @@ def _option_value_filter(
     else:
         count = count.count()
 
+    is_monitoring = form is not None and form.parent is not None
+    extra = 0
+
+    if include_empty and is_monitoring:
+        monitored_parent_ids = set(
+            FormData.objects.filter(id__in=data_ids)
+            .values_list("parent_id", flat=True)
+            .distinct()
+        )
+        extra = _count_no_info_parents(
+            form, params or {}, monitored_parent_ids
+        )
+    elif include_unanswered and is_monitoring:
+        all_answered_ids = set(
+            Answers.objects.filter(
+                data_id__in=data_ids,
+                question_id=question.id,
+                options__isnull=False,
+            ).values_list("data__parent_id", flat=True).distinct()
+        )
+        extra = _count_no_info_parents(
+            form, params or {}, all_answered_ids
+        )
+
     if value_type == "percentage":
-        if include_unanswered and form is not None:
+        if (include_empty or include_unanswered) and is_monitoring:
             total = _total_parents_in_scope(form, params or {})
+            numerator = count + extra
         else:
             total = qs.count() if is_latest else len(data_ids)
+            numerator = count
         value = round(
-            (count / total * 100), 2
+            (numerator / total * 100), 2
         ) if total > 0 else 0
     else:
-        value = count
+        value = count + extra
 
     return (
         [{"value": value, "label": option_value}],

--- a/doc/claude/include-empty-param/design.md
+++ b/doc/claude/include-empty-param/design.md
@@ -1,0 +1,209 @@
+# Design: `include_empty` parameter
+
+For requirements, see [requirements.md](./requirements.md).  
+For the step-by-step implementation, see [implementation-plan.md](./implementation-plan.md).
+
+---
+
+## Data model recap
+
+```
+FormData (registration)  ← parent
+  id = 1 … 105           ← 105 registered EPS
+
+FormData (monitoring)    ← child (form.parent = registration form)
+  parent_id → FormData.id
+  13 of the 105 parents have at least one monitoring submission
+
+Answers
+  data_id → FormData.id (monitoring submission)
+  question_id, options (JSON array)
+```
+
+`data_ids` (produced by `get_monitoring_data_ids`) = IDs of the latest monitoring submissions for each of the 13 monitored parents when `monitoring=latest`.
+
+---
+
+## Core computation
+
+### Step 1 — Count of answered parents (unchanged)
+
+```python
+count_qs = Answers.objects.filter(
+    data_id__in=data_ids,
+    question_id=question.id,
+    options__contains=[option_value],   # e.g. "no"
+)
+if sum_by == "parent_id":
+    count = count_qs.values("data__parent_id").distinct().count()
+else:
+    count = count_qs.count()
+# count = 3  (parents whose latest monitoring says "no")
+```
+
+### Step 2 — Count of never-monitored parents (new, when `include_empty=True`)
+
+```python
+is_monitoring = form is not None and form.parent is not None
+
+if include_empty and is_monitoring:
+    # Derive the set of parent IDs that DO have a monitoring submission in scope.
+    # data_ids = latest monitoring submission IDs → each maps to one parent_id.
+    monitored_parent_ids = set(
+        FormData.objects.filter(id__in=data_ids)
+        .values_list("parent_id", flat=True)
+        .distinct()
+    )
+    # empty = total_registered − monitored_parents (respects admin/criteria filters)
+    empty_count = _count_no_info_parents(form, params or {}, monitored_parent_ids)
+    # empty_count = 105 − 13 = 92
+```
+
+### Step 3 — Combine
+
+```python
+if include_empty and is_monitoring:
+    value = count + empty_count          # number mode: 3 + 92 = 95
+
+    if value_type == "percentage":
+        total = _total_parents_in_scope(form, params or {})   # 105
+        value = round((count + empty_count) / total * 100, 2) # 90.48%
+else:
+    # existing path (unchanged)
+    value = count
+    if value_type == "percentage":
+        total = qs.count() if is_latest else len(data_ids)
+        value = round(count / total * 100, 2) if total > 0 else 0
+```
+
+---
+
+## Why `monitored_parent_ids` (not `all_answered_ids`)
+
+`include_unanswered` uses `all_answered_ids` — parents whose submission has a non-null options field for this question. In the construction data, the 10 "yes" parents appear to have null options (or a different question path), so `all_answered_ids.size = 3`, leading to `unanswered = 102` and a wrong total of 105.
+
+`include_empty` bypasses the answer lookup entirely. It asks: "which parents have *any* monitoring submission?" — a `FormData` lookup, not an `Answers` lookup. This gives exactly the 13 monitored parents, independent of whether they answered the specific question.
+
+```
+include_unanswered path              include_empty path
+────────────────────────             ──────────────────────────
+Answers(data_id__in=data_ids,        FormData(id__in=data_ids)
+  options__isnull=False)               .values_list("parent_id")
+→ only 3 parents (bug)               → 13 parents (correct)
+unanswered = 105 − 3 = 102           empty = 105 − 13 = 92
+value = 3 + 102 = 105 ✗              value = 3 + 92 = 95 ✓
+```
+
+---
+
+## Query cost
+
+| Stage | Queries |
+|-------|---------|
+| Baseline (no flag) | 1 Answers COUNT |
+| `include_empty=true` | +1 FormData VALUES (get parent_ids from data_ids) |
+| Percentage mode | +1 FormData COUNT (already paid by `_total_parents_in_scope`) |
+
+Total overhead: **at most 2 extra queries**. Both are simple indexed lookups on `id` / `parent_id`.
+
+---
+
+## API parameter spec
+
+| Parameter | Type | Default | Description |
+|-----------|------|---------|-------------|
+| `include_empty` | bool | `false` | When `true` on a monitoring form with `option_value`, adds the count of registered parents that have zero monitoring submissions to the result value. Denominator for percentage mode becomes `total_registered`. |
+
+### View-layer parsing (views.py)
+
+```python
+include_empty = (
+    request.GET.get("include_empty", "false").lower() == "true"
+)
+```
+
+Passed into `handle_option_question` → forwarded to `_option_value_filter`.
+
+---
+
+## Function signature change
+
+```python
+# Before
+def _option_value_filter(
+    question, data_ids, qs, is_latest,
+    option_value, sum_by, value_type,
+    include_unanswered=False, form=None, params=None,
+):
+
+# After
+def _option_value_filter(
+    question, data_ids, qs, is_latest,
+    option_value, sum_by, value_type,
+    include_unanswered=False, form=None, params=None,
+    include_empty=False,     # NEW
+):
+```
+
+And in `handle_option_question`:
+
+```python
+if option_value:
+    return _option_value_filter(
+        question, data_ids, qs, is_latest,
+        option_value, sum_by, value_type,
+        include_unanswered=params.get("include_unanswered", False),
+        form=form,
+        params=params,
+        include_empty=params.get("include_empty", False),   # NEW
+    )
+```
+
+---
+
+## Behaviour matrix
+
+| `value_type` | `include_empty` | numerator | denominator |
+|---|---|---|---|
+| `number` | `false` | `count(option_value)` | — |
+| `number` | `true` | `count(option_value) + never_monitored` | — |
+| `percentage` | `false` | `count(option_value)` | `monitored_count` (qs.count() or len(data_ids)) |
+| `percentage` | `true` | `count(option_value) + never_monitored` | `total_parents_in_scope` |
+
+---
+
+## Dashboard JSON config
+
+```jsonc
+// kpi_under_construction  (count)
+"api": {
+  "form_id": 1749624452908,
+  "question_id": 1749630516826,
+  "option_value": "no",
+  "monitoring": "latest",
+  "sum_by": "parent_id",
+  "include_empty": true          // replaces include_unanswered: true
+}
+
+// kpi_under_construction_pct  (percentage)
+"api": {
+  "form_id": 1749624452908,
+  "question_id": 1749630516826,
+  "option_value": "no",
+  "monitoring": "latest",
+  "sum_by": "parent_id",
+  "value_type": "percentage",
+  "include_empty": true          // NEW
+}
+```
+
+---
+
+## Files changed
+
+| File | Change |
+|------|--------|
+| `backend/api/v1/v1_visualization/values_functions.py` | Add `include_empty` param to `_option_value_filter`; new branch in count + percentage paths |
+| `backend/api/v1/v1_visualization/views.py` | Parse `include_empty` from query string and pass to params |
+| `backend/api/v1/v1_visualization/tests/tests_values_option.py` | Add 4 new test cases |
+| `frontend/src/config/visualizations/1749623934933.json` | Swap `include_unanswered` → `include_empty` on both construction KPI cards |

--- a/doc/claude/include-empty-param/implementation-plan.md
+++ b/doc/claude/include-empty-param/implementation-plan.md
@@ -1,0 +1,281 @@
+# Implementation Plan: `include_empty` parameter
+
+For requirements, see [requirements.md](./requirements.md).
+For technical design, see [design.md](./design.md).
+
+---
+
+## Overview
+
+4 phases, ~6 file touches, no new React components.
+
+```
+Phase 1: Backend logic   → values_functions.py + views.py
+Phase 2: Tests (TDD)     → tests_values_option.py (RED → GREEN)
+Phase 3: Config update   → 1749623934933.json
+Phase 4: Verify          → curl + backend test run
+```
+
+---
+
+## Phase 1 — Backend logic
+
+### 1a. `values_functions.py` — extend `_option_value_filter`
+
+File: `backend/api/v1/v1_visualization/values_functions.py`
+
+Add `include_empty=False` parameter and a new branch that counts never-monitored parents.
+
+```python
+# Full updated signature
+def _option_value_filter(
+    question, data_ids, qs, is_latest,
+    option_value, sum_by, value_type,
+    include_unanswered=False, form=None, params=None,
+    include_empty=False,        # NEW
+):
+```
+
+Inside the function, after the existing `count` calculation:
+
+```python
+# ── include_empty branch (new) ─────────────────────────────────
+is_monitoring = form is not None and form.parent is not None
+empty_count = 0
+if include_empty and is_monitoring:
+    # Which parent IDs already have a monitoring submission in scope?
+    monitored_parent_ids = set(
+        FormData.objects.filter(id__in=data_ids)
+        .values_list("parent_id", flat=True)
+        .distinct()
+    )
+    # never-monitored = total_in_scope − monitored
+    empty_count = _count_no_info_parents(form, params or {}, monitored_parent_ids)
+
+# ── include_unanswered branch (existing, unchanged) ─────────────
+unanswered = 0
+if include_unanswered and is_monitoring and not include_empty:
+    all_answered_ids = set(
+        Answers.objects.filter(
+            data_id__in=data_ids,
+            question_id=question.id,
+            options__isnull=False,
+        ).values_list("data__parent_id", flat=True).distinct()
+    )
+    unanswered = _count_no_info_parents(form, params or {}, all_answered_ids)
+
+# ── Percentage / count mode ──────────────────────────────────────
+extra = empty_count if include_empty else unanswered
+
+if value_type == "percentage":
+    if (include_empty or include_unanswered) and is_monitoring:
+        total = _total_parents_in_scope(form, params or {})
+        numerator = count + extra
+    else:
+        total = qs.count() if is_latest else len(data_ids)
+        numerator = count
+    value = round((numerator / total * 100), 2) if total > 0 else 0
+else:
+    value = count + extra
+```
+
+> **Note**: The `and not include_empty` guard prevents the `include_unanswered` branch from running when `include_empty=True`, avoiding a double-add. When both flags are set, `include_empty` wins.
+
+### 1b. `handle_option_question` — forward the new param
+
+Same file. In the `if option_value:` block:
+
+```python
+if option_value:
+    return _option_value_filter(
+        question, data_ids, qs, is_latest,
+        option_value, sum_by, value_type,
+        include_unanswered=params.get("include_unanswered", False),
+        form=form,
+        params=params,
+        include_empty=params.get("include_empty", False),   # ADD
+    )
+```
+
+### 1c. `views.py` — parse query param
+
+File: `backend/api/v1/v1_visualization/views.py`
+
+Find where `include_unanswered` is parsed and add the new param alongside it:
+
+```python
+include_empty = (
+    request.GET.get("include_empty", "false").lower() == "true"
+)
+# Add to params dict passed to handlers:
+params["include_empty"] = include_empty
+```
+
+---
+
+## Phase 2 — Tests (TDD)
+
+File: `backend/api/v1/v1_visualization/tests/tests_values_option.py`
+
+Write tests BEFORE running (RED phase), then make them pass (GREEN).
+
+### Test setup
+
+The existing mixin gives:
+- 2 registered parents (`reg1`, `reg2`), both monitored
+- Latest: reg1→active, reg2→pending
+
+For `include_empty` tests we need **unmonitored** registrations. Add them in each test method (not in setUp) to avoid breaking existing tests:
+
+```python
+def _make_unmonitored_regs(self, n=2):
+    """Create n registered parents with zero monitoring submissions."""
+    created = []
+    for i in range(n):
+        fd = FormData.objects.create(
+            form=self.registration,
+            name=f"unreg_{i}",
+            administration=self.administration,
+        )
+        created.append(fd)
+    return created
+```
+
+### Test cases to add
+
+```
+test_include_empty_count_adds_never_monitored
+  Setup: 2 extra unmonitored regs → total=4, monitored=2, answered "active"=1
+  GET option_value=active, monitoring=latest, sum_by=parent_id, include_empty=true
+  Expected value = 1 (answered) + 2 (never monitored) = 3
+
+test_include_empty_percentage_uses_total_registered
+  Same setup (4 total, 1 answered active, 2 never monitored)
+  GET option_value=active, value_type=percentage, monitoring=latest,
+      sum_by=parent_id, include_empty=true
+  Expected value = (1+2)/4 × 100 = 75.0
+
+test_include_empty_no_unmonitored
+  No extra regs → total=2, monitored=2, answered "active"=1
+  GET include_empty=true
+  Expected value = 1 + 0 = 1  (no empty parents → same as without flag)
+
+test_include_empty_backward_compat
+  2 extra unmonitored regs present but flag NOT set
+  GET include_empty=false (or absent)
+  Expected value = 1  (only answered count, unmonitored ignored)
+```
+
+---
+
+## Phase 3 — Frontend config
+
+File: `frontend/src/config/visualizations/1749623934933.json`
+
+### Change 1: `kpi_under_construction` (lines ~148–162)
+
+```jsonc
+// Before
+"api": {
+  "form_id": 1749624452908,
+  "question_id": 1749630516826,
+  "option_value": "no",
+  "monitoring": "latest",
+  "sum_by": "parent_id",
+  "include_unanswered": true    // ← remove
+}
+
+// After
+"api": {
+  "form_id": 1749624452908,
+  "question_id": 1749630516826,
+  "option_value": "no",
+  "monitoring": "latest",
+  "sum_by": "parent_id",
+  "include_empty": true         // ← add
+}
+```
+
+### Change 2: `kpi_under_construction_pct` (lines ~884–892)
+
+```jsonc
+// Before
+"api": {
+  "form_id": 1749624452908,
+  "question_id": 1749630516826,
+  "option_value": "no",
+  "monitoring": "latest",
+  "sum_by": "parent_id",
+  "value_type": "percentage"
+  // may have include_unanswered: true incorrectly added
+}
+
+// After
+"api": {
+  "form_id": 1749624452908,
+  "question_id": 1749630516826,
+  "option_value": "no",
+  "monitoring": "latest",
+  "sum_by": "parent_id",
+  "value_type": "percentage",
+  "include_empty": true         // ← add
+}
+```
+
+---
+
+## Phase 4 — Verify
+
+### Backend tests
+
+```bash
+./dc.sh exec backend python manage.py test \
+  api.v1.v1_visualization.tests.tests_values_option -v 2
+```
+
+All tests must pass (green).
+
+### Manual API check
+
+```bash
+# Without flag (baseline): should return 3
+curl 'http://localhost:3000/api/v1/visualization/values?\
+form_id=1749624452908&question_id=1749630516826\
+&option_value=no&monitoring=latest&sum_by=parent_id'
+
+# With include_empty: should return 95 (3 + 92)
+curl 'http://localhost:3000/api/v1/visualization/values?\
+form_id=1749624452908&question_id=1749630516826\
+&option_value=no&monitoring=latest&sum_by=parent_id&include_empty=true'
+
+# Percentage: should return 90.48 (95/105 × 100)
+curl 'http://localhost:3000/api/v1/visualization/values?\
+form_id=1749624452908&question_id=1749630516826\
+&option_value=no&monitoring=latest&sum_by=parent_id\
+&value_type=percentage&include_empty=true'
+```
+
+### Dashboard visual check
+
+Open http://localhost:3000 → EPS Overview dashboard.
+
+| Card | Expected |
+|------|----------|
+| "Total EPS under construction" | 95 |
+| "Total EPS under construction" (%) | 90.48% |
+| Other KPI cards | Unchanged |
+
+---
+
+## Checklist
+
+```
+[ ] Phase 1a: _option_value_filter — include_empty branch added
+[ ] Phase 1b: handle_option_question — include_empty forwarded
+[ ] Phase 1c: views.py — include_empty parsed from query string
+[ ] Phase 2:  Tests written (RED), then pass (GREEN)
+[ ] Phase 3:  JSON config swapped on both construction KPIs
+[ ] Phase 4:  curl baseline = 3, with flag = 95, pct = 90.48
+[ ] Phase 4:  Dashboard cards show correct values
+[ ] Session close: git add + bd sync + git commit
+```

--- a/doc/claude/include-empty-param/requirements.md
+++ b/doc/claude/include-empty-param/requirements.md
@@ -1,0 +1,133 @@
+# Requirements: `include_empty` parameter for `/api/v1/visualization/values`
+
+For design and SQL, see [design.md](./design.md).  
+For the step-by-step implementation, see [implementation-plan.md](./implementation-plan.md).
+
+---
+
+## Problem statement
+
+The `kpi_under_construction` KPI cards on the EPS dashboard produce wrong numbers:
+
+| Card | Current value | Expected value | Why wrong |
+|------|--------------|----------------|-----------|
+| `kpi_under_construction` (count) | 105 | 95 | `include_unanswered=true` adds 102 never-monitored EPS to count of 3, giving 105 |
+| `kpi_under_construction_pct` (%) | 23.08% | 90.48% | Denominator is 13 (monitored EPS count) instead of 105 (total registered) |
+
+**Observed data facts** (EPS construction monitoring form):
+
+| Group | Count |
+|-------|-------|
+| Total registered EPS | 105 |
+| EPS with at least one monitoring submission | 13 |
+| EPS with latest monitoring answer = "no" (under construction) | 3 |
+| EPS with latest monitoring answer = "yes" (completed) | 10 |
+| EPS with **zero** monitoring submissions (never visited) | 92 |
+
+**What the KPI should express:**  
+"How many EPS are still under construction?" → answered "no" (3) + never monitored (92, assumed still under construction) = **95**
+
+**Percentage:** 95 / 105 total registered × 100 = **90.48%**
+
+---
+
+## Why `include_unanswered=true` is the wrong tool here
+
+`include_unanswered` (implemented in the previous feature cycle) was designed for the **donut / group_by_option** use case: it appends a `_no_info` bucket for parents that lack any qualifying answer. Its "unanswered" count is:
+
+```
+unanswered = total_parents − parents_who_answered_this_question_with_any_option
+```
+
+When applied to the construction KPI with `option_value=no`:
+- `all_answered_ids` = parents whose latest monitoring submission has `options IS NOT NULL` for this question
+- In the actual data, only 3 parents have a non-null options field → `all_answered_ids.size = 3`
+- `unanswered = 105 − 3 = 102`
+- `value = 3 + 102 = 105` ← wrong; this accidentally double-counts EPS that answered "yes"
+
+The root cause: `include_unanswered` measures **answer completeness within monitored parents**, not **monitoring coverage** of the full registered universe.
+
+---
+
+## `include_empty` — the correct concept
+
+`include_empty` explicitly counts registered parents with **zero monitoring submissions** — i.e., parents that never appear in `data_ids` at all.
+
+| Concept | "Empty" definition | What it measures |
+|---------|-------------------|-----------------|
+| `include_unanswered` | Parent has a monitoring submission but the specific question has null options | Data quality gaps within monitored EPS |
+| `include_empty` | Parent has **no monitoring submission** | Coverage gaps — EPS never visited |
+
+For the construction use case, the logical rule is:
+> "An EPS is 'under construction' if its latest monitoring says 'no', OR it has never been monitored (so we have no evidence it is complete)."
+
+---
+
+## Functional requirements
+
+### FR-1 — New `include_empty` flag
+
+`GET /api/v1/visualization/values` accepts a new boolean parameter `include_empty`.
+
+When `include_empty=true`, the count of registered parents with **zero monitoring submissions** is added to the result value.
+
+### FR-2 — Applies to `option_value` mode only
+
+`include_empty=true` is meaningful only when `option_value` is also provided (single-value filter mode). For all other modes (`group_by=option`, count mode, etc.) the flag is ignored with no error.
+
+### FR-3 — Monitoring forms only
+
+The flag is silently ignored when the requested form has no parent (registration-only forms). The same scope guard as `include_unanswered`.
+
+### FR-4 — Count mode behaviour
+
+```
+value = count(option_value answers) + count(parents with zero monitoring submissions)
+      = 3 + 92 = 95
+```
+
+### FR-5 — Percentage mode behaviour
+
+```
+numerator   = count(option_value answers) + count(never-monitored parents)
+            = 3 + 92 = 95
+denominator = total_parents_in_scope (all registered, respecting admin filter)
+            = 105
+value       = 95 / 105 × 100 = 90.48%
+```
+
+The denominator is `_total_parents_in_scope` — **not** the monitored EPS count.
+
+### FR-6 — Filter parity
+
+`include_empty` respects `administration_id` and `parent_criteria` filters. The "never monitored" pool is narrowed to the same parent universe as the option count.
+
+### FR-7 — `include_unanswered` unchanged
+
+No changes to `include_unanswered` semantics. Both flags can coexist; `include_empty` takes precedence when both are supplied for `option_value` mode.
+
+### FR-8 — No frontend React changes
+
+Only the JSON config (`api` block) and backend need to change. No new React components or hooks are required.
+
+---
+
+## Dashboard config changes required
+
+File: `frontend/src/config/visualizations/1749623934933.json`
+
+| Item id | Current api params | Required change |
+|---------|-------------------|----------------|
+| `kpi_under_construction` | `include_unanswered: true` | Replace with `include_empty: true` |
+| `kpi_under_construction_pct` | (was incorrectly set in prev session) | Replace with `include_empty: true` |
+
+The two `kpi_under_construction_*` cards share the same underlying query (construction monitoring form, `option_value=no`, `sum_by=parent_id`). Only the `value_type` differs (`number` vs `percentage`).
+
+---
+
+## Out of scope
+
+- `include_empty` for `group_by=option` / donut charts → use existing `include_unanswered`
+- `include_empty` for registration forms → guard in place, flag silently ignored
+- `include_empty` + `group_by=month` time series → deferred
+- Splitting "never visited" vs "visited but skipped" into separate buckets → deferred

--- a/frontend/src/components/dashboard/ChartRenderer.jsx
+++ b/frontend/src/components/dashboard/ChartRenderer.jsx
@@ -12,6 +12,7 @@ import { computeCrossTab } from "./compute/crossTab";
 import { computeAccessibilityBucket } from "./compute/accessibility";
 import { computeKpiStack } from "./compute/kpiStack";
 import DotsChart from "./DotsChart";
+import DotStripChart from "./DotStripChart";
 
 const COMPONENT_BY_TYPE = {
   bar: Bar,
@@ -473,9 +474,10 @@ const ChartRenderer = ({
   const chartType = item.chart_type === "histogram" ? "bar" : item.chart_type;
   const Component = COMPONENT_BY_TYPE[chartType];
   const isDots = item.chart_type === "dots";
+  const isDotStrip = item.chart_type === "dot_strip";
 
   const isApiDriven =
-    (Boolean(Component) || isDots) &&
+    (Boolean(Component) || isDots || isDotStrip) &&
     Boolean(item.api) &&
     (!item.compute || (item.compute === "kpi_stack" && !item.segments)) &&
     !item.source;
@@ -654,7 +656,7 @@ const ChartRenderer = ({
     fiscalYearStartMonth,
   ]);
 
-  if (!Component && !isDots) {
+  if (!Component && !isDots && !isDotStrip) {
     return (
       <Alert
         type="error"
@@ -687,6 +689,24 @@ const ChartRenderer = ({
       <div style={{ padding: 16, color: "#999", textAlign: "center" }}>
         No data
       </div>
+    );
+  }
+
+  if (isDotStrip) {
+    const boxRows = apiData?.data || [];
+    if (boxRows.length === 0) {
+      return (
+        <div style={{ padding: 16, color: "#999", textAlign: "center" }}>
+          No data
+        </div>
+      );
+    }
+    return (
+      <DotStripChart
+        rows={boxRows}
+        threshold={item.threshold}
+        config={item.config}
+      />
     );
   }
 

--- a/frontend/src/components/dashboard/DashboardRenderer.jsx
+++ b/frontend/src/components/dashboard/DashboardRenderer.jsx
@@ -31,6 +31,7 @@ const CHART_TYPES = new Set([
   "stack_bar",
   "histogram",
   "dots",
+  "dot_strip",
 ]);
 
 /**

--- a/frontend/src/components/dashboard/DotStripChart.jsx
+++ b/frontend/src/components/dashboard/DotStripChart.jsx
@@ -1,0 +1,240 @@
+import React, { useEffect, useRef } from "react";
+import PropTypes from "prop-types";
+import * as echarts from "echarts";
+
+/**
+ * Returns true when v satisfies all defined threshold bounds.
+ * threshold.max: v must be ≤ max; threshold.min: v must be ≥ min.
+ */
+const checkCompliant = (v, threshold) => {
+  if (!threshold) {
+    return true;
+  }
+  if (typeof threshold.max === "number" && v > threshold.max) {
+    return false;
+  }
+  if (typeof threshold.min === "number" && v < threshold.min) {
+    return false;
+  }
+  return true;
+};
+
+/**
+ * Sort values, assign rank-based jitter in [-JITTER, +JITTER], split into
+ * compliant (blue) and non-compliant (red) scatter datasets.
+ * Deterministic rank ordering keeps the chart stable across re-renders.
+ */
+const buildSeries = (rows, threshold) => {
+  const values = rows
+    .map((r) => Number(r.value))
+    .filter((v) => Number.isFinite(v))
+    .sort((a, b) => a - b);
+
+  const JITTER = 0.38;
+  const compliant = [];
+  const nonCompliant = [];
+
+  // Count occurrences per value for tooltip and jitter calculation.
+  const counts = new Map();
+  values.forEach((v) => counts.set(v, (counts.get(v) || 0) + 1));
+
+  // Track rank within each value group so jitter is per-group, not global.
+  // Single dots (count=1) get y=0. Groups spread evenly in [-JITTER, +JITTER].
+  // This prevents the "ascending curve" artifact where high-x dots accumulate
+  // high global-rank jitter, falsely implying a value–density correlation.
+  const rankWithin = new Map();
+  values.forEach((v) => {
+    const rank = rankWithin.get(v) || 0;
+    const n = counts.get(v);
+    const jitter = n > 1 ? (rank / (n - 1) - 0.5) * 2 * JITTER : 0;
+    rankWithin.set(v, rank + 1);
+    if (checkCompliant(v, threshold)) {
+      compliant.push([v, jitter]);
+    } else {
+      nonCompliant.push([v, jitter]);
+    }
+  });
+
+  return { compliant, nonCompliant, counts };
+};
+
+const BLUE_ZONE = "rgba(91,143,249,0.08)";
+const RED_ZONE = "rgba(231,76,60,0.08)";
+const LARGE = 1e9;
+
+const buildMarkAreaData = (threshold) => {
+  if (!threshold) {
+    return [];
+  }
+  const hasMax = typeof threshold.max === "number";
+  const hasMin = typeof threshold.min === "number";
+  if (hasMax && !hasMin) {
+    const zones = [];
+    if (threshold.max > 0) {
+      zones.push([
+        { xAxis: 0, itemStyle: { color: BLUE_ZONE } },
+        { xAxis: threshold.max },
+      ]);
+    }
+    zones.push([
+      { xAxis: threshold.max, itemStyle: { color: RED_ZONE } },
+      { xAxis: LARGE },
+    ]);
+    return zones;
+  }
+  if (hasMin && !hasMax) {
+    return [
+      [{ xAxis: 0, itemStyle: { color: RED_ZONE } }, { xAxis: threshold.min }],
+      [
+        { xAxis: threshold.min, itemStyle: { color: BLUE_ZONE } },
+        { xAxis: LARGE },
+      ],
+    ];
+  }
+  if (hasMin && hasMax) {
+    return [
+      [{ xAxis: 0, itemStyle: { color: RED_ZONE } }, { xAxis: threshold.min }],
+      [
+        { xAxis: threshold.min, itemStyle: { color: BLUE_ZONE } },
+        { xAxis: threshold.max },
+      ],
+      [
+        { xAxis: threshold.max, itemStyle: { color: RED_ZONE } },
+        { xAxis: LARGE },
+      ],
+    ];
+  }
+  return [];
+};
+
+const buildOption = (rows, threshold, config) => {
+  const axisLabel = config?.xAxisLabel || "";
+  const entityLabel = config?.entity_label || "";
+  const { compliant, nonCompliant, counts } = buildSeries(rows, threshold);
+
+  const allValues = rows
+    .map((r) => Number(r.value))
+    .filter((v) => Number.isFinite(v));
+  const dataMax = allValues.length > 0 ? Math.max(...allValues) : 0;
+  const threshMax = typeof threshold?.max === "number" ? threshold.max : 0;
+  const threshMin = typeof threshold?.min === "number" ? threshold.min : 0;
+  const rawMax = Math.max(dataMax, threshMax, threshMin);
+  const axisMax = rawMax === 0 ? 1 : null;
+
+  const markLineData = [];
+  if (threshold) {
+    if (typeof threshold.max === "number") {
+      markLineData.push({
+        xAxis: threshold.max,
+        lineStyle: { color: "#e74c3c", width: 2, type: "dashed" },
+        label: { show: false },
+      });
+    }
+    if (typeof threshold.min === "number") {
+      markLineData.push({
+        xAxis: threshold.min,
+        lineStyle: { color: "#e74c3c", width: 2, type: "dashed" },
+        label: { show: false },
+      });
+    }
+  }
+
+  const markAreaData = buildMarkAreaData(threshold);
+
+  const tooltipFormatter = (params) => {
+    const v = params.value[0];
+    const cnt = counts.get(v) || 1;
+    const noun = entityLabel ? ` ${entityLabel}` : "";
+    const suffix = cnt > 1 ? ` (${cnt}${noun})` : "";
+    return `Value: ${v} ${axisLabel}${suffix}`;
+  };
+
+  const scatterBase = { type: "scatter", symbolSize: 8 };
+
+  return {
+    grid: { top: 16, right: 24, bottom: 48, left: 24 },
+    tooltip: { trigger: "item", formatter: tooltipFormatter },
+    xAxis: {
+      type: "value",
+      name: axisLabel,
+      nameLocation: "middle",
+      nameGap: 32,
+      min: 0,
+      ...(axisMax !== null ? { max: axisMax } : {}),
+    },
+    yAxis: {
+      type: "value",
+      min: -0.5,
+      max: 0.5,
+      show: false,
+      splitLine: { show: false },
+    },
+    series: [
+      {
+        ...scatterBase,
+        name: "Compliant",
+        data: compliant,
+        itemStyle: { color: "#5b8ff9" },
+        ...(markLineData.length > 0
+          ? {
+              markLine: {
+                symbol: "none",
+                silent: true,
+                animation: false,
+                data: markLineData,
+              },
+            }
+          : {}),
+        ...(markAreaData.length > 0
+          ? { markArea: { silent: true, data: markAreaData } }
+          : {}),
+      },
+      {
+        ...scatterBase,
+        name: "Above threshold",
+        data: nonCompliant,
+        itemStyle: { color: "#e74c3c" },
+      },
+    ],
+  };
+};
+
+const DotStripChart = ({ rows, threshold, config }) => {
+  const containerRef = useRef(null);
+
+  useEffect(() => {
+    const container = containerRef.current;
+    if (!container || rows.length === 0) {
+      return () => {};
+    }
+
+    const chart =
+      echarts.getInstanceByDom(container) || echarts.init(container);
+    chart.setOption(buildOption(rows, threshold, config), true);
+    chart.resize();
+
+    const handleResize = () => chart.resize();
+    window.addEventListener("resize", handleResize);
+
+    return () => {
+      window.removeEventListener("resize", handleResize);
+      chart.dispose();
+    };
+  }, [rows, threshold, config]);
+
+  return <div ref={containerRef} style={{ height: 120, width: "100%" }} />;
+};
+
+DotStripChart.propTypes = {
+  rows: PropTypes.arrayOf(PropTypes.object).isRequired,
+  threshold: PropTypes.shape({
+    min: PropTypes.number,
+    max: PropTypes.number,
+  }),
+  config: PropTypes.shape({
+    xAxisLabel: PropTypes.string,
+    entity_label: PropTypes.string,
+  }),
+};
+
+export default DotStripChart;

--- a/frontend/src/components/dashboard/EscalationTable.jsx
+++ b/frontend/src/components/dashboard/EscalationTable.jsx
@@ -1,8 +1,9 @@
 import React, { useCallback, useMemo, useState } from "react";
 import PropTypes from "prop-types";
-import { Alert, Table } from "antd";
+import { Alert, Table, Button } from "antd";
 import { DownCircleOutlined, LeftCircleOutlined } from "@ant-design/icons";
 import { useDashboardEscalation } from "../../util/hooks";
+import { uiText, store } from "../../lib";
 
 const MAX_COLUMNS = 6;
 
@@ -47,6 +48,11 @@ const EscalationTable = ({
     pageSize,
     customFilterDefs,
   });
+  uiText;
+  const { active: activeLang } = store.useState((s) => s.language);
+  const text = useMemo(() => {
+    return uiText?.[activeLang] || uiText.en;
+  }, [activeLang]);
 
   const visibleColumns = useMemo(
     () => (item.columns || []).filter((c) => !c.hide),
@@ -96,43 +102,65 @@ const EscalationTable = ({
   );
 
   const renderExpandedRow = useCallback(
-    (row) => {
+    (row, item, text) => {
       const rows = visibleColumns.map((c) => ({
         key: c.key,
         label: c.label,
         display: renderValue(c, row, cellComputers),
       }));
       return (
-        <div className="pending-data-wrapper">
-          <h3>{item.label || "Details"}</h3>
-          <Table
-            pagination={false}
-            dataSource={rows}
-            rowKey="key"
-            columns={[
-              {
-                title: "Question",
-                dataIndex: "label",
-                width: "50%",
-                className: "table-col-question",
-              },
-              {
-                title: "Response",
-                dataIndex: "display",
-                width: "50%",
-                render: (display) =>
-                  display === null ? (
-                    <span style={{ color: "#bbb" }}>—</span>
-                  ) : (
-                    display
-                  ),
-              },
-            ]}
-          />
+        <div>
+          {item?.api?.form_id && (
+            <div
+              style={{
+                textAlign: "right",
+                marginRight: 20,
+                paddingBottom: 4,
+                paddingTop: 4,
+              }}
+            >
+              <a
+                href={`/control-center/data/${item.api.form_id}/monitoring/${row.id}`}
+                target="_blank"
+                rel="noopener noreferrer"
+              >
+                <Button type="primary" shape="round">
+                  {text.viewDetails}
+                </Button>
+              </a>
+            </div>
+          )}
+          <div className="pending-data-wrapper">
+            <h3>{item.label || "Details"}</h3>
+            <Table
+              pagination={false}
+              dataSource={rows}
+              rowKey="key"
+              columns={[
+                {
+                  title: "Question",
+                  dataIndex: "label",
+                  width: "50%",
+                  className: "table-col-question",
+                },
+                {
+                  title: "Response",
+                  dataIndex: "display",
+                  width: "50%",
+                  render: (display) =>
+                    display === null ? (
+                      <span style={{ color: "#bbb" }}>—</span>
+                    ) : (
+                      display
+                    ),
+                },
+              ]}
+            />
+          </div>
         </div>
       );
     },
-    [visibleColumns, cellComputers, item.label]
+    [visibleColumns, cellComputers]
   );
 
   if (error) {
@@ -151,7 +179,7 @@ const EscalationTable = ({
       columns={columns}
       dataSource={data?.results || []}
       expandable={{
-        expandedRowRender: renderExpandedRow,
+        expandedRowRender: (row) => renderExpandedRow(row, item, text),
         expandRowByClick: true,
         expandIcon: ({ expanded, onExpand, record }) =>
           expanded ? (

--- a/frontend/src/components/dashboard/__test__/ChartRenderer.test.js
+++ b/frontend/src/components/dashboard/__test__/ChartRenderer.test.js
@@ -6,6 +6,14 @@ import { __clearVisualizationCache } from "../../../util/hooks/useVisualizationR
 
 jest.mock("axios");
 
+// Stub ECharts so DotStripChart can render in jsdom without a real canvas.
+// Implementations (init return value, getInstanceByDom return value) are set
+// up per-test via mockReturnValue so the factory stays free of jest.fn closures.
+jest.mock("echarts", () => ({
+  init: jest.fn(),
+  getInstanceByDom: jest.fn(),
+}));
+
 // Replace akvo-charts with lightweight stand-ins that expose the props they
 // were called with, so we can assert on what ChartRenderer passed through.
 // Bar is forwardRef so ChartWithMarkLines can call ref.current.setOption;
@@ -505,5 +513,55 @@ describe("ChartRenderer", () => {
         "true"
       )
     );
+  });
+
+  test("boxplot fetches data and renders a chart container", async () => {
+    const echartsLib = require("echarts");
+    const mockChart = {
+      setOption: jest.fn(),
+      resize: jest.fn(),
+      dispose: jest.fn(),
+    };
+    echartsLib.init.mockReset();
+    echartsLib.getInstanceByDom.mockReset();
+    echartsLib.init.mockReturnValue(mockChart);
+    echartsLib.getInstanceByDom.mockReturnValue(null);
+
+    axios.mockResolvedValue({
+      data: {
+        data: [
+          { value: 0, label: "EPS A", group: "a" },
+          { value: 0, label: "EPS B", group: "b" },
+          { value: 15, label: "EPS C", group: "c" },
+          { value: 200, label: "EPS D", group: "d" },
+        ],
+      },
+    });
+
+    render(
+      <ChartRenderer
+        item={{
+          id: "param_total_coliform",
+          chart_type: "dot_strip",
+          threshold: { max: 0 },
+          config: { title: "Total coliform presence", xAxisLabel: "CFU/100mL" },
+          api: {
+            form_id: 1749632545233,
+            question_id: 1749633259392,
+            group_by: "parent_id",
+            monitoring: "latest",
+          },
+        }}
+        filterState={emptyFilters}
+        today={today}
+      />
+    );
+
+    await waitFor(() => expect(echartsLib.init).toHaveBeenCalled());
+    expect(mockChart.setOption).toHaveBeenCalled();
+    const option = mockChart.setOption.mock.calls[0][0];
+    expect(option.series[0].type).toBe("scatter");
+    expect(option.series[0].markLine.data[0].xAxis).toBe(0);
+    expect(axios).toHaveBeenCalledTimes(1);
   });
 });

--- a/frontend/src/components/dashboard/compute/progressHistogram.js
+++ b/frontend/src/components/dashboard/compute/progressHistogram.js
@@ -10,7 +10,6 @@ export const toHistogramBarData = (response) => {
   return histogram.map((bucket) => ({
     label: bucket.progress,
     value: bucket.count,
-    group: bucket.progress,
   }));
 };
 

--- a/frontend/src/components/dashboard/custom-components/IndividualEPSOverview.jsx
+++ b/frontend/src/components/dashboard/custom-components/IndividualEPSOverview.jsx
@@ -42,6 +42,8 @@ import {
   WQ_CBT_PARAMS,
   WQ_DATE_QID,
   WQ_LAB_PARAMS,
+  WQ_LAB_CHEMICAL_PARAMS,
+  WQ_LAB_PHYSICAL_PARAMS,
   WQ_PHOTO_CAPTION_QID,
   WQ_PHOTO_QID,
   WQ_STATUS_QID,
@@ -377,25 +379,57 @@ const IndividualEPSOverview = () => {
               </Row>
 
               {showLabCharts && (
-                <Card
-                  title="Microbial parameters"
-                  size="small"
-                  style={{ marginBottom: 16 }}
+                <Space
+                  direction="vertical"
+                  size="large"
+                  style={{ width: "100%", marginBottom: 16 }}
                 >
-                  <Row gutter={16}>
-                    {WQ_LAB_PARAMS.map((p) => (
-                      <Col span={8} key={p.key}>
-                        <HistoricalLineChart
-                          title={p.title}
-                          data={buildSeries(wqHistory.rows, p.qid)}
-                          unit={p.unit}
-                          thresholdMin={p.thresholdMin}
-                          thresholdMax={p.thresholdMax}
-                        />
-                      </Col>
-                    ))}
-                  </Row>
-                </Card>
+                  <Card title="Microbial parameters" size="small">
+                    <Row gutter={16}>
+                      {WQ_LAB_PARAMS.map((p) => (
+                        <Col xl={8} lg={12} md={24} key={p.key}>
+                          <HistoricalLineChart
+                            title={p.title}
+                            data={buildSeries(wqHistory.rows, p.qid)}
+                            unit={p.unit}
+                            thresholdMin={p.thresholdMin}
+                            thresholdMax={p.thresholdMax}
+                          />
+                        </Col>
+                      ))}
+                    </Row>
+                  </Card>
+                  <Card title="Chemical Parameters" size="small">
+                    <Row gutter={16}>
+                      {WQ_LAB_CHEMICAL_PARAMS.map((p) => (
+                        <Col xl={8} lg={12} md={24} key={p.key}>
+                          <HistoricalLineChart
+                            title={p.title}
+                            data={buildSeries(wqHistory.rows, p.qid)}
+                            unit={p.unit}
+                            thresholdMin={p.thresholdMin}
+                            thresholdMax={p.thresholdMax}
+                          />
+                        </Col>
+                      ))}
+                    </Row>
+                  </Card>
+                  <Card title="Physical Parameters" size="small">
+                    <Row gutter={16}>
+                      {WQ_LAB_PHYSICAL_PARAMS.map((p) => (
+                        <Col xl={8} lg={12} md={24} key={p.key}>
+                          <HistoricalLineChart
+                            title={p.title}
+                            data={buildSeries(wqHistory.rows, p.qid)}
+                            unit={p.unit}
+                            thresholdMin={p.thresholdMin}
+                            thresholdMax={p.thresholdMax}
+                          />
+                        </Col>
+                      ))}
+                    </Row>
+                  </Card>
+                </Space>
               )}
 
               {showCbtCharts && (
@@ -408,6 +442,7 @@ const IndividualEPSOverview = () => {
                           data={buildSeries(wqHistory.rows, p.qid)}
                           unit={p.unit}
                           thresholdMax={p.thresholdMax}
+                          thresholdMin={p.thresholdMin}
                         />
                       </Col>
                     ))}

--- a/frontend/src/components/dashboard/custom-components/individual-overview/config/eps.js
+++ b/frontend/src/components/dashboard/custom-components/individual-overview/config/eps.js
@@ -216,13 +216,66 @@ export const WQ_LAB_PARAMS = [
   },
 ];
 
+/**
+ * Chemical Parameters.
+ * Lab test that includes: pH, Conductivity and Salinity.
+ */
+
+export const WQ_LAB_CHEMICAL_PARAMS = [
+  {
+    key: "ph",
+    title: "pH",
+    qid: 1797307852532,
+    unit: "pH",
+    thresholdMax: 8.5,
+    thresholdMin: 6.5,
+  },
+  {
+    key: "conductivity",
+    title: "Conductivity",
+    qid: 1797307852533,
+    unit: "µS/cm",
+    thresholdMax: 1000,
+  },
+  {
+    key: "salinity",
+    title: "Salinity",
+    qid: 1797307852534,
+    unit: "ppt",
+    thresholdMax: 0.5,
+  },
+];
+
+/**
+ * Physical parameters.
+ * Lab test that includes: Temperature and Turbidity in NTU.
+ */
+
+export const WQ_LAB_PHYSICAL_PARAMS = [
+  {
+    key: "temperature",
+    title: "Temperature",
+    qid: 1797307852531,
+    unit: "°C",
+    thresholdMax: 30,
+  },
+  {
+    key: "turbidity",
+    title: "Turbidity",
+    qid: 1749633220745,
+    unit: "NTU",
+    thresholdMax: 5,
+  },
+];
+
 export const WQ_CBT_PARAMS = [
   {
     key: "cbt_count",
-    title: "CBT contamination count",
+    title: "Contamination using CBT bags",
     qid: 1749633325456,
     unit: "count",
-    thresholdMax: 0,
+    thresholdMax: 5,
+    thresholdMin: 3,
   },
 ];
 

--- a/frontend/src/components/dashboard/custom-components/individual-overview/shared/HistoricalLineChart.jsx
+++ b/frontend/src/components/dashboard/custom-components/individual-overview/shared/HistoricalLineChart.jsx
@@ -24,11 +24,15 @@ const numericValue = (raw) => {
 const FIGURE_MIN_HEIGHT = 320;
 
 /**
- * <Line> with rotated x-axis labels. akvo-charts doesn't expose axisLabel
- * config, so we grab the ECharts instance via callback ref and setOption
- * after mount — same pattern as ChartRenderer's ChartWithScrollLegend.
+ * <Line> with rotated x-axis labels and optional threshold markArea.
+ * akvo-charts doesn't expose axisLabel or series-level config, so we grab
+ * the ECharts instance via callback ref and setOption after mount — same
+ * pattern as ChartRenderer's ChartWithScrollLegend.
+ *
+ * markAreaBounds drives the green band; yAxisFloor extends the y-axis below
+ * the threshold so the band is visible when thresholdMax is at or near 0.
  */
-const LineWithRotatedAxis = ({ config, data }) => {
+const LineWithRotatedAxis = ({ config, data, markAreaBounds, yAxisFloor }) => {
   const [chart, setChart] = useState(null);
   const setRef = useCallback((instance) => {
     if (instance && typeof instance.setOption === "function") {
@@ -39,17 +43,31 @@ const LineWithRotatedAxis = ({ config, data }) => {
     if (!chart) {
       return;
     }
-    chart.setOption(
-      {
-        xAxis: {
-          axisTick: { alignWithLabel: true },
-          axisLabel: { rotate: 45, interval: "auto", hideOverlap: true },
-          nameGap: 64,
-          nameLocation: "middle",
-        },
+    const opts = {
+      xAxis: {
+        axisTick: { alignWithLabel: true },
+        axisLabel: { rotate: 45, interval: "auto", hideOverlap: true },
+        nameGap: 64,
+        nameLocation: "middle",
       },
-      false
-    );
+    };
+    if (markAreaBounds) {
+      opts.series = [
+        {
+          markArea: {
+            silent: true,
+            itemStyle: { color: "rgba(82, 196, 26, 0.12)" },
+            data: [
+              [{ yAxis: markAreaBounds.lo }, { yAxis: markAreaBounds.hi }],
+            ],
+          },
+        },
+      ];
+    }
+    if (typeof yAxisFloor === "number") {
+      opts.yAxis = { min: yAxisFloor };
+    }
+    chart.setOption(opts, false);
   }); // No deps: re-apply after every render (akvo-charts re-runs setOption each render).
   return <Line ref={setRef} config={config} data={data} />;
 };
@@ -57,6 +75,11 @@ const LineWithRotatedAxis = ({ config, data }) => {
 LineWithRotatedAxis.propTypes = {
   config: PropTypes.object.isRequired,
   data: PropTypes.array.isRequired,
+  markAreaBounds: PropTypes.shape({
+    lo: PropTypes.number,
+    hi: PropTypes.number,
+  }),
+  yAxisFloor: PropTypes.number,
 };
 
 /**
@@ -85,28 +108,40 @@ const HistoricalLineChart = ({
       .filter((row) => row.value !== null);
   }, [sorted]);
 
-  const chartConfig = useMemo(() => {
-    // No `title` here — the AntD <Card> header already shows it. Height is
-    // driven by div[role="figure"]'s SCSS min-height.
-    const cfg = {
+  const chartConfig = useMemo(
+    () => ({
       ...baseConfig,
       xAxisLabel: "Date",
       yAxisLabel: unit || "",
-    };
+    }),
+    [unit]
+  );
+
+  // markArea bounds for the green threshold band, passed to LineWithRotatedAxis
+  // which applies them directly via chart.setOption (ECharts series-level API).
+  // Avoids ±Infinity which ECharts silently drops.
+  const markAreaBounds = useMemo(() => {
     const hasMin = typeof thresholdMin === "number";
     const hasMax = typeof thresholdMax === "number";
-    if (hasMin || hasMax) {
-      const lo = hasMin ? thresholdMin : -Infinity;
-      const hi = hasMax ? thresholdMax : Infinity;
-      cfg.rawConfig = {
-        markArea: {
-          itemStyle: { color: "rgba(82, 196, 26, 0.12)" },
-          data: [[{ yAxis: lo }, { yAxis: hi }]],
-        },
-      };
+    if (!hasMin && !hasMax) {
+      return null;
     }
-    return cfg;
-  }, [unit, thresholdMin, thresholdMax]);
+    return {
+      lo: hasMin ? thresholdMin : thresholdMax - 1,
+      hi: hasMax ? thresholdMax : thresholdMin + 1,
+    };
+  }, [thresholdMin, thresholdMax]);
+
+  // When only thresholdMax is set (e.g. E-coli max=0), the safe band sits one
+  // unit below the threshold. Extend yAxis.min so that band is visible.
+  const yAxisFloor = useMemo(() => {
+    const hasMin = typeof thresholdMin === "number";
+    const hasMax = typeof thresholdMax === "number";
+    if (hasMax && !hasMin) {
+      return thresholdMax - 1;
+    }
+    return null;
+  }, [thresholdMin, thresholdMax]);
 
   const body =
     seriesData.length === 0 ? (
@@ -121,7 +156,12 @@ const HistoricalLineChart = ({
         <Empty description="No history yet" />
       </div>
     ) : (
-      <LineWithRotatedAxis config={chartConfig} data={seriesData} />
+      <LineWithRotatedAxis
+        config={chartConfig}
+        data={seriesData}
+        markAreaBounds={markAreaBounds}
+        yAxisFloor={yAxisFloor}
+      />
     );
 
   return (

--- a/frontend/src/components/dashboard/widgets/MetricCard.jsx
+++ b/frontend/src/components/dashboard/widgets/MetricCard.jsx
@@ -46,8 +46,8 @@ const formatRatioPercentage = (numerator, denominator) => {
   if (isMissingPair(numerator, denominator)) {
     return "—";
   }
-  const pct = Math.round((numerator / denominator) * 100);
-  return `${numerator}/${denominator} (${pct}%)`;
+  const pct = (numerator / denominator) * 100;
+  return `${numerator}/${denominator} (${parseFloat(pct.toFixed(2))}%)`;
 };
 
 const formatShare = (numerator, denominator) => {

--- a/frontend/src/components/dashboard/widgets/__test__/MetricCard.test.jsx
+++ b/frontend/src/components/dashboard/widgets/__test__/MetricCard.test.jsx
@@ -79,7 +79,7 @@ describe("MetricCard — share mode (target_group set)", () => {
     expect(await screen.findByText("2/4 (50%)")).toBeInTheDocument();
   });
 
-  test("rounds percentage to nearest integer", async () => {
+  test("strips trailing zeros, up to 2 dp when non-zero", async () => {
     axiosRows([
       { group: "operational", value: 1 },
       { group: "non_functional", value: 2 },
@@ -90,8 +90,8 @@ describe("MetricCard — share mode (target_group set)", () => {
         filterState={emptyFilters}
       />
     );
-    // 1/3 = 33.33... → 33%
-    expect(await screen.findByText("1/3 (33%)")).toBeInTheDocument();
+    // 1/3 = 33.33...%
+    expect(await screen.findByText("1/3 (33.33%)")).toBeInTheDocument();
   });
 
   test("renders — when denominator is zero (all values zero)", async () => {

--- a/frontend/src/config/visualizations/1749621221728.json
+++ b/frontend/src/config/visualizations/1749621221728.json
@@ -838,7 +838,7 @@
             },
             {
               "id": "param_e_coli",
-              "chart_type": "histogram",
+              "chart_type": "dot_strip",
               "order": 11,
               "col_span": 12,
               "group": "microbial",
@@ -847,12 +847,7 @@
               "config": {
                 "title": "E-coli presence",
                 "xAxisLabel": "CFU/100mL",
-                "yAxisLabel": "RWS count",
-                "yAxis": { "minInterval": 1 }
-              },
-              "display": {
-                "mode": "histogram",
-                "bin_width": 50
+                "entity_label": "RWS"
               },
               "threshold": {
                 "max": 0
@@ -867,7 +862,7 @@
             },
             {
               "id": "param_total_coliform",
-              "chart_type": "histogram",
+              "chart_type": "dot_strip",
               "order": 12,
               "col_span": 12,
               "group": "microbial",
@@ -876,12 +871,7 @@
               "config": {
                 "title": "Total coliform presence",
                 "xAxisLabel": "CFU/100mL",
-                "yAxisLabel": "RWS count",
-                "yAxis": { "minInterval": 1 }
-              },
-              "display": {
-                "mode": "histogram",
-                "bin_width": 50
+                "entity_label": "RWS"
               },
               "threshold": {
                 "max": 0
@@ -896,7 +886,7 @@
             },
             {
               "id": "param_fecal_coliform",
-              "chart_type": "histogram",
+              "chart_type": "dot_strip",
               "order": 13,
               "col_span": 12,
               "group": "microbial",
@@ -906,12 +896,7 @@
               "config": {
                 "title": "Fecal coliform presence",
                 "xAxisLabel": "CFU/100mL",
-                "yAxisLabel": "RWS count",
-                "yAxis": { "minInterval": 1 }
-              },
-              "display": {
-                "mode": "histogram",
-                "bin_width": 50
+                "entity_label": "RWS"
               },
               "threshold": {
                 "max": 0
@@ -933,7 +918,7 @@
             },
             {
               "id": "param_turbidity",
-              "chart_type": "histogram",
+              "chart_type": "dot_strip",
               "order": 21,
               "col_span": 12,
               "group": "physical",
@@ -942,12 +927,7 @@
               "config": {
                 "title": "Turbidity",
                 "xAxisLabel": "NTU",
-                "yAxisLabel": "RWS count",
-                "yAxis": { "minInterval": 1 }
-              },
-              "display": {
-                "mode": "histogram",
-                "bin_width": 1
+                "entity_label": "RWS"
               },
               "threshold": {
                 "max": 5
@@ -962,7 +942,7 @@
             },
             {
               "id": "param_temperature",
-              "chart_type": "histogram",
+              "chart_type": "dot_strip",
               "order": 22,
               "col_span": 12,
               "group": "physical",
@@ -971,12 +951,7 @@
               "config": {
                 "title": "Water Temperature",
                 "xAxisLabel": "°C",
-                "yAxisLabel": "RWS count",
-                "yAxis": { "minInterval": 1 }
-              },
-              "display": {
-                "mode": "histogram",
-                "bin_width": 1
+                "entity_label": "RWS"
               },
               "threshold": {
                 "max": 30
@@ -998,7 +973,7 @@
             },
             {
               "id": "param_ph",
-              "chart_type": "histogram",
+              "chart_type": "dot_strip",
               "order": 31,
               "col_span": 8,
               "group": "chemical",
@@ -1007,12 +982,7 @@
               "config": {
                 "title": "pH",
                 "xAxisLabel": "pH",
-                "yAxisLabel": "RWS count",
-                "yAxis": { "minInterval": 1 }
-              },
-              "display": {
-                "mode": "histogram",
-                "bin_width": 0.5
+                "entity_label": "RWS"
               },
               "threshold": {
                 "min": 6.5,
@@ -1028,7 +998,7 @@
             },
             {
               "id": "param_conductivity",
-              "chart_type": "histogram",
+              "chart_type": "dot_strip",
               "order": 32,
               "col_span": 8,
               "group": "chemical",
@@ -1037,12 +1007,7 @@
               "config": {
                 "title": "Conductivity",
                 "xAxisLabel": "µS/cm",
-                "yAxisLabel": "RWS count",
-                "yAxis": { "minInterval": 1 }
-              },
-              "display": {
-                "mode": "histogram",
-                "bin_width": 100
+                "entity_label": "RWS"
               },
               "threshold": {
                 "max": 1000
@@ -1057,7 +1022,7 @@
             },
             {
               "id": "param_salinity",
-              "chart_type": "histogram",
+              "chart_type": "dot_strip",
               "order": 33,
               "col_span": 8,
               "group": "chemical",
@@ -1066,12 +1031,7 @@
               "config": {
                 "title": "Salinity",
                 "xAxisLabel": "ppt",
-                "yAxisLabel": "RWS count",
-                "yAxis": { "minInterval": 1 }
-              },
-              "display": {
-                "mode": "histogram",
-                "bin_width": 0.1
+                "entity_label": "RWS"
               },
               "threshold": {
                 "max": 1

--- a/frontend/src/config/visualizations/1749623934933.json
+++ b/frontend/src/config/visualizations/1749623934933.json
@@ -157,7 +157,7 @@
         "option_value": "no",
         "monitoring": "latest",
         "sum_by": "parent_id",
-        "include_unanswered": true
+        "include_empty": true
       }
     },
     {
@@ -656,7 +656,7 @@
             },
             {
               "id": "param_e_coli",
-              "chart_type": "histogram",
+              "chart_type": "dot_strip",
               "order": 11,
               "col_span": 12,
               "group": "microbial",
@@ -665,12 +665,7 @@
               "config": {
                 "title": "E-coli presence",
                 "xAxisLabel": "CFU/100mL",
-                "yAxisLabel": "EPS count",
-                "yAxis": { "minInterval": 1 }
-              },
-              "display": {
-                "mode": "histogram",
-                "bin_width": 50
+                "entity_label": "EPS"
               },
               "threshold": {
                 "max": 0
@@ -685,7 +680,7 @@
             },
             {
               "id": "param_total_coliform",
-              "chart_type": "histogram",
+              "chart_type": "dot_strip",
               "order": 12,
               "col_span": 12,
               "group": "microbial",
@@ -694,12 +689,7 @@
               "config": {
                 "title": "Total coliform presence",
                 "xAxisLabel": "CFU/100mL",
-                "yAxisLabel": "EPS count",
-                "yAxis": { "minInterval": 1 }
-              },
-              "display": {
-                "mode": "histogram",
-                "bin_width": 50
+                "entity_label": "EPS"
               },
               "threshold": {
                 "max": 0
@@ -714,7 +704,7 @@
             },
             {
               "id": "param_fecal_coliform",
-              "chart_type": "histogram",
+              "chart_type": "dot_strip",
               "order": 13,
               "col_span": 12,
               "group": "microbial",
@@ -724,12 +714,7 @@
               "config": {
                 "title": "Fecal coliform presence",
                 "xAxisLabel": "CFU/100mL",
-                "yAxisLabel": "EPS count",
-                "yAxis": { "minInterval": 1 }
-              },
-              "display": {
-                "mode": "histogram",
-                "bin_width": 50
+                "entity_label": "EPS"
               },
               "threshold": {
                 "max": 0
@@ -751,7 +736,7 @@
             },
             {
               "id": "param_turbidity",
-              "chart_type": "histogram",
+              "chart_type": "dot_strip",
               "order": 21,
               "col_span": 12,
               "group": "physical",
@@ -760,12 +745,7 @@
               "config": {
                 "title": "Turbidity",
                 "xAxisLabel": "NTU",
-                "yAxisLabel": "EPS count",
-                "yAxis": { "minInterval": 1 }
-              },
-              "display": {
-                "mode": "histogram",
-                "bin_width": 1
+                "entity_label": "EPS"
               },
               "threshold": {
                 "max": 5
@@ -780,7 +760,7 @@
             },
             {
               "id": "param_temperature",
-              "chart_type": "histogram",
+              "chart_type": "dot_strip",
               "order": 22,
               "col_span": 12,
               "group": "physical",
@@ -789,12 +769,7 @@
               "config": {
                 "title": "Water Temperature",
                 "xAxisLabel": "°C",
-                "yAxisLabel": "EPS count",
-                "yAxis": { "minInterval": 1 }
-              },
-              "display": {
-                "mode": "histogram",
-                "bin_width": 1
+                "entity_label": "EPS"
               },
               "threshold": {
                 "max": 30
@@ -816,7 +791,7 @@
             },
             {
               "id": "param_ph",
-              "chart_type": "histogram",
+              "chart_type": "dot_strip",
               "order": 31,
               "col_span": 8,
               "group": "chemical",
@@ -825,12 +800,7 @@
               "config": {
                 "title": "pH",
                 "xAxisLabel": "pH",
-                "yAxisLabel": "EPS count",
-                "yAxis": { "minInterval": 1 }
-              },
-              "display": {
-                "mode": "histogram",
-                "bin_width": 0.5
+                "entity_label": "EPS"
               },
               "threshold": {
                 "min": 6.5,
@@ -846,7 +816,7 @@
             },
             {
               "id": "param_conductivity",
-              "chart_type": "histogram",
+              "chart_type": "dot_strip",
               "order": 32,
               "col_span": 8,
               "group": "chemical",
@@ -855,12 +825,7 @@
               "config": {
                 "title": "Conductivity",
                 "xAxisLabel": "µS/cm",
-                "yAxisLabel": "EPS count",
-                "yAxis": { "minInterval": 1 }
-              },
-              "display": {
-                "mode": "histogram",
-                "bin_width": 100
+                "entity_label": "EPS"
               },
               "threshold": {
                 "max": 1000
@@ -875,7 +840,7 @@
             },
             {
               "id": "param_salinity",
-              "chart_type": "histogram",
+              "chart_type": "dot_strip",
               "order": 33,
               "col_span": 8,
               "group": "chemical",
@@ -884,12 +849,7 @@
               "config": {
                 "title": "Salinity",
                 "xAxisLabel": "ppt",
-                "yAxisLabel": "EPS count",
-                "yAxis": { "minInterval": 1 }
-              },
-              "display": {
-                "mode": "histogram",
-                "bin_width": 0.1
+                "entity_label": "EPS"
               },
               "threshold": {
                 "max": 1
@@ -922,7 +882,8 @@
                 "option_value": "no",
                 "monitoring": "latest",
                 "sum_by": "parent_id",
-                "value_type": "percentage"
+                "value_type": "percentage",
+                "include_empty": true
               }
             },
             {

--- a/frontend/src/config/visualizations/README.md
+++ b/frontend/src/config/visualizations/README.md
@@ -94,7 +94,8 @@ Only these six keys at the top level. Everything else is an item.
 | `card` | KPI tile | `color`, `api`, `api.value_type` (including `"ratio_percentage"` + sibling `denominator_api`), or `compute` ∈ {`compliance_kpi`, `accessibility_no_issues_kpi`} |
 | `metric_card` | Single-fetch metric tile (count / % / share / share %) | `color`, `api`, `target_group`, `show_percentage` — see [Metric cards](#8-metric-cards-metric_card) |
 | `bar`, `line`, `doughnut`, `half_doughnut`, `pie`, `stack_bar` | akvo-charts component | `config`, and one of: `api` / (`source`+`progress_ref`+`field`) / (`compute`+`params_ref`+`globals_ref`) / (`compute`+`category_api`+`series_api`) / (`compute`+`sample_api`+`issues_api`) / (`compute`+`segments[]`) |
-| `histogram` | Bar chart with binned water-quality data | `group`, `threshold`, `display`, `api` |
+| `boxplot` | Dot strip plot — one dot per record, colored by threshold compliance | `threshold`, `config` (`xAxisLabel`, `entity_label`), `api` — see [Dot strip chart](#9-dot-strip-chart-boxplot) |
+| `histogram` | Bar chart with binned numeric data (legacy — prefer `boxplot` for water-quality params) | `group`, `threshold`, `display`, `api` |
 | `table` | Escalation / data table | `api` (with `criteria[]`), `columns[]` |
 | `map` | Leaflet map | `source_form_id`, `status_question_id`, `status_monitoring_form_id`, `status_colors`, `click_url_template` |
 | `section_title` | `<h4>` heading | `text` |
@@ -205,8 +206,8 @@ background. No extra API call.
 
 ### 3. Frontend-computed (`compute: "compliance"`)
 
-Fans out `/values` calls per referenced `histogram` item (via `params_ref[]`)
-and builds a stacked-bar chart client-side.
+Fans out `/values` calls per referenced water-quality param item (via `params_ref[]`)
+and builds a stacked-bar chart client-side. Param items are typically `chart_type: "dot_strip"`.
 
 ```json
 {
@@ -429,82 +430,65 @@ Scalar count example (no `target_group`, no `show_percentage`):
 }
 ```
 
----
+### 9. Dot strip chart (`boxplot`)
 
-## Custom component escape hatch
-
-Some dashboard tabs follow a **record-centric** pattern that does not fit the
-aggregate chart paradigm — the user picks one record and downstream widgets
-render details for that single record. Rather than extending the JSON schema
-with primitives that only make sense for these tabs (token templates,
-component dependencies, custom endpoints, named render registries), use the
-`custom_component` chart_type to delegate rendering to a freely authored React
-component.
-
-### When to reach for it
-
-- The interaction model is **record-centric**, not aggregate.
-- The tab needs internal state that is not expressible as a global filter.
-- The behavior is unique enough that no other dashboard would reuse it today.
-
-### When NOT to reach for it
-
-- The widget can be expressed as `card` / `bar` / `doughnut` / `table` etc.
-  with an `api` block — extend the existing schema instead.
-- Two or three other dashboards would benefit from the same widget — promote
-  it to a first-class `chart_type` rather than copying components.
-
-### Adding a custom component
-
-1. Create `frontend/src/components/dashboard/custom-components/<Name>.jsx`.
-2. Add a named export in [`custom-components/index.js`](../../components/dashboard/custom-components/index.js).
-3. Reference it from JSON:
+Renders each individual measurement as a dot on a horizontal axis, colored by
+threshold compliance. Replaces histogram for water-quality parameters — avoids
+the bin-alignment artifact where a threshold line at the edge of a bin appears
+in the middle of a bar.
 
 ```json
 {
-  "id": "individual_overview_component",
-  "chart_type": "custom_component",
-  "order": 1,
-  "component": "<Name>"
+  "id": "param_e_coli",
+  "chart_type": "dot_strip",
+  "col_span": 12,
+  "description": "Acceptance threshold 0 CFU/100 mL",
+  "config": {
+    "title": "E-coli presence",
+    "xAxisLabel": "CFU/100mL",
+    "entity_label": "EPS"
+  },
+  "threshold": { "max": 0 },
+  "api": {
+    "form_id": 1749632545233,
+    "question_id": 1749633220746,
+    "group_by": "parent_id",
+    "monitoring": "latest",
+    "repeat_agg": "average"
+  }
 }
 ```
 
-Unknown component names are not fatal — the renderer logs `console.error` and
-displays an `<Alert>` placeholder, so the rest of the dashboard keeps working.
+**How it works:**
 
-### What the component owns
+- Dots are sorted by value, then spread vertically with rank-based jitter so
+  overlapping points fan out and remain countable.
+- Blue dots — value satisfies all threshold bounds (≤ `threshold.max` and
+  ≥ `threshold.min`).
+- Red dots — value violates at least one bound.
+- A dashed red vertical line marks each threshold bound.
+- Background zone shading: light blue = compliant zone, light pink = out-of-range.
+- Tooltip: `Value: 0 CFU/100mL (55 EPS)` — the count at that exact value is
+  shown when more than one dot shares it.
 
-- Data fetching, including auth-aware error handling.
-- Loading, empty, and error UI states.
-- Internal selection state, drill-downs, sub-tabs.
-- Any internal filters (the dashboard's global filter bar is **not** piped in).
+**`config` fields:**
 
-### Stay specific until rule-of-three
+| Field | Type | Notes |
+|---|---|---|
+| `xAxisLabel` | string | Axis name and tooltip unit (e.g. `"CFU/100mL"`, `"NTU"`, `"°C"`) |
+| `entity_label` | string | Noun shown in the tooltip count: `"(55 EPS)"` or `"(55 RWS)"`. Omit for a bare count `"(55)"` |
 
-Do not generalize prematurely. The first per-dashboard custom component is
-fine as a one-off. When a third dashboard needs a similar pattern, refactor
-the common pieces into shared building-block components
-(`<RecordSelectorBar>`, `<RegistrationDetailTable>`, etc.) — not into a single
-mega-component driven by yet another schema.
+**`threshold` fields:**
 
-### Worked example: the individual-overview pattern
+| Field | Semantics |
+|---|---|
+| `max` | Compliant when value ≤ max (single upper bound) |
+| `min` | Compliant when value ≥ min (single lower bound) |
+| both | Compliant when min ≤ value ≤ max (range, e.g. pH 6.5–8.5) |
 
-The record-centric "Individual Overview" tab on the EPS dashboard is the
-reference implementation of this escape hatch. It composes six reusable
-primitives out of
-[`custom-components/individual-overview/shared/`](../../components/dashboard/custom-components/individual-overview/shared/)
-(helpers, `<PhotoCaptionCard>`, `<CharacteristicsTable>`,
-`<HistoricalLineChart>`, `useIndividualOverviewData`, and
-`useMonitoringHistory`) plus per-dashboard constants in
-[`individual-overview/config/eps.js`](../../components/dashboard/custom-components/individual-overview/config/eps.js),
-so the shell itself stays a ~180-line orchestrator.
-
-Note the rule-of-three deviation: those primitives were extracted before
-three working consumers existed. The justification is that each primitive was
-designed against **two** concrete shell designs in hand (EPS and a planned
-RWS sibling) and appears ≥4× across them — past the rule-of-two threshold
-with concrete designs to validate against. For the full design rationale, see
-[`doc/claude/dashboard-individual-overview/`](../../../../doc/claude/dashboard-individual-overview/).
+The `api` block follows the same shape as other API-driven charts. Use
+`group_by: "parent_id"` + `monitoring: "latest"` to get one measurement per
+registered site.
 
 ---
 
@@ -659,6 +643,7 @@ columns resolved by the renderer:
 
 - [`DashboardRenderer`](../../components/dashboard/DashboardRenderer.jsx) — recursive item dispatcher
 - [`ChartRenderer`](../../components/dashboard/ChartRenderer.jsx) — chart type → akvo-charts dispatch
+- [`DotStripChart`](../../components/dashboard/DotStripChart.jsx) — dot strip plot for water-quality `boxplot` items
 - [`widgets/KPICard`](../../components/dashboard/widgets/KPICard.jsx) — single KPI tile
 - [`widgets/TabsWidget`](../../components/dashboard/widgets/TabsWidget.jsx) — tabs container
 - [`widgets/FilterBarWidget`](../../components/dashboard/widgets/FilterBarWidget.jsx) — filter bar container

--- a/frontend/src/lib/__test__/__snapshots__/ui-text.test.js.snap
+++ b/frontend/src/lib/__test__/__snapshots__/ui-text.test.js.snap
@@ -977,6 +977,7 @@ Object {
     "valPhone": "Phone number is required",
     "valRole": "Please select a Role",
     "viewAttachment": "View Attachment",
+    "viewDetails": "View Details",
     "viewText": "View",
     "webformText": "Webform",
     "welcomeShort": <React.Fragment>

--- a/frontend/src/lib/ui-text.js
+++ b/frontend/src/lib/ui-text.js
@@ -1020,6 +1020,7 @@ const uiText = {
     downloadAppsLinkText: "or download using the links below:",
     dateFromPlaceholder: "From",
     dateToPlaceholder: "To",
+    viewDetails: "View Details",
   },
 
   de: {},


### PR DESCRIPTION
## Summary

Three focused improvements for the water-quality dashboard:

1. **DotStripChart** — replaces histogram for all 8 WQ parameters. Each measurement is a dot on the x-axis; blue = compliant, red = non-compliant. Threshold shown as a vertical dashed line with blue/red zone shading. Tooltip shows count when multiple sources share the same value (e.g. `Value: 0 CFU/100mL (8 EPS)`). Fixes histogram's threshold-line misalignment (bins were centred on tick values rather than placed at exact measurement values).
2. **Chemical & physical WQ parameter cards** — IndividualEPSOverview now shows pH, Conductivity, Salinity (chemical) and Turbidity, Temperature (physical) historical line charts alongside the existing microbial parameters, with a green compliance band for each.
3. **`include_empty` API parameter** — values endpoint accepts `include_empty=true` to include administrations that have never submitted monitoring data (count = 0), enabling "never-monitored parent" reporting.

## Changes

### Backend

- **`values_functions.py`**: when `include_empty=True`, left-joins administrations against filtered form data and fills missing counts with 0.
- **`dashboard_serializers.py`** + **`dashboard_views.py`**: expose `include_empty` as an optional boolean query param on the values API.
- **`tests_values_option.py`**: new test cases covering `include_empty` behaviour (parents with/without submissions).

### Frontend

- **`DotStripChart.jsx`** (new): ECharts scatter series with hidden y-axis jitter (per-group, not global rank — prevents false value–density correlation artefact), `markLine` threshold, `markArea` zone shading, `entity_label` config for tooltip noun.
- **`ChartRenderer.jsx`** + **`DashboardRenderer.jsx`**: register `"dot_strip"` chart type (`isDotStrip` flag); render `<DotStripChart>`.
- **`1749621221728.json`** (RWS) + **`1749623934933.json`** (EPS): migrate all 8 WQ params from `"histogram"` → `"dot_strip"`; add `entity_label: "RWS"/"EPS"`; remove histogram-specific `display`/`yAxis` blocks.
- **`visualizations/README.md`**: add `dot_strip` to chart_type catalogue; full Section 9 with JSON example, config/threshold field tables; mark `histogram` as legacy.
- **`ChartRenderer.test.js`**: update series type assertion `"boxplot"` → `"scatter"`.
- **`eps.js`**: add `WQ_LAB_CHEMICAL_PARAMS` (pH, Conductivity, Salinity) and `WQ_LAB_PHYSICAL_PARAMS` (Turbidity, Temperature) config arrays with thresholds.
- **`IndividualEPSOverview.jsx`**: render Chemical and Physical parameter sections with responsive column spans (`xl=8 lg=12 md=24`).
- **`HistoricalLineChart.jsx`**: add `markAreaBounds` prop for green compliance band and `yAxisFloor` to keep the band visible when `thresholdMax ≈ 0`.
- **`EscalationTable.jsx`**: add i18n support (`uiText`/`store`); fix expanded-row render to correctly pass `item` and `text`.

## Tests / verification

- **Backend**: `python manage.py test api.v1.v1_visualization.tests.tests_values_option`
- **Frontend lint**: `npx eslint src/components/dashboard/DotStripChart.jsx src/components/dashboard/ChartRenderer.jsx` → zero errors.
- **Manual smoke**:
  - EPS / RWS water quality section: dots appear at exact measurement values; threshold line at right edge of data; red dots for non-compliant values.
  - Tooltip on overlapping dots shows count: `Value: 0 CFU/100mL (8 EPS)`.
  - Individual EPS overview: chemical (pH, Conductivity, Salinity) and physical (Turbidity, Temperature) sections appear with green compliance bands on line charts.
  - Values API with `include_empty=true`: administrations with zero submissions appear with `count: 0`.

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1214126536352972