### PR TITLE
[#214] Fix date range filter for flow-imported data in list API and z…

### DIFF
--- a/backend/api/v1/v1_data/tests/tests_latest_activity_sorter.py
+++ b/backend/api/v1/v1_data/tests/tests_latest_activity_sorter.py
@@ -308,6 +308,112 @@ class LatestActivitySortingTestCase(TestCase, ProfileTestHelperMixin):
         )
         self.assertIsNone(no_monitoring_item["latest_activity_source"])
 
+    def test_null_updated_child_uses_created_for_latest_activity(self):
+        """Children with updated=NULL (flow-imported) must use created.
+
+        latest_child_activity must fall back to children__created when
+        children__updated is NULL, otherwise imported records are missed.
+        """
+        # Create a registration created long ago (simulates flow import)
+        old_reg = self.form.form_form_data.create(
+            name="OldFlowImport",
+            administration=self.administration,
+            geo=[0.0, 0.0],
+            created_by=self.user,
+            updated_by=self.user,
+            is_pending=False,
+            is_draft=False,
+        )
+        old_reg.created = self.base_time - timedelta(days=2000)
+        old_reg.updated = None  # Simulates flow-imported record
+        old_reg.save()
+
+        # Monitoring child also has updated=NULL but created recently
+        child_created = self.base_time - timedelta(days=1)
+        child = self.child_form.form_form_data.create(
+            parent=old_reg,
+            name="FlowMonitoringChild",
+            uuid=old_reg.uuid,
+            administration=self.administration,
+            geo=[0.0, 0.0],
+            created_by=self.user,
+            updated_by=self.user,
+            is_pending=False,
+            is_draft=False,
+        )
+        child.created = child_created
+        child.updated = None  # Simulates flow-imported record
+        child.save()
+
+        date_from = (self.base_time - timedelta(days=7)).date()
+        date_to = self.base_time.date()
+
+        response = self.client.get(
+            (
+                f"/api/v1/form-data/{self.form.id}"
+                f"?sort_by=latest_activity&sort_type=descend"
+                f"&date_from={date_from}&date_to={date_to}"
+            ),
+            HTTP_AUTHORIZATION=f"Bearer {self.token}",
+        )
+        self.assertEqual(response.status_code, 200)
+        data = response.json()
+        ids = [item["id"] for item in data["data"]]
+
+        # old_reg has a child created 1 day ago — must be included
+        self.assertIn(old_reg.id, ids)
+
+    def test_date_filter_uses_latest_activity_when_sorting_by_it(self):
+        """Date filters should use latest_activity when sort_by=latest_activity.
+
+        A registration created before date_from must appear if its most recent
+        monitoring child falls within the requested date range.
+        """
+        # data_recent_monitoring was created 9 days ago (before date_from=8
+        # days ago), but its child was updated 1 day ago (within range).
+        date_from = (self.base_time - timedelta(days=7)).date()
+        date_to = self.base_time.date()
+
+        response = self.client.get(
+            (
+                f"/api/v1/form-data/{self.form.id}"
+                f"?sort_by=latest_activity&sort_type=descend"
+                f"&date_from={date_from}&date_to={date_to}"
+            ),
+            HTTP_AUTHORIZATION=f"Bearer {self.token}",
+        )
+        self.assertEqual(response.status_code, 200)
+        data = response.json()
+        ids = [item["id"] for item in data["data"]]
+
+        # data_recent_monitoring created 9 days ago but child updated 1 day
+        # ago — must be included because its latest_activity is in range.
+        self.assertIn(self.data_recent_monitoring.id, ids)
+
+        # data_no_monitoring: created and updated 10 days ago — outside range.
+        self.assertNotIn(self.data_no_monitoring.id, ids)
+
+    def test_date_filter_uses_created_when_not_sorting_by_latest_activity(
+        self,
+    ):
+        """Date filters should use created field when sort_by is not
+        latest_activity, preserving existing behaviour."""
+        self.data_recent_monitoring.refresh_from_db()
+        created_date = self.data_recent_monitoring.created.date()
+
+        response = self.client.get(
+            (
+                f"/api/v1/form-data/{self.form.id}"
+                f"?sort_by=created&sort_type=descend"
+                f"&date_from={created_date}&date_to={created_date}"
+            ),
+            HTTP_AUTHORIZATION=f"Bearer {self.token}",
+        )
+        self.assertEqual(response.status_code, 200)
+        data = response.json()
+        ids = [item["id"] for item in data["data"]]
+        self.assertIn(self.data_recent_monitoring.id, ids)
+
     def test_latest_activity_fallback_for_parent_query(self):
         """Test latest_activity falls back to updated when parent provided."""
         # When querying with parent (monitoring data), latest_activity

--- a/backend/api/v1/v1_data/views.py
+++ b/backend/api/v1/v1_data/views.py
@@ -145,16 +145,24 @@ class FormDataAddListView(APIView):
                 required=False,
                 type=OpenApiTypes.DATE,
                 location=OpenApiParameter.QUERY,
-                description="Filter data created on or after this date "
-                "(YYYY-MM-DD)",
+                description=(
+                    "Lower bound date filter (YYYY-MM-DD). When "
+                    "sort_by=latest_activity, matches on the latest "
+                    "monitoring activity date; otherwise matches on "
+                    "the registration created date."
+                ),
             ),
             OpenApiParameter(
                 name="date_to",
                 required=False,
                 type=OpenApiTypes.DATE,
                 location=OpenApiParameter.QUERY,
-                description="Filter data created on or before this date "
-                "(YYYY-MM-DD)",
+                description=(
+                    "Upper bound date filter (YYYY-MM-DD). When "
+                    "sort_by=latest_activity, matches on the latest "
+                    "monitoring activity date; otherwise matches on "
+                    "the registration created date."
+                ),
             ),
         ],
         summary="To get list of form data",
@@ -258,20 +266,26 @@ class FormDataAddListView(APIView):
             user_path = adm.path if adm.path else f"{adm.pk}."
             filter_data["administration__path__startswith"] = user_path
 
-        # Subquery to get the form name of the child with latest activity
+        # Subquery to get the form name of the child with latest activity.
+        # Order by Coalesce(updated, created) so NULL updated records are
+        # ranked by created instead of being sorted first by PostgreSQL.
         latest_child_form_subquery = FormData.objects.filter(
             parent=OuterRef('pk'),
             is_pending=False,
             is_draft=False
-        ).order_by('-updated').values('form__name')[:1]
+        ).annotate(
+            child_activity=Coalesce('updated', 'created')
+        ).order_by('-child_activity').values('form__name')[:1]
 
         queryset = form.form_form_data.filter(**filter_data).annotate(
             total_children=Count(
                 'children',
                 filter=Q(children__is_pending=False, children__is_draft=False)
             ),
+            # Use Coalesce so flow-imported children with NULL updated
+            # fall back to their created date for activity calculation.
             latest_child_activity=Max(
-                'children__updated',
+                Coalesce('children__updated', 'children__created'),
                 filter=Q(children__is_pending=False, children__is_draft=False)
             ),
             latest_activity_source=Subquery(latest_child_form_subquery),
@@ -282,18 +296,27 @@ class FormDataAddListView(APIView):
         )
         if search:
             queryset = queryset.filter(name__icontains=search)
+        # When sorting by latest_activity, filter on that annotation so
+        # registrations with recent monitoring children are not excluded.
+        date_filter_field = (
+            "latest_activity" if sort_by == "latest_activity" else "created"
+        )
         if date_from:
             start_datetime = datetime.combine(date_from, time.min)
             if settings.USE_TZ:
                 start_datetime = timezone.make_aware(start_datetime)
-            queryset = queryset.filter(created__gte=start_datetime)
+            queryset = queryset.filter(
+                **{f"{date_filter_field}__gte": start_datetime}
+            )
         if date_to:
             end_datetime = datetime.combine(
                 date_to + timedelta(days=1), time.min
             )
             if settings.USE_TZ:
                 end_datetime = timezone.make_aware(end_datetime)
-            queryset = queryset.filter(created__lt=end_datetime)
+            queryset = queryset.filter(
+                **{f"{date_filter_field}__lt": end_datetime}
+            )
         queryset = queryset.order_by(order_by)
 
         instance = paginator.paginate_queryset(queryset, request)

--- a/backend/api/v1/v1_jobs/job.py
+++ b/backend/api/v1/v1_jobs/job.py
@@ -77,9 +77,18 @@ def download_data(
     date_from: str = None,
     date_to: str = None,
     selection_ids: list = None,
+    filter_child_form_ids: list = None,
 ) -> list:
     if child_form_ids is None:
         child_form_ids = []
+    # filter_child_form_ids controls which child forms are used when
+    # computing the union for date-range filtering. Falls back to
+    # child_form_ids when not provided (preserves existing behaviour).
+    effective_filter_children = (
+        filter_child_form_ids
+        if filter_child_form_ids is not None
+        else child_form_ids
+    )
 
     if selection_ids:
         data = form.form_form_data.filter(
@@ -116,12 +125,13 @@ def download_data(
     if administration_ids:
         filter_data["administration_id__in"] = administration_ids
 
-    if has_date_filter and child_form_ids:
-        # Filter children by date, include their parents regardless
+    if has_date_filter and effective_filter_children:
+        # Include parents with in-range children (by created date) OR
+        # parents whose own created date is in range.
         child_filter = {
             "is_pending": False,
             "is_draft": False,
-            "form_id__in": child_form_ids,
+            "form_id__in": effective_filter_children,
             **date_filter,
         }
         if administration_ids:
@@ -222,6 +232,7 @@ def generate_data_sheet(
     date_from: str = None,
     date_to: str = None,
     selection_ids: list = None,
+    filter_child_form_ids: list = None,
 ) -> None:
     if child_form_ids is None:
         child_form_ids = []
@@ -238,6 +249,7 @@ def generate_data_sheet(
         date_from=date_from,
         date_to=date_to,
         selection_ids=selection_ids,
+        filter_child_form_ids=filter_child_form_ids,
     )
     if len(data):
         df = pd.DataFrame(data)
@@ -591,6 +603,10 @@ def _generate_zip_download(job, **kwargs):
                     date_from=date_from,
                     date_to=date_to,
                     selection_ids=selection_ids or None,
+                    # Pass child_form_ids so registrations whose monitoring
+                    # falls within the date range are included even when the
+                    # registration itself was created before date_from.
+                    filter_child_form_ids=child_form_ids,
                 )
                 _write_context_sheet(
                     rw, form, child_forms, job,

--- a/backend/api/v1/v1_jobs/tests/tests_zip_download.py
+++ b/backend/api/v1/v1_jobs/tests/tests_zip_download.py
@@ -343,6 +343,70 @@ class ZipDownloadTestCase(TestCase, ProfileTestHelperMixin):
             os.remove(zip_path)
         storage.delete(url=f"download/{job.result}")
 
+    def test_zip_registration_included_when_monitoring_in_date_range(self):
+        """Registration created before date_from must appear in the
+        registration sheet when its monitoring child was created within
+        the date range (mirrors form-data list API behaviour)."""
+        import shutil
+
+        # Pick one registration and push its created date far into the past
+        reg = self.form.form_form_data.filter(
+            is_pending=False, is_draft=False
+        ).first()
+        self.assertIsNotNone(reg)
+        FormData.objects.filter(pk=reg.pk).update(
+            created=timezone.now() - timedelta(days=365)
+        )
+
+        # Set its monitoring child to be within the date range
+        child = self.child_form.form_form_data.filter(
+            parent=reg, is_pending=False, is_draft=False
+        ).first()
+        self.assertIsNotNone(child)
+        FormData.objects.filter(pk=child.pk).update(
+            created=timezone.now() - timedelta(days=1)
+        )
+
+        # Date range: only the last 7 days (registration is 365 days old)
+        date_from = (timezone.now() - timedelta(days=7)).date()
+        date_to = timezone.now().date()
+        job = self._create_zip_job(
+            date_from=str(date_from),
+            date_to=str(date_to),
+        )
+        job_generate_data_download(job_id=job.id, **job.info)
+        storage.download(f"download/{job.result}")
+        zip_path = f"./tmp/{job.result}"
+        reg_name = _sanitize_form_name(self.form.name) + ".xlsx"
+        child_name = (
+            _sanitize_form_name(
+                self.child_form.name,
+                form_id=self.child_form.id,
+            ) + ".xlsx"
+        )
+        with zipfile.ZipFile(zip_path, 'r') as zf:
+            zf.extract(reg_name, "./tmp/zip_extract/")
+            reg_df = pd.read_excel(
+                f"./tmp/zip_extract/{reg_name}", sheet_name="data"
+            )
+            reg_ids = reg_df["id"].tolist()
+            self.assertIn(
+                reg.id, reg_ids,
+                "Registration created before date_from must be included "
+                "because its monitoring child falls within the range."
+            )
+            zf.extract(child_name, "./tmp/zip_extract/")
+            child_df = pd.read_excel(
+                f"./tmp/zip_extract/{child_name}", sheet_name="data"
+            )
+            child_ids = child_df["id"].tolist()
+            self.assertIn(child.id, child_ids)
+        if os.path.exists("./tmp/zip_extract"):
+            shutil.rmtree("./tmp/zip_extract")
+        if os.path.exists(zip_path):
+            os.remove(zip_path)
+        storage.delete(url=f"download/{job.result}")
+
     def test_zip_definition_sheet_per_form(self):
         job = self._create_zip_job()
         job_generate_data_download(job_id=job.id, **job.info)


### PR DESCRIPTION


- Fix `latest_child_activity` annotation to use `Coalesce(updated, created)` so flow-imported children with `updated=NULL` contribute their `created` date instead of NULL, preventing registrations with recent monitoring from being excluded by the date filter
- Fix `latest_child_form_subquery` ordering to use `Coalesce(updated, created)` so NULL-updated records are ranked by `created` rather than sorted first
- When `sort_by=latest_activity`, apply date filter to the annotated `latest_activity` field so registrations with recent monitoring children are included even when the registration itself predates `date_from`
- Add `filter_child_form_ids` param to `download_data` and `generate_data_sheet` to separate "which children determine parent inclusion" from "which children are merged into rows"
- In `_generate_zip_download`, pass `filter_child_form_ids=child_form_ids` when generating the registration sheet so the union approach (parent in range OR child in range) applies even though monitoring columns are not merged into the registration sheet
- Add tests: `test_null_updated_child_uses_created_for_latest_activity`, `test_date_filter_uses_latest_activity_when_sorting_by_it`, `test_date_filter_uses_created_when_not_sorting_by_latest_activity`, `test_zip_registration_included_when_monitoring_in_date_range`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1214888279996390