### PR TITLE
ci: disable Deploy step pending repo split

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -76,6 +76,8 @@ jobs:
           ./ci/build.sh
 
       - name: Deploy
+        if: false  # iwsims deployment moved to akvo/iwsims repo; this step retained
+                   # for reference until DEVOPS-005 cleanup removes the deploy path entirely.
         env:
           APP_SHORT_NAME: ${{ secrets.APP_SHORT_NAME }}
           CI_COMMIT: ${{ env.COMMIT_SHORT_SHA }}


### PR DESCRIPTION
## Summary

Disables the `Deploy` step in `.github/workflows/main.yml` (sets `if: false`). The Build step is unaffected.

## Why

Deployment of iwsims is moving to its own repo. Leaving this step active would let pushes here re-apply the old k8s manifests over the new setup. The step is retained in the file (rather than deleted) for one-PR rollback if needed; final removal is a follow-up.