### PR TITLE
Granular Form-Builder Permissions (FB-009)

### DIFF
--- a/backend/api/v1/v1_profile/models.py
+++ b/backend/api/v1/v1_profile/models.py
@@ -252,6 +252,24 @@ class UserRole(models.Model):
             access=FeatureAccessTypes.form_delete,
         ).exists()
 
+    def can_form_create(self):
+        return self.role.role_role_feature_access.filter(
+            type=FeatureTypes.form_builder,
+            access=FeatureAccessTypes.form_create,
+        ).exists()
+
+    def can_form_edit(self):
+        return self.role.role_role_feature_access.filter(
+            type=FeatureTypes.form_builder,
+            access=FeatureAccessTypes.form_edit,
+        ).exists()
+
+    def can_form_publish(self):
+        return self.role.role_role_feature_access.filter(
+            type=FeatureTypes.form_builder,
+            access=FeatureAccessTypes.form_publish
+        ).exists()
+
     def __str__(self):
         return f"{self.user.name} - {self.role.name} ({self.administration})"
 

--- a/backend/api/v1/v1_users/serializers.py
+++ b/backend/api/v1/v1_users/serializers.py
@@ -684,7 +684,8 @@ class UserRoleListSerializer(serializers.ModelSerializer):
             'id', 'role', 'administration',
             'is_approver', 'is_submitter', 'is_editor',
             'can_delete', 'can_invite_user', 'can_form_builder',
-            'can_form_delete',
+            'can_form_delete', 'can_form_create', 'can_form_edit',
+            'can_form_publish',
         ]
 
 

--- a/backend/api/v1/v1_users/tests/tests_user_profile.py
+++ b/backend/api/v1/v1_users/tests/tests_user_profile.py
@@ -99,6 +99,9 @@ class UserProfileTestCase(TestCase, ProfileTestHelperMixin):
                 'can_invite_user',
                 'can_form_builder',
                 'can_form_delete',
+                'can_form_create',
+                'can_form_edit',
+                'can_form_publish',
             ]
         )
         self.assertEqual(

--- a/frontend/src/components/can/ability.js
+++ b/frontend/src/components/can/ability.js
@@ -19,6 +19,11 @@ const defineAbilityFor = (user) => {
     const can_invite_user = roles.filter((r) => r?.can_invite_user).length > 0;
     const can_form_builder =
       roles.filter((r) => r?.can_form_builder).length > 0;
+    const can_form_delete = roles.filter((r) => r?.can_form_delete).length > 0;
+    const can_form_create = roles.filter((r) => r?.can_form_create).length > 0;
+    const can_form_edit = roles.filter((r) => r?.can_form_edit).length > 0;
+    const can_form_publish =
+      roles.filter((r) => r?.can_form_publish).length > 0;
 
     if (is_approver) {
       can("manage", "approvals");
@@ -41,7 +46,19 @@ const defineAbilityFor = (user) => {
       can("manage", "user");
     }
     if (can_form_builder) {
-      can("manage", "form-builder");
+      can("read", "form-builder");
+    }
+    if (can_form_delete) {
+      can("delete", "form-builder");
+    }
+    if (can_form_create) {
+      can("create", "form-builder");
+    }
+    if (can_form_edit) {
+      can("edit", "form-builder");
+    }
+    if (can_form_publish) {
+      can("publish", "form-builder");
     }
     can("read", "data");
     can("read", "downloads");

--- a/frontend/src/components/sidebar/index.jsx
+++ b/frontend/src/components/sidebar/index.jsx
@@ -275,7 +275,7 @@ const Sidebar = () => {
           )}
 
           {/* Form builder */}
-          {ability.can("manage", "form-builder") && (
+          {ability.can("read", "form-builder") && (
             <Menu.Item
               key="menu-form-builder"
               icon={<FormOutlined />}

--- a/frontend/src/pages/form-builder/FormBuilderEdit.jsx
+++ b/frontend/src/pages/form-builder/FormBuilderEdit.jsx
@@ -15,6 +15,7 @@ import {
 import { useNotification } from "../../util/hooks";
 import { FormEditorBanners, VersionHistoryDrawer } from "./components";
 import "./style.scss";
+import { Can } from "../../components/can";
 
 const regExpFilename = /filename="(?<filename>.*)"/;
 
@@ -277,40 +278,47 @@ const FormBuilderEdit = () => {
               >
                 {text.formBuilderExportButton}
               </Button>
+
               {hasVersionHistory && (
-                <Button
-                  icon={<HistoryOutlined />}
-                  onClick={openDrawer}
-                  disabled={saving || publishing || unpublishing}
-                >
-                  {text.formBuilderVersionsButton}
-                </Button>
+                <Can I="publish" a="form-builder">
+                  <Button
+                    icon={<HistoryOutlined />}
+                    onClick={openDrawer}
+                    disabled={saving || publishing || unpublishing}
+                  >
+                    {text.formBuilderVersionsButton}
+                  </Button>
+                </Can>
               )}
               {showPublish && (
-                <Button
-                  type="primary"
-                  loading={publishing}
-                  disabled={saving || unpublishing}
-                  onClick={onPublish}
-                >
-                  {text.formBuilderPublishButton}
-                </Button>
+                <Can I="publish" a="form-builder">
+                  <Button
+                    type="primary"
+                    loading={publishing}
+                    disabled={saving || unpublishing}
+                    onClick={onPublish}
+                  >
+                    {text.formBuilderPublishButton}
+                  </Button>
+                </Can>
               )}
               {showUnpublish && (
-                <Popconfirm
-                  title={text.formBuilderUnpublishTitle}
-                  description={text.formBuilderUnpublishDesc}
-                  onConfirm={onUnpublish}
-                  okText={text.formBuilderUnpublishButton}
-                  cancelText={text.cancelButton}
-                >
-                  <Button
-                    loading={unpublishing}
-                    disabled={saving || publishing}
+                <Can I="publish" a="form-builder">
+                  <Popconfirm
+                    title={text.formBuilderUnpublishTitle}
+                    description={text.formBuilderUnpublishDesc}
+                    onConfirm={onUnpublish}
+                    okText={text.formBuilderUnpublishButton}
+                    cancelText={text.cancelButton}
                   >
-                    {text.formBuilderUnpublishButton}
-                  </Button>
-                </Popconfirm>
+                    <Button
+                      loading={unpublishing}
+                      disabled={saving || publishing}
+                    >
+                      {text.formBuilderUnpublishButton}
+                    </Button>
+                  </Popconfirm>
+                </Can>
               )}
             </Space>
           </div>

--- a/frontend/src/pages/form-builder/FormBuilderList.jsx
+++ b/frontend/src/pages/form-builder/FormBuilderList.jsx
@@ -1,4 +1,10 @@
-import React, { useEffect, useState, useMemo, useCallback } from "react";
+import React, {
+  useEffect,
+  useState,
+  useMemo,
+  useCallback,
+  useContext,
+} from "react";
 import dayjs from "dayjs";
 import customParseFormat from "dayjs/plugin/customParseFormat";
 import { useNavigate } from "react-router-dom";
@@ -30,6 +36,7 @@ import { FormStatusTag, ImportFormModal } from "./components";
 import { api, store, uiText, REGISTRATION_FORM } from "../../lib";
 import { useNotification } from "../../util/hooks";
 import "./style.scss";
+import { AbilityContext, Can } from "../../components/can";
 
 dayjs.extend(customParseFormat);
 
@@ -66,6 +73,7 @@ const FormBuilderList = () => {
     { title: "Control Center", link: "/control-center" },
     { title: text.menuFormBuilder },
   ];
+  const ability = useContext(AbilityContext);
 
   // Debounce the search input, resetting to the first page on change.
   useEffect(() => {
@@ -240,11 +248,8 @@ const FormBuilderList = () => {
   const renderActiveActions = (_, record) => {
     const canCreateMonitoring =
       record.status === "published" && record.type === REGISTRATION_FORM;
-    const menuItems = [
-      { key: "duplicate", label: text.formBuilderDuplicateButton },
-      { key: "export", label: text.formBuilderExportButton },
-    ];
-    if (record.status === "draft") {
+    const menuItems = [{ key: "export", label: text.formBuilderExportButton }];
+    if (record.status === "draft" && ability.can("publish", "form-builder")) {
       menuItems.push({ key: "publish", label: text.formBuilderPublishButton });
     }
     if (canCreateMonitoring) {
@@ -253,12 +258,22 @@ const FormBuilderList = () => {
         label: text.formBuilderCreateMonitoringButton,
       });
     }
-    menuItems.push({ type: "divider" });
-    menuItems.push({
-      key: "archive",
-      label: text.formBuilderArchiveButton,
-      danger: true,
-    });
+
+    if (ability.can("create", "form-builder")) {
+      menuItems.push({
+        key: "duplicate",
+        label: text.formBuilderDuplicateButton,
+      });
+    }
+
+    if (ability.can("delete", "form-builder")) {
+      menuItems.push({ type: "divider" });
+      menuItems.push({
+        key: "archive",
+        label: text.formBuilderArchiveButton,
+        danger: true,
+      });
+    }
 
     const onMenuClick = ({ key }) => {
       if (key === "duplicate") {
@@ -289,14 +304,16 @@ const FormBuilderList = () => {
 
     return (
       <Space size="small">
-        <Button
-          shape="round"
-          onClick={() => {
-            navigate(`/control-center/form-builder/${record.id}/edit`);
-          }}
-        >
-          {text.editButton}
-        </Button>
+        <Can I="edit" a="form-builder">
+          <Button
+            shape="round"
+            onClick={() => {
+              navigate(`/control-center/form-builder/${record.id}/edit`);
+            }}
+          >
+            {text.editButton}
+          </Button>
+        </Can>
         <Dropdown
           trigger={["click"]}
           menu={{ items: menuItems, onClick: onMenuClick }}
@@ -310,42 +327,46 @@ const FormBuilderList = () => {
   const renderDeletePermanently = (record) => {
     if (record.submission_count === 0) {
       return (
-        <Popconfirm
-          title={text.formBuilderDeleteConfirmTitle}
-          description={text.formBuilderDeleteConfirmDesc}
-          okText={text.formBuilderDeleteButton}
-          okButtonProps={{ danger: true }}
-          onConfirm={() => onDelete(record.id)}
-        >
-          <Button shape="round" danger>
-            {text.formBuilderDeleteButton}
-          </Button>
-        </Popconfirm>
+        <Can I="delete" a="form-builder">
+          <Popconfirm
+            title={text.formBuilderDeleteConfirmTitle}
+            description={text.formBuilderDeleteConfirmDesc}
+            okText={text.formBuilderDeleteButton}
+            okButtonProps={{ danger: true }}
+            onConfirm={() => onDelete(record.id)}
+          >
+            <Button shape="round" danger>
+              {text.formBuilderDeleteButton}
+            </Button>
+          </Popconfirm>
+        </Can>
       );
     }
     return (
       <Tooltip title={text.formBuilderDeleteDisabledTooltip}>
-        <span>
+        <Can I="delete" a="form-builder">
           <Button shape="round" danger disabled>
             {text.formBuilderDeleteButton}
           </Button>
-        </span>
+        </Can>
       </Tooltip>
     );
   };
 
   const renderArchivedActions = (_, record) => (
     <Space size="middle" wrap>
-      <Popconfirm
-        title={text.formBuilderRestoreConfirmTitle}
-        description={text.formBuilderRestoreConfirmDesc}
-        okText={text.formBuilderRestoreButton}
-        onConfirm={() => onRestore(record.id)}
-      >
-        <Button shape="round" type="primary">
-          {text.formBuilderRestoreButton}
-        </Button>
-      </Popconfirm>
+      <Can I="delete" a="form-builder">
+        <Popconfirm
+          title={text.formBuilderRestoreConfirmTitle}
+          description={text.formBuilderRestoreConfirmDesc}
+          okText={text.formBuilderRestoreButton}
+          onConfirm={() => onRestore(record.id)}
+        >
+          <Button shape="round" type="primary">
+            {text.formBuilderRestoreButton}
+          </Button>
+        </Popconfirm>
+      </Can>
       {hasFormDelete && renderDeletePermanently(record)}
     </Space>
   );
@@ -446,27 +467,29 @@ const FormBuilderList = () => {
             </Col>
             {!isArchivedTab && (
               <Col>
-                <Space>
-                  <Button
-                    shape="round"
-                    icon={<UploadOutlined />}
-                    onClick={() => {
-                      setImportModalOpen(true);
-                    }}
-                  >
-                    {text.formBuilderImportButton}
-                  </Button>
-                  <Button
-                    shape="round"
-                    type="primary"
-                    icon={<PlusOutlined />}
-                    onClick={() => {
-                      navigate("/control-center/form-builder/create");
-                    }}
-                  >
-                    {text.formBuilderCreateButton}
-                  </Button>
-                </Space>
+                <Can I="create" a="form-builder">
+                  <Space>
+                    <Button
+                      shape="round"
+                      icon={<UploadOutlined />}
+                      onClick={() => {
+                        setImportModalOpen(true);
+                      }}
+                    >
+                      {text.formBuilderImportButton}
+                    </Button>
+                    <Button
+                      shape="round"
+                      type="primary"
+                      icon={<PlusOutlined />}
+                      onClick={() => {
+                        navigate("/control-center/form-builder/create");
+                      }}
+                    >
+                      {text.formBuilderCreateButton}
+                    </Button>
+                  </Space>
+                </Can>
               </Col>
             )}
           </Row>


### PR DESCRIPTION
## What This PR Does

Makes Form Builder actions obey **per-action role permissions** instead of a
single all-or-nothing flag. A role can now be granted any subset of
**create / edit / publish / delete** for forms, and the UI hides exactly the
buttons a user isn't allowed to use.

This fixes a real authorization leak: previously the CASL ability granted
`manage` (a wildcard matching *every* action) to anyone with form-builder
access, so a user with `can_form_edit: false` still saw the Edit, Create,
Publish and Delete controls.

---

## Commits

| SHA | Description |
|---|---|
| `d2975dea` | Backend: add `can_form_create` / `can_form_edit` / `can_form_publish` to user profile |
| `baa00983` | Frontend: gate form-builder actions on granular CASL abilities + fix sidebar visibility |

---

## Changes by Layer

### Backend — Profile Permissions (`v1_profile`, `v1_users`)

The profile API already exposed `can_form_builder` and `can_form_delete`.
This PR adds the three missing per-action checks so the frontend has a complete
permission set to gate on.

- **`v1_profile/models.py`** — three new methods on `UserRoleDetail`, each
  resolving a `FeatureAccessTypes` against the role's feature-access rows:
  - `can_form_create()` → `FeatureAccessTypes.form_create` (4)
  - `can_form_edit()` → `FeatureAccessTypes.form_edit` (5)
  - `can_form_publish()` → `FeatureAccessTypes.form_publish` (6)
- **`v1_users/serializers.py`** — `UserRoleDetailSerializer` now emits
  `can_form_create`, `can_form_edit`, `can_form_publish` alongside the existing
  `can_form_delete`
- **`v1_users/tests/tests_user_profile.py`** — asserts the three new fields are
  present in the serialized role payload

### Frontend — CASL Ability (`components/can/ability.js`)

The core fix. Replaced the wildcard grant with non-wildcard, per-action rules:

- `can_form_builder` now grants `read` (section access) instead of `manage`
  — `manage` was a wildcard that silently authorized every action
- Each form-builder flag maps to its own ability:
  `can_form_create → create`, `can_form_edit → edit`,
  `can_form_publish → publish`, `can_form_delete → delete`

### Frontend — Sidebar (`components/sidebar/index.jsx`)

- Form Builder menu item gated on `ability.can("read", "form-builder")`
  (was `manage`) — section visibility preserved without leaking action rights

### Frontend — Form Builder Pages (`pages/form-builder/`)

**`FormBuilderList.jsx`**
- Row **Edit** button wrapped in `<Can I="edit" a="form-builder">`
- Row **Delete** (and its disabled-tooltip variant) wrapped in
  `<Can I="delete" a="form-builder">`
- `⋯` dropdown items built conditionally via `useContext(AbilityContext)`:
  - **Publish** added only when `record.status === "draft"` **and**
    `ability.can("publish", "form-builder")`
  - **Duplicate** added only when `ability.can("create", "form-builder")`
  - **Archive** (+ divider) added only when `ability.can("delete", "form-builder")`
  - **Export** always available
- Header **Import / Create** actions gated on `create`

**`FormBuilderEdit.jsx`**
- **Version history**, **Publish**, and **Unpublish** buttons wrapped in
  `<Can I="publish" a="form-builder">`

---

## Testing

```bash
# Backend
./dc.sh exec backend python manage.py test api.v1.v1_users.tests.tests_user_profile

# Frontend lint (clean)
./dc.sh exec -T frontend npx eslint src/components/can/ability.js \
  src/components/sidebar/index.jsx src/pages/form-builder
```

- Backend: profile serializer test updated to cover the three new fields
- Frontend: ESLint passes on all changed files

### Manual verification matrix (`can_form_builder: true`, others toggled)

| Flag off | Control that disappears |
|---|---|
| `can_form_edit` | Row **Edit** button |
| `can_form_create` | Header Import/Create, dropdown **Duplicate** |
| `can_form_publish` | Edit-page **Publish/Unpublish/Versions**, list **Publish** item |
| `can_form_delete` | Row **Delete**, dropdown **Archive** |

---

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1214919594158144