### PR TITLE
Feature/241 remove windowforms

### DIFF
--- a/backend/api/v1/v1_data/management/commands/generate_config.py
+++ b/backend/api/v1/v1_data/management/commands/generate_config.py
@@ -10,12 +10,9 @@ from mis.settings import (
     APK_NAME,
     SHOW_LANDING_PAGE,
 )
-from api.v1.v1_forms.models import Forms
 from api.v1.v1_profile.models import Levels
 from api.v1.v1_profile.constants import FeatureTypes, FeatureAccessTypes
-from api.v1.v1_forms.serializers import FormDataSerializer
 from api.v1.v1_visualization.functions import refresh_materialized_data
-from api.v1.v1_forms.constants import FormStatus
 
 
 class Command(BaseCommand):
@@ -51,22 +48,16 @@ class Command(BaseCommand):
         # write config
         config_file = jsmin(open("source/config/config.js").read())
         levels = []
-        forms = []
+        # NOTE: forms are no longer baked here. The web frontend fetches them
+        # at runtime from GET /api/v1/forms/published so newly published forms
+        # reflect without a config rebuild. See doc/claude/
+        # remove-window-forms-runtime-fetch.md
         for level in Levels.objects.all():
             levels.append(
                 {
                     "id": level.id,
                     "name": level.name,
                     "level": level.level,
-                }
-            )
-        for form in Forms.objects.filter(status=FormStatus.published).all():
-            forms.append(
-                {
-                    "id": form.id,
-                    "name": form.name,
-                    "version": form.version,
-                    "content": FormDataSerializer(instance=form).data,
                 }
             )
         role_features = []
@@ -93,9 +84,6 @@ class Command(BaseCommand):
                     "var levels=",
                     json.dumps(levels),
                     ";",
-                    "var forms=",
-                    json.dumps(forms),
-                    ";",
                     config_file,
                     "var appConfig=",
                     json.dumps({
@@ -114,7 +102,6 @@ class Command(BaseCommand):
         open("source/config/config.min.js", "w").write(min_config)
         # os.remove(administration_json)
         del levels
-        del forms
         del min_config
         if options.get("refresh_views"):
             refresh_materialized_data()

--- a/backend/api/v1/v1_forms/constants.py
+++ b/backend/api/v1/v1_forms/constants.py
@@ -97,3 +97,6 @@ _TYPE_STR_TO_INT = {
 _TYPE_INT_TO_STR = {
     k: v.lower() for k, v in QuestionTypes.FieldStr.items()
 }
+
+# Cache key for the published-forms payload served to the web frontend.
+PUBLISHED_FORMS_CACHE = "published-forms"

--- a/backend/api/v1/v1_forms/functions.py
+++ b/backend/api/v1/v1_forms/functions.py
@@ -11,6 +11,7 @@ from api.v1.v1_forms.constants import (
     FORM_IMPORT_SUPPORTED_VERSIONS,
     FormStatus,
     FormTypes,
+    PUBLISHED_FORMS_CACHE,
     QuestionTypes,
     _CAMEL_FIELDS,
     _SNAKE_TO_CAMEL,
@@ -25,6 +26,32 @@ from api.v1.v1_forms.models import (
     QuestionOptions,
 )
 from api.v1.v1_profile.models import Entity
+from api.v1.v1_data.functions import get_cache, create_cache
+from api.v1.v1_forms.serializers import FormDataSerializer
+
+
+def get_published_forms_payload():
+    """Return all published forms with full content for the web frontend.
+
+    Shape matches what generate_config used to bake into window.forms:
+    [{"id", "name", "version", "content": FormDataSerializer(...)}].
+    Cached via the shared date-prefixed cache (bypassed under TEST_ENV);
+    invalidated by the form-mutation signal cache.clear() and clear_cache.
+    """
+    cached = get_cache(PUBLISHED_FORMS_CACHE)
+    if cached is not None:
+        return cached
+    payload = [
+        {
+            "id": form.id,
+            "name": form.name,
+            "version": form.version,
+            "content": FormDataSerializer(instance=form).data,
+        }
+        for form in Forms.objects.filter(status=FormStatus.published).all()
+    ]
+    create_cache(PUBLISHED_FORMS_CACHE, payload)
+    return payload
 
 
 def _parse_form_type(type_val):

--- a/backend/api/v1/v1_forms/tasks.py
+++ b/backend/api/v1/v1_forms/tasks.py
@@ -13,14 +13,17 @@ from api.v1.v1_forms.functions import (
 
 
 def refresh_form_config():
-    """Clear the Django cache and regenerate config.min.js.
+    """Clear the Django cache after a form is published.
 
-    Dispatched asynchronously after a form is published so the web form
-    renderer and the frontend FormDropdown both see the updated form list
-    without blocking the publish HTTP response.
+    Dispatched asynchronously after a form is published. Forms are no longer
+    baked into config.min.js — the web frontend fetches them at runtime from
+    GET /api/v1/forms/published (see doc/claude/
+    remove-window-forms-runtime-fetch.md). Clearing the cache evicts the
+    cached published-forms payload and the per-form webform-{id} entries so
+    the next fetch returns the updated form list. generate_config is no
+    longer needed on the publish path.
     """
     call_command("clear_cache")
-    call_command("generate_config")
 
 
 def import_form_job(job_id):

--- a/backend/api/v1/v1_forms/tests/tests_list_published_forms.py
+++ b/backend/api/v1/v1_forms/tests/tests_list_published_forms.py
@@ -1,0 +1,62 @@
+from django.core.management import call_command
+from django.test import TestCase
+from django.test.utils import override_settings
+
+from api.v1.v1_forms.models import Forms
+from api.v1.v1_forms.constants import FormStatus
+
+
+@override_settings(USE_TZ=False, TEST_ENV=True)
+class ListPublishedFormsTestCase(TestCase):
+    """GET /api/v1/forms/published — runtime forms feed for the web app.
+
+    Replaces the window.forms global baked into config.min.js.
+    """
+
+    def setUp(self):
+        call_command("administration_seeder", "--test")
+        call_command("form_seeder", "--test")
+        self.url = "/api/v1/forms/published"
+
+    def test_returns_200_without_auth(self):
+        """Public, like config.js — no authentication required."""
+        res = self.client.get(self.url)
+        self.assertEqual(res.status_code, 200)
+
+    def test_sets_no_cache_header(self):
+        """Cache-Control: no-cache prevents the browser-cache staleness."""
+        res = self.client.get(self.url)
+        self.assertEqual(res["Cache-Control"], "no-cache")
+
+    def test_item_shape_matches_baked_forms(self):
+        """Each item has id, name, version and full content."""
+        data = self.client.get(self.url).json()
+        self.assertIsInstance(data, list)
+        self.assertGreater(len(data), 0)
+        item = data[0]
+        self.assertEqual(
+            sorted(item.keys()), ["content", "id", "name", "version"]
+        )
+        self.assertIn("question_group", item["content"])
+
+    def test_returns_all_published_forms_including_children(self):
+        """Mirrors generate_config: every published form, parents AND
+        children (unlike /forms which filters parent__isnull)."""
+        published_ids = set(
+            Forms.objects.filter(
+                status=FormStatus.published
+            ).values_list("id", flat=True)
+        )
+        data = self.client.get(self.url).json()
+        returned_ids = {item["id"] for item in data}
+        self.assertEqual(returned_ids, published_ids)
+
+    def test_excludes_unpublished_forms(self):
+        """Draft/unpublished forms must not leak into the feed."""
+        form = Forms.objects.filter(status=FormStatus.published).first()
+        form.status = FormStatus.draft
+        form.save(update_fields=["status"])
+
+        data = self.client.get(self.url).json()
+        returned_ids = {item["id"] for item in data}
+        self.assertNotIn(form.id, returned_ids)

--- a/backend/api/v1/v1_forms/urls.py
+++ b/backend/api/v1/v1_forms/urls.py
@@ -3,6 +3,7 @@ from django.urls import re_path
 from api.v1.v1_forms.views import (
     web_form_details,
     list_form,
+    list_published_forms,
     form_data,
     check_form_approver,
     form_approver,
@@ -12,6 +13,9 @@ from api.v1.v1_forms.views import (
 
 urlpatterns = [
     # Existing read-only (unchanged)
+    re_path(
+        r"^(?P<version>(v1))/forms/published$", list_published_forms
+    ),
     re_path(r"^(?P<version>(v1))/forms$", list_form),
     re_path(r"^(?P<version>(v1))/form/(?P<form_id>[0-9]+)", form_data),
     re_path(

--- a/backend/api/v1/v1_forms/views.py
+++ b/backend/api/v1/v1_forms/views.py
@@ -15,7 +15,7 @@ from rest_framework import status, serializers, viewsets
 from rest_framework.decorators import api_view, permission_classes, action
 from rest_framework.generics import get_object_or_404
 from rest_framework.parsers import MultiPartParser
-from rest_framework.permissions import IsAuthenticated
+from rest_framework.permissions import IsAuthenticated, AllowAny
 from utils.custom_permissions import FormBuilderAccess
 from rest_framework.response import Response
 
@@ -34,6 +34,7 @@ from api.v1.v1_forms.constants import (
 from api.v1.v1_forms.functions import (
     create_published_version,
     export_form_definition,
+    get_published_forms_payload,
     normalize_form_definition,
     restore_from_snapshot,
     save_form,
@@ -281,6 +282,27 @@ def list_form(request, version):
         ListFormSerializer(instance=instance, many=True).data,
         status=status.HTTP_200_OK,
     )
+
+
+@extend_schema(
+    tags=["Form"],
+    summary="Published forms with full content for the web frontend",
+    description=(
+        "Returns every published form (parents and children) with its full "
+        "content definition. Replaces the window.forms global previously "
+        "baked into config.min.js so newly published forms reflect without "
+        "a config rebuild. Public, like config.js."
+    ),
+)
+@api_view(["GET"])
+@permission_classes([AllowAny])
+def list_published_forms(request, version):
+    response = Response(
+        get_published_forms_payload(),
+        status=status.HTTP_200_OK,
+    )
+    response["Cache-Control"] = "no-cache"
+    return response
 
 
 @extend_schema(

--- a/doc/claude/remove-window-forms-runtime-fetch.md
+++ b/doc/claude/remove-window-forms-runtime-fetch.md
@@ -1,0 +1,235 @@
+# Design: Remove `window.forms` → Runtime Forms Fetch
+
+**Status:** Design (ready for `/sc:implement`)
+**Scope:** `window.forms` only. `window.levels` / `window.topojson` / `window.appConfig` / `window.roleFeatures` stay baked.
+**Related:** [iwsims-dashboard-config-example.md](./iwsims-dashboard-config-example.md), `generate_config.py`, `v1_forms/tasks.py`, `v1_forms/signals.py`
+
+---
+
+## 1. Problem & Root Cause
+
+Published forms do not reflect in the web app without a config rebuild + hard reload.
+
+Forms are baked into a **load-once global script**. `public/index.html` loads `config.js` → `get_config_file` serves `config.min.js`, which sets `var forms = [...]` as a `window.forms` global. Two staleness layers:
+
+1. **Load order** — the SPA reads `window.forms` once at startup; forms published after page load never appear in the open tab.
+2. **No cache-busting** — `get_config_file` sets no `Cache-Control`/`ETag`; the browser heuristically caches `config.js`, so even a reload can serve the stale bundle.
+
+Backend regeneration is **not** broken: the worker-regenerated `config.min.js` already contains the published form. This is purely a delivery-model problem.
+
+---
+
+## 2. Target Architecture
+
+Forms move from a baked global to a runtime fetch into the existing pullstate store.
+
+```
+BEFORE                                  AFTER
+──────                                  ─────
+index.html <script config.js>           index.html <script config.js>
+  └─ var forms = [...]  (baked)            └─ (no var forms)
+        │                                 App bootstrap (blocks render)
+   window.forms                             └─ GET /api/v1/forms/published
+        │                                          │
+   store.forms = window.forms.sort()         store.allForms = data
+        │                                     store.forms = filtered+sorted
+   consumers read window.forms            consumers read store.allForms / accessor
+```
+
+`allForms` = full published list (replaces `window.forms`). `forms` = assignment-filtered, sorted UI render list (unchanged semantics).
+
+### Bootstrap data flow
+
+```
+App mount  (loading = true, render blocked — Decision Q2)
+  │
+  ├─ GET /forms/published ──► [{id,name,version,content}]
+  │        store.update(s => s.allForms = data)
+  │
+  ├─ if AUTH_TOKEN: GET /profile ──► reloadData(profile)
+  │        store.forms = filterByAssignment(profile, s.allForms).sort()
+  │
+  └─ all resolved → setLoading(false) → render
+```
+
+---
+
+## 3. Backend Design
+
+### 3.1 New endpoint — `GET /api/v1/forms/published`
+
+| Property | Value |
+|---|---|
+| Path | `^(?P<version>(v1))/forms/published$` in `api/v1/v1_forms/urls.py` |
+| View | `list_published_forms` in `api/v1/v1_forms/views.py` |
+| Method | `GET` |
+| Auth | **`AllowAny`** — parity with public `config.js`; dashboards in `config.allowedGlobal` render pre-login (Decision Q1). |
+| Cache-Control | `no-cache` response header (kills the browser-cache staleness layer). |
+
+**Response** (array, shape-identical to the old baked `var forms`):
+
+```json
+[
+  { "id": 1782832048404, "name": "New Form", "version": 1,
+    "content": { /* FormDataSerializer(instance=form).data */ } }
+]
+```
+
+**Selection mirrors `generate_config.py` exactly** — `Forms.objects.filter(status=FormStatus.published)` with **no** `parent__isnull` filter (parents **and** children, so dashboard helpers that resolve child forms by id keep working). This differs from the existing `list_form` (`/forms`), which filters `parent__isnull=True` — do not reuse it.
+
+**View (interface — build in `/sc:implement`):**
+
+```python
+@extend_schema(tags=["Form"], summary="Published forms with content")
+@api_view(["GET"])
+@permission_classes([AllowAny])
+def list_published_forms(request, version):
+    payload = get_published_forms_payload()      # §3.2, cached
+    resp = Response(payload, status=status.HTTP_200_OK)
+    resp["Cache-Control"] = "no-cache"
+    return resp
+```
+
+### 3.2 Shared serializer helper (DRY with generate_config) + server-side cache
+
+Extract the forms loop duplicated between `generate_config.py` and the new view into one cached function. **Use the existing `get_cache`/`create_cache` helpers** (`v1_data/functions.py`) so the payload participates in the established invalidation path (Decision Q4, aligned with Q3 — see §3.4):
+
+```python
+# api/v1/v1_forms/functions.py
+from api.v1.v1_data.functions import get_cache, create_cache
+
+PUBLISHED_FORMS_CACHE = "published-forms"
+
+def get_published_forms_payload():
+    cached = get_cache(PUBLISHED_FORMS_CACHE)
+    if cached is not None:
+        return cached
+    payload = [
+        {"id": f.id, "name": f.name, "version": f.version,
+         "content": FormDataSerializer(instance=f).data}
+        for f in Forms.objects.filter(status=FormStatus.published).all()
+    ]
+    create_cache(PUBLISHED_FORMS_CACHE, payload)
+    return payload
+```
+
+- `get_cache`/`create_cache` are date-prefixed and **bypass under `TEST_ENV`** — no per-request re-serialization in prod, correct freshness in tests.
+- No version-embedded key needed: invalidation is handled blanket-style in §3.4.
+
+### 3.3 `generate_config.py` changes
+
+- Remove the `forms = []` loop and the `"var forms=", json.dumps(forms), ";"` segment + `del forms`.
+- Keep `levels`, `topojson`, `appConfig`, `roleFeatures` untouched.
+- Net: `config.min.js` no longer carries form definitions (smaller bundle).
+
+### 3.4 Cache invalidation — why Q4 aligns with Q3
+
+Already in place: [`v1_forms/signals.py`](../../backend/api/v1/v1_forms/signals.py) connects `post_save`/`post_delete` on `Forms`/`QuestionGroup`/`Questions`/`QuestionOptions` → **`cache.clear()`** (wipes the entire default cache). `refresh_form_config` also calls `clear_cache` on publish.
+
+Therefore the new `published-forms` cache entry is invalidated automatically by **both**:
+1. the form-mutation signal (`cache.clear()`), and
+2. the kept `clear_cache` call (Decision Q3).
+
+**`refresh_form_config` change:** keep `clear_cache`; **drop `generate_config`** from the publish path (forms are now fetched live; only caches need eviction). `clear_cache` remains necessary to evict the `published-forms` payload **and** the per-form `webform-{id}-…` cache.
+
+> Q4 ↔ Q3 confirmed: the server-side cache is safe *because* `clear_cache` (and the signal's `cache.clear()`) is retained on publish. Removing `clear_cache` would strand a stale `published-forms` payload until the date-prefix rolls over at midnight.
+
+---
+
+## 4. Frontend Design
+
+### 4.1 Store (`src/lib/store.js`)
+
+```diff
+- forms: window.forms.sort(sortArray),
++ allForms: [],   // full published list from /forms/published
++ forms: [],      // assignment-filtered + sorted (UI render list)
+  levels: window.levels,
+```
+
+`forms` init `[]` removes the `window.forms.sort()` crash risk.
+
+### 4.2 Fetch + bootstrap (`src/util/form.js`, `src/App.js`)
+
+- `fetchPublishedForms()` in `util/form.js`: `GET forms/published` → `store.update(s => { s.allForms = data })`.
+- `reloadData(profile, dataset)` sources the full list from `s.allForms` (not `window.forms`):
+
+```js
+const filterFormByAssigment = (profile = {}, allForms = []) => {
+  if (!Object.keys(profile).length) { return allForms; }
+  return profile.forms.length
+    ? allForms.filter((x) => profile.forms.map((f) => f.id).includes(x.id))
+    : allForms;
+};
+```
+
+- **Render blocked until forms load (Decision Q2):** `App.js` keeps `loading = true` until `fetchPublishedForms()` resolves (and `/profile` when a token exists). Run the forms fetch on mount for **all** routes (public + authed) so public dashboards get `allForms` too. `reloadData` runs after both resolve.
+- `LoginForm` / `RegistrationForm` already call `reloadData(res.data)`; `allForms` is already populated from the mount fetch, so they just re-filter.
+
+### 4.3 Consumer migration (`window.forms` → store/accessor)
+
+One snapshot accessor for non-component code:
+
+```js
+// util/form.js
+export const getForms = () => store.getRawState().allForms || [];
+```
+
+| File | Current | Change |
+|---|---|---|
+| `util/form.js` | `window.forms` ×3 | `allForms` param / `getForms()` |
+| `lib/store.js` | `window.forms.sort` | `[]` init |
+| `dashboard/EscalationTable.jsx` | `window.forms?.flatMap` | `store.useState(s=>s.allForms)` |
+| `dashboard/DashboardMap/getQuestionOptions.js` | `window.forms` | `getForms()` |
+| `dashboard/DashboardFilters.jsx` | `window.forms` ×2 | `getForms()` / store |
+| `dashboard/.../individual-overview/shared/helpers.js` | `window.forms` ×2 | `getForms()` |
+| `components/filters/FormDropdown.js` | `window.forms` ×3 | `store.useState(s=>s.allForms)` |
+| `components/filters/DataFilters.js` | `window.forms` | `store.useState` / `getForms()` |
+| `*/__test__/*` | set/delete `window.forms` | seed store via `store.update` / mock `getForms` |
+
+> React render paths prefer `store.useState(s => s.allForms)` (reactive); pure helpers use the `getForms()` snapshot.
+
+---
+
+## 5. Sequence — publish reflects without rebuild
+
+```
+Editor publishes form
+  ├─ Forms.status = published; version bump
+  ├─ post_save signal → cache.clear()           [evicts published-forms + webform caches]
+  └─ refresh_form_config (async): clear_cache    [Decision Q3 — generate_config dropped]
+Any user loads/reloads app
+  └─ GET /forms/published (Cache-Control: no-cache, server cache MISS → fresh)
+        └─ new form present ✔  (no config.min.js rebuild)
+```
+
+---
+
+## 6. Acceptance Criteria
+
+- Publish a form → reload app (no `generate_config` rerun) → appears in `s.allForms`, dashboards, `FormDropdown`.
+- Unpublish → reload → disappears.
+- No `window.forms` reference remains in `frontend/src` (excluding removed test scaffolding).
+- `generate_config` output contains no `var forms=`.
+- `/forms/published` returns parents **and** children with full `content` (parity with old baked list); `Cache-Control: no-cache`; `AllowAny`.
+- App render is gated until forms load (no flash of empty dropdowns).
+- After publish, `cache.clear()`/`clear_cache` evicts the `published-forms` payload (next fetch is fresh).
+
+---
+
+## 7. Decisions (locked)
+
+1. **Auth** — `AllowAny`, public like `config.js`.
+2. **Bootstrap** — block initial render until forms load.
+3. **`refresh_form_config`** — keep `clear_cache`; drop `generate_config` from publish path.
+4. **Server-side cache** — yes, via shared `get_cache`/`create_cache`; invalidated by the retained `clear_cache`/signal `cache.clear()` (aligned with #3).
+
+---
+
+## 8. Out of Scope
+
+- `window.levels`, `window.topojson`, `window.appConfig`, `window.roleFeatures` (stay baked).
+- Mobile app (separate SQLite/config path).
+- Live push to open tabs (websocket/poll) — deferred.
+
+**Next:** `/sc:implement` — backend (helper extraction + cached endpoint + `generate_config`/`refresh_form_config` edits, independently testable), then frontend store/bootstrap gating, then consumer migration + tests.

--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -61,7 +61,7 @@ import { store, api, config } from "./lib";
 import { Layout, PageLoader } from "./components";
 import { useNotification } from "./util/hooks";
 import { eraseCookieFromAllPaths } from "./util/date";
-import { reloadData } from "./util/form";
+import { reloadData, fetchPublishedForms } from "./util/form";
 import { ability, AbilityContext } from "./components/can";
 
 const Private = ({ element: Element, alias }) => {
@@ -340,6 +340,7 @@ const App = () => {
   const { user: authUser, isLoggedIn } = store.useState((state) => state);
   const [cookies] = useCookies(["AUTH_TOKEN"]);
   const [loading, setLoading] = useState(true);
+  const [formsLoading, setFormsLoading] = useState(true);
   const { notify } = useNotification();
   const pageLocation = useLocation();
 
@@ -354,6 +355,19 @@ const App = () => {
       s.showAdvancedFilters = false;
     });
   }, [pageLocation]);
+
+  // Fetch published forms once at bootstrap (replaces the window.forms global
+  // baked into config.js). Gates render so dropdowns/dashboards never show an
+  // empty list before the forms resolve.
+  useEffect(() => {
+    fetchPublishedForms()
+      .catch((err) => {
+        console.error(err);
+      })
+      .finally(() => {
+        setFormsLoading(false);
+      });
+  }, []);
 
   useEffect(() => {
     if (!location.pathname.includes("/login")) {
@@ -421,7 +435,7 @@ const App = () => {
       <Layout>
         <Layout.Header />
         <Layout.Body>
-          {loading && !isHome && !isPublic ? (
+          {(loading || formsLoading) && !isHome && !isPublic ? (
             <PageLoader message="Initializing. Please wait.." />
           ) : (
             <RouteList />

--- a/frontend/src/components/dashboard/DashboardFilters.jsx
+++ b/frontend/src/components/dashboard/DashboardFilters.jsx
@@ -4,16 +4,18 @@ import { FilterOutlined } from "@ant-design/icons";
 import PropTypes from "prop-types";
 import AdministrationDropdown from "../filters/AdministrationDropdown";
 import { store } from "../../lib";
+import { getForms } from "../../util/form";
 
 const { RangePicker } = DatePicker;
 
 /**
- * Look up a question's option[] by scanning `window.forms` (populated at app
- * startup) for the matching form_id, then walking its question groups.
- * Returns an empty array if the form, question, or its options aren't found.
+ * Look up a question's option[] by scanning the published forms (fetched at
+ * app startup into the store) for the matching form_id, then walking its
+ * question groups. Returns an empty array if the form, question, or its
+ * options aren't found.
  */
-const extractOptionsFromWindow = (formId, questionId) => {
-  const form = (window.forms || []).find((f) => f.id === Number(formId));
+const extractOptionsFromStore = (formId, questionId) => {
+  const form = getForms().find((f) => f.id === Number(formId));
   const groups = form?.content?.question_group || [];
   for (let i = 0; i < groups.length; i += 1) {
     const q = (groups[i].question || []).find((x) => x.id === questionId);
@@ -68,12 +70,12 @@ const DashboardFilters = ({ filterItems, filters, onChange }) => {
     [filterItems]
   );
 
-  // Resolve option lists for each custom filter from window.forms (populated
-  // at app startup). No extra fetch required.
+  // Resolve option lists for each custom filter from the published forms in
+  // the store (fetched at app startup). No extra fetch required.
   const customOptions = useMemo(() => {
     const out = {};
     customDefs.forEach((d) => {
-      out[d.key] = extractOptionsFromWindow(d.form_id, d.question_id);
+      out[d.key] = extractOptionsFromStore(d.form_id, d.question_id);
     });
     return out;
   }, [customDefs]);

--- a/frontend/src/components/dashboard/DashboardMap/getQuestionOptions.js
+++ b/frontend/src/components/dashboard/DashboardMap/getQuestionOptions.js
@@ -1,13 +1,15 @@
+import { getForms } from "../../../util/form";
+
 /**
- * Look up a question's option[] by scanning `window.forms` (populated
- * at app startup) for the matching form_id, then walking its question
- * groups. Returns an empty array if the form, question, or its
+ * Look up a question's option[] by scanning the published forms (fetched at
+ * app startup into the store) for the matching form_id, then walking its
+ * question groups. Returns an empty array if the form, question, or its
  * options aren't found. Mirrors the helper inlined in
  * `DashboardFilters.jsx`; kept module-local to avoid scope-creeping
  * an extraction across the dashboard tree in this PR.
  */
 const getQuestionOptions = (formId, questionId) => {
-  const form = (window.forms || []).find((f) => f.id === Number(formId));
+  const form = getForms().find((f) => f.id === Number(formId));
   const groups = form?.content?.question_group || [];
   for (let i = 0; i < groups.length; i += 1) {
     const q = (groups[i].question || []).find((x) => x.id === questionId);

--- a/frontend/src/components/dashboard/DashboardMap/useMapByParent.js
+++ b/frontend/src/components/dashboard/DashboardMap/useMapByParent.js
@@ -8,7 +8,8 @@ import getQuestionOptions from "./getQuestionOptions";
  * /visualization/values/formula (decision #22):
  *   - formula filters pass the config JSON directly
  *   - question-id filters build an equivalent option_equals formula
- *     from window.forms so the formula endpoint handles both modes
+ *     from the published forms (getForms()) so the formula endpoint
+ *     handles both modes
  *
  * @param {{
  *   activeFilter: Object | null,

--- a/frontend/src/components/dashboard/EscalationTable.jsx
+++ b/frontend/src/components/dashboard/EscalationTable.jsx
@@ -50,6 +50,7 @@ const EscalationTable = ({
   });
   uiText;
   const { active: activeLang } = store.useState((s) => s.language);
+  const allForms = store.useState((s) => s.allForms);
   const text = useMemo(() => {
     return uiText?.[activeLang] || uiText.en;
   }, [activeLang]);
@@ -59,13 +60,12 @@ const EscalationTable = ({
     [item.columns]
   );
 
-  // window.forms is populated once at app load — stable reference, no deps.
   const allQuestions = useMemo(
     () =>
-      window.forms?.flatMap((f) =>
+      allForms?.flatMap((f) =>
         f?.content?.question_group?.flatMap((qg) => qg?.question)
       ),
-    []
+    [allForms]
   );
 
   const summaryColumns = useMemo(() => {

--- a/frontend/src/components/dashboard/custom-components/individual-overview/shared/CharacteristicsTable.jsx
+++ b/frontend/src/components/dashboard/custom-components/individual-overview/shared/CharacteristicsTable.jsx
@@ -5,7 +5,7 @@ import { findAnswer, findQuestion, formatAnswerValue } from "./helpers";
 import useAdministrationNames from "./useAdministrationNames";
 
 /**
- * Two-column AntD <Table> rendering Question (window.forms label) /
+ * Two-column AntD <Table> rendering Question (published-form label) /
  * Answer (formatAnswerValue) for a list of question ids. Skips qids with
  * no resolvable answer rather than rendering blank rows.
  */

--- a/frontend/src/components/dashboard/custom-components/individual-overview/shared/__test__/helpers.test.js
+++ b/frontend/src/components/dashboard/custom-components/individual-overview/shared/__test__/helpers.test.js
@@ -12,13 +12,17 @@ import {
   __resetAdministrationNameCache,
 } from "../helpers";
 import { api } from "../../../../../../lib";
+import { getForms } from "../../../../../../util/form";
 
 jest.mock("../../../../../../lib", () => ({
   __esModule: true,
   api: { get: jest.fn() },
 }));
 
-const originalForms = window.forms;
+jest.mock("../../../../../../util/form", () => ({
+  __esModule: true,
+  getForms: jest.fn(() => []),
+}));
 
 const FORMS_FIXTURE = [
   {
@@ -77,11 +81,7 @@ const FORMS_FIXTURE = [
 ];
 
 beforeEach(() => {
-  window.forms = FORMS_FIXTURE;
-});
-
-afterAll(() => {
-  window.forms = originalForms;
+  getForms.mockReturnValue(FORMS_FIXTURE);
 });
 
 describe("findQuestion", () => {
@@ -97,13 +97,13 @@ describe("findQuestion", () => {
     expect(findQuestion(999)).toBeNull();
   });
 
-  test("returns null when window.forms is empty", () => {
-    window.forms = [];
+  test("returns null when there are no forms", () => {
+    getForms.mockReturnValue([]);
     expect(findQuestion(101)).toBeNull();
   });
 
-  test("returns null when window.forms is missing", () => {
-    delete window.forms;
+  test("returns null when forms is empty", () => {
+    getForms.mockReturnValue([]);
     expect(findQuestion(101)).toBeNull();
   });
 });
@@ -243,8 +243,8 @@ describe("findQuestionGroup", () => {
     expect(findQuestionGroup(null)).toBeNull();
   });
 
-  test("returns null when window.forms is missing", () => {
-    delete window.forms;
+  test("returns null when there are no forms", () => {
+    getForms.mockReturnValue([]);
     expect(findQuestionGroup(2001)).toBeNull();
   });
 });

--- a/frontend/src/components/dashboard/custom-components/individual-overview/shared/helpers.js
+++ b/frontend/src/components/dashboard/custom-components/individual-overview/shared/helpers.js
@@ -1,12 +1,13 @@
 /**
  * Pure lookup + formatting helpers for the Individual Overview pattern.
  *
- * Centralises every walk over `window.forms` and every transform applied to
- * a `/data/<id>` answer payload, so shell components stay free of
- * form-walking code.
+ * Centralises every walk over the published forms (from getForms()) and
+ * every transform applied to a `/data/<id>` answer payload, so shell
+ * components stay free of form-walking code.
  */
 
 import { api } from "../../../../../lib";
+import { getForms } from "../../../../../util/form";
 
 const toNumericId = (id) => {
   if (typeof id === "number") {
@@ -17,9 +18,9 @@ const toNumericId = (id) => {
 };
 
 /**
- * Find a question definition by id across every form in `window.forms`.
+ * Find a question definition by id across every published form (getForms()).
  *
- * `window.forms` shape (set at app startup):
+ * forms shape (fetched at app startup into the store):
  *   [{ id, name, content: { question_group: [{ question: [{ id, label, type, option }] }] } }]
  *
  * @param {number|string} questionId
@@ -30,7 +31,7 @@ export const findQuestion = (questionId) => {
     return null;
   }
   const target = toNumericId(questionId);
-  const forms = window.forms || [];
+  const forms = getForms();
   for (let i = 0; i < forms.length; i += 1) {
     const groups = forms[i]?.content?.question_group || [];
     for (let j = 0; j < groups.length; j += 1) {
@@ -281,8 +282,8 @@ export const extractPhotoUrl = (values, questionId) => {
 };
 
 /**
- * Find a question group definition by its id across every form in
- * `window.forms`. Returns null when not found.
+ * Find a question group definition by its id across every published form
+ * (getForms()). Returns null when not found.
  *
  * @param {number|string} groupId
  * @returns {object|null}
@@ -292,7 +293,7 @@ export const findQuestionGroup = (groupId) => {
     return null;
   }
   const target = toNumericId(groupId);
-  const forms = window.forms || [];
+  const forms = getForms();
   for (let i = 0; i < forms.length; i += 1) {
     const groups = forms[i]?.content?.question_group || [];
     const found = groups.find((g) => g?.id === target);

--- a/frontend/src/components/filters/DataFilters.js
+++ b/frontend/src/components/filters/DataFilters.js
@@ -50,6 +50,7 @@ const DataFilters = ({
   const showAdvancedFilters = store.useState((s) => s.showAdvancedFilters);
   const dateRange = store.useState((s) => s.dateRange);
   const activeLang = store.useState((s) => s.language?.active);
+  const allForms = store.useState((s) => s.allForms);
   const { pathname } = useLocation();
   const navigate = useNavigate();
   const { notify } = useNotification();
@@ -67,8 +68,8 @@ const DataFilters = ({
   }, [activeLang]);
 
   const childForms = useMemo(() => {
-    return window.forms?.filter((f) => f?.content?.parent === selectedForm);
-  }, [selectedForm]);
+    return allForms?.filter((f) => f?.content?.parent === selectedForm);
+  }, [selectedForm, allForms]);
 
   const selectedAdm = takeRight(administration, 1)[0];
 

--- a/frontend/src/components/filters/FormDropdown.js
+++ b/frontend/src/components/filters/FormDropdown.js
@@ -12,31 +12,36 @@ const FormDropdown = ({
   width = 160,
   ...props
 }) => {
-  const { forms, selectedForm, loadingForm } = store.useState((state) => state);
+  const { forms, allForms, selectedForm, loadingForm } = store.useState(
+    (state) => state
+  );
   const filterForms = useMemo(() => {
-    const form_items = title ? window.forms : forms;
+    const form_items = title ? allForms : forms;
     return form_items.filter((f) => !f.content?.parent);
-  }, [title, forms]);
+  }, [title, forms, allForms]);
 
-  const handleChange = useCallback((e) => {
-    if (!e) {
-      return;
-    }
-    store.update((s) => {
-      s.loadingForm = true;
-    });
-    store.update((s) => {
-      s.questionGroups = window.forms.find(
-        (f) => f.id === e
-      ).content.question_group;
-      s.selectedForm = e;
-      s.loadingForm = false;
-      s.advancedFilters = [];
-      s.showAdvancedFilters = false;
-    });
-  }, []);
+  const handleChange = useCallback(
+    (e) => {
+      if (!e) {
+        return;
+      }
+      store.update((s) => {
+        s.loadingForm = true;
+      });
+      store.update((s) => {
+        s.questionGroups = allForms.find(
+          (f) => f.id === e
+        ).content.question_group;
+        s.selectedForm = e;
+        s.loadingForm = false;
+        s.advancedFilters = [];
+        s.showAdvancedFilters = false;
+      });
+    },
+    [allForms]
+  );
   useEffect(() => {
-    const findForm = window.forms.find((f) => f.id === selectedForm);
+    const findForm = allForms.find((f) => f.id === selectedForm);
     const urlParams = new URLSearchParams(window.location.search);
     if (
       urlParams.has("form_id") &&
@@ -57,7 +62,7 @@ const FormDropdown = ({
     ) {
       handleChange(filterForms[0].id);
     }
-  }, [filterForms, selectedForm, handleChange]);
+  }, [filterForms, selectedForm, handleChange, allForms]);
   if (filterForms && !hidden) {
     return (
       <Select

--- a/frontend/src/components/layout/Header.jsx
+++ b/frontend/src/components/layout/Header.jsx
@@ -6,6 +6,7 @@ import { FaChevronDown } from "react-icons/fa";
 import { Link, useLocation, useNavigate } from "react-router-dom";
 import { config, store, uiText } from "../../lib";
 import { eraseCookieFromAllPaths } from "../../util/date";
+import { getForms } from "../../util/form";
 import { listVisualizations } from "../../config/visualizations";
 
 const Header = ({ className = "header", ...props }) => {
@@ -19,7 +20,7 @@ const Header = ({ className = "header", ...props }) => {
   }, [activeLang]);
   const dashboardForms = useMemo(() => {
     const registered = listVisualizations();
-    const availableFormIds = new Set((window?.forms || []).map((f) => f.id));
+    const availableFormIds = new Set(getForms().map((f) => f.id));
     return registered.filter((d) => availableFormIds.has(d.parent_form_id));
   }, []);
   const showDashboardsMenu =

--- a/frontend/src/lib/__test__/__snapshots__/store.test.js.snap
+++ b/frontend/src/lib/__test__/__snapshots__/store.test.js.snap
@@ -5,6 +5,22 @@ Object {
   "administration": Array [],
   "administrationLevel": null,
   "advancedFilters": Array [],
+  "allForms": Array [
+    Object {
+      "id": 1,
+      "name": "Example 1",
+      "type": 1,
+      "type_text": "County",
+      "version": 1,
+    },
+    Object {
+      "id": 2,
+      "name": "Example 2",
+      "type": 2,
+      "type_text": "National",
+      "version": 1,
+    },
+  ],
   "dateRange": null,
   "filters": Object {
     "attributeType": null,
@@ -39,28 +55,7 @@ Object {
       "en": "English",
     },
   },
-  "levels": Array [
-    Object {
-      "id": 1,
-      "level": 0,
-      "name": "National",
-    },
-    Object {
-      "id": 2,
-      "level": 1,
-      "name": "County",
-    },
-    Object {
-      "id": 3,
-      "level": 2,
-      "name": "Sub-County",
-    },
-    Object {
-      "id": 4,
-      "level": 3,
-      "name": "Ward",
-    },
-  ],
+  "levels": undefined,
   "loadingForm": false,
   "loadingMap": false,
   "masterData": Object {

--- a/frontend/src/lib/__test__/store.test.js
+++ b/frontend/src/lib/__test__/store.test.js
@@ -1,6 +1,5 @@
 import "@testing-library/jest-dom";
 import store from "../store";
-import { sortArray } from "../../util/form";
 
 describe("Store", () => {
   test("check the initial state", () => {
@@ -22,7 +21,8 @@ describe("Store", () => {
       administration: [],
       selectedAdministration: null,
       loadingMap: false,
-      forms: window.forms.sort(sortArray),
+      allForms: [],
+      forms: [],
       levels: window.levels,
       selectedForm: null,
       loadingForm: false,

--- a/frontend/src/lib/store.js
+++ b/frontend/src/lib/store.js
@@ -1,5 +1,4 @@
 import { Store } from "pullstate";
-import { sortArray } from "../util/form";
 
 const defaultUIState = {
   isLoggedIn: false,
@@ -19,7 +18,11 @@ const defaultUIState = {
   administration: [],
   selectedAdministration: null,
   loadingMap: false,
-  forms: window.forms.sort(sortArray),
+  // allForms: full published list fetched at runtime from
+  // GET /api/v1/forms/published (replaces the old window.forms global).
+  // forms: assignment-filtered, sorted subset rendered by the UI.
+  allForms: [],
+  forms: [],
   levels: window.levels,
   selectedForm: null,
   selectedFormData: null,

--- a/frontend/src/pages/approvals/ApprovalDetail.jsx
+++ b/frontend/src/pages/approvals/ApprovalDetail.jsx
@@ -31,6 +31,7 @@ import {
 import { RawDataTable } from "../../components";
 import { isEqual, flatten } from "lodash";
 import { useNotification } from "../../util/hooks";
+import { getForms } from "../../util/form";
 import { getTimeDifferenceText } from "../../util/date";
 const { TextArea } = Input;
 const { TabPane } = Tabs;
@@ -322,7 +323,7 @@ const ApprovalDetail = ({
     setRawValues((rv) =>
       rv.map((rI) => (rI.id === record?.id ? { ...rI, loading: true } : rI))
     );
-    const qg = window.forms.find((f) => f.id === record?.form).content
+    const qg = getForms().find((f) => f.id === record?.form).content
       .question_group;
     setQuestionGroups(qg);
     fetchData(record?.id, qg);

--- a/frontend/src/pages/form-builder/FormBuilderEdit.jsx
+++ b/frontend/src/pages/form-builder/FormBuilderEdit.jsx
@@ -13,6 +13,7 @@ import {
   ARF_CASCASE_URLS,
 } from "../../lib";
 import { useNotification } from "../../util/hooks";
+import { fetchPublishedForms } from "../../util/form";
 import { FormEditorBanners, VersionHistoryDrawer } from "./components";
 import "./style.scss";
 import { Can } from "../../components/can";
@@ -116,8 +117,9 @@ const FormBuilderEdit = () => {
         setFormVersion(res.data.version);
         setFormLatestVersion(res.data.latest_version);
         notify({ type: "success", message: text.formBuilderPublishSuccess });
-        // window.forms is a global bundle — reload to pick up the updated object
-        window.location.reload();
+        // Refresh the published-forms global store so dropdowns/dashboards
+        // pick up the newly published form without a full page reload.
+        fetchPublishedForms();
       })
       .catch((err) => {
         const msg = err.response?.data?.message || text.formBuilderPublishError;
@@ -137,8 +139,9 @@ const FormBuilderEdit = () => {
         setFormVersion(res.data.version);
         setFormLatestVersion(res.data.latest_version);
         notify({ type: "success", message: text.formBuilderUnpublishSuccess });
-        // window.forms is a global bundle — reload to pick up the updated object
-        window.location.reload();
+        // Refresh the published-forms global store so the unpublished form
+        // is removed from dropdowns/dashboards without a full page reload.
+        fetchPublishedForms();
       })
       .catch((err) => {
         const msg =
@@ -170,6 +173,9 @@ const FormBuilderEdit = () => {
       setInitialValue(null);
       setActivatingId(null);
       await loadForm();
+      // Refresh the published-forms global store so the newly activated
+      // version's content propagates to dropdowns/dashboards.
+      fetchPublishedForms();
     } catch (err) {
       setActivatingId(null);
       const msg = err.response?.data?.message || text.formBuilderActivateError;

--- a/frontend/src/pages/login/__test__/Login.test.js
+++ b/frontend/src/pages/login/__test__/Login.test.js
@@ -8,6 +8,12 @@ import "@testing-library/jest-dom";
 jest.mock("axios");
 
 describe("Login and Registration", () => {
+  beforeEach(() => {
+    // App bootstrap fetches GET /forms/published on mount; give every
+    // api call a resolvable default so the unmocked fetch doesn't reject.
+    axios.mockResolvedValue({ status: 200, data: [] });
+  });
+
   test("test if the login form exists", () => {
     const { asFragment } = render(<TestApp />);
     userEvent.click(screen.getByText("Log in"), { button: 0 });

--- a/frontend/src/pages/login/__test__/__snapshots__/Login.test.js.snap
+++ b/frontend/src/pages/login/__test__/__snapshots__/Login.test.js.snap
@@ -515,7 +515,6 @@ exports[`Login and Registration test if the registration form exists: Registrati
                                 id="registration-form_password"
                                 placeholder="Password"
                                 type="password"
-                                value=""
                               />
                               <span
                                 class="ant-input-suffix"
@@ -585,7 +584,6 @@ exports[`Login and Registration test if the registration form exists: Registrati
                                 id="registration-form_confirm"
                                 placeholder="Confirm Password"
                                 type="password"
-                                value=""
                               />
                               <span
                                 class="ant-input-suffix"

--- a/frontend/src/pages/manage-data/DataDetail.jsx
+++ b/frontend/src/pages/manage-data/DataDetail.jsx
@@ -52,7 +52,7 @@ const DataDetail = ({
   const isEditor = ability.can("edit", "data") || authUser?.is_superuser;
 
   const questionGroups = useMemo(() => {
-    const formList = window?.forms || allForms || [];
+    const formList = allForms || [];
     return formList?.find((f) => f.id === record?.form)?.content
       ?.question_group;
   }, [record?.form, allForms]);

--- a/frontend/src/pages/manage-data/MonitoringDetail.jsx
+++ b/frontend/src/pages/manage-data/MonitoringDetail.jsx
@@ -36,6 +36,7 @@ import {
 } from "@ant-design/icons";
 import { useParams, useNavigate } from "react-router-dom";
 import { api, store, uiText } from "../../lib";
+import { getForms } from "../../util/form";
 import DataDetail from "./DataDetail";
 import { Breadcrumbs, DescriptionPanel } from "../../components";
 import { useNotification } from "../../util/hooks";
@@ -56,7 +57,7 @@ const MonitoringDetail = () => {
     user: authUser,
   } = store.useState((s) => s);
   const childrenForms = useMemo(() => {
-    return window?.forms?.filter((f) => `${f.content?.parent}` === form);
+    return getForms().filter((f) => `${f.content?.parent}` === form);
   }, [form]);
 
   // Get form_id from URL as default selectedForm
@@ -112,12 +113,11 @@ const MonitoringDetail = () => {
   const { questionGroups } = store.useState((state) => state);
 
   const overviewQuestions = useMemo(() => {
-    const forms =
-      window?.forms?.filter((f) =>
-        selectedForm
-          ? f?.id === selectedForm
-          : f?.content?.parent === parseInt(form, 10)
-      ) || [];
+    const forms = getForms().filter((f) =>
+      selectedForm
+        ? f?.id === selectedForm
+        : f?.content?.parent === parseInt(form, 10)
+    );
     return forms
       .map((f) => f.content.question_group)
       .flat()
@@ -215,7 +215,7 @@ const MonitoringDetail = () => {
   useEffect(() => {
     if (questionGroups.length === 0 && dataset.length > 0) {
       store.update((s) => {
-        s.questionGroups = window.forms.find(
+        s.questionGroups = getForms().find(
           (f) => f.id === dataset[0]?.form
         ).content.question_group;
       });

--- a/frontend/src/pages/manage-data/components/ManageDataMap.jsx
+++ b/frontend/src/pages/manage-data/components/ManageDataMap.jsx
@@ -12,6 +12,7 @@ import { scaleQuantize } from "d3-scale";
 import { GradationLegend, MapView, MarkerLegend } from "../../../components";
 import { api, store, uiText, geo, QUESTION_TYPES, config } from "../../../lib";
 import { color } from "../../../util";
+import { getForms } from "../../../util/form";
 const { getBounds } = geo;
 
 const ManageDataMap = () => {
@@ -62,13 +63,13 @@ const ManageDataMap = () => {
   }, [activeLang]);
 
   const mapForms = useMemo(() => {
-    return window?.forms?.filter((f) => f.content?.parent === selectedForm);
+    return getForms().filter((f) => f.content?.parent === selectedForm);
   }, [selectedForm]);
   const [mapForm, setMapForm] = useState(mapForms?.[0]?.id);
 
   const mapQuestions = useMemo(() => {
-    const f = window?.forms?.find((f) => f.id === mapForm);
-    const registrationGroup = window?.forms?.find((f) => f.id === selectedForm);
+    const f = getForms().find((f) => f.id === mapForm);
+    const registrationGroup = getForms().find((f) => f.id === selectedForm);
     const groupQuestions =
       registrationGroup?.content?.question_group &&
       f?.content?.question_group?.length

--- a/frontend/src/pages/manage-draft/DraftDetail.jsx
+++ b/frontend/src/pages/manage-draft/DraftDetail.jsx
@@ -33,7 +33,7 @@ const DraftDetail = ({
   }, [activeLang]);
 
   const questionGroups = useMemo(() => {
-    const formList = window?.forms || allForms || [];
+    const formList = allForms || [];
     return formList?.find((f) => f.id === record?.form)?.content
       ?.question_group;
   }, [record?.form, allForms]);

--- a/frontend/src/pages/manage-draft/ManageDraft.jsx
+++ b/frontend/src/pages/manage-draft/ManageDraft.jsx
@@ -54,6 +54,7 @@ const ManageDraft = () => {
     selectedForm,
     user,
     forms: registrationForms,
+    allForms,
   } = store.useState((s) => s);
   const { active: activeLang } = language;
   const text = useMemo(() => {
@@ -72,8 +73,8 @@ const ManageDraft = () => {
   }, [selectedAdministration, administration, user?.administration?.id]);
 
   const childrenForms = useMemo(() => {
-    return window?.forms?.filter((f) => f?.content?.parent === selectedForm);
-  }, [selectedForm]);
+    return (allForms || []).filter((f) => f?.content?.parent === selectedForm);
+  }, [selectedForm, allForms]);
 
   const goToAddForm = () => {
     navigate(`/control-center/data/draft/${selectedForm}`, {

--- a/frontend/src/pages/submissions/BatchDetail.jsx
+++ b/frontend/src/pages/submissions/BatchDetail.jsx
@@ -9,6 +9,7 @@ import {
 } from "../../lib";
 import { isEqual, flatten } from "lodash";
 import { useNotification } from "../../util/hooks";
+import { getForms } from "../../util/form";
 import { validateDependency } from "../../util";
 
 const BatchDetail = ({
@@ -31,7 +32,7 @@ const BatchDetail = ({
     return uiText[activeLang];
   }, [activeLang]);
 
-  const questionGroups = window.forms
+  const questionGroups = getForms()
     .find((f) => f.id === expanded.form)
     ?.content?.question_group?.filter(
       (qg) =>

--- a/frontend/src/pages/submissions/Submissions.jsx
+++ b/frontend/src/pages/submissions/Submissions.jsx
@@ -15,6 +15,7 @@ import {
   columnsPending as defaultPendingCols,
 } from "../../lib";
 import { useNotification } from "../../util/hooks";
+import { getForms } from "../../util/form";
 import UploadDetail from "./UploadDetail";
 import BatchDetail from "./BatchDetail";
 import { DataFilters } from "../../components";
@@ -56,7 +57,7 @@ const Submissions = () => {
       link: "/control-center",
     },
     {
-      title: window.forms?.find((x) => x.id === selectedForm)?.name,
+      title: getForms().find((x) => x.id === selectedForm)?.name,
     },
   ];
 

--- a/frontend/src/pages/submissions/UploadDetail.jsx
+++ b/frontend/src/pages/submissions/UploadDetail.jsx
@@ -18,6 +18,7 @@ import { ApproverDetailTable, RawDataTable } from "../../components";
 import { isEqual, flatten } from "lodash";
 import { useNotification } from "../../util/hooks";
 import { getTimeDifferenceText } from "../../util/date";
+import { getForms } from "../../util/form";
 import UploadAttachmentModal from "./UploadAttachmentModal";
 const { TabPane } = Tabs;
 
@@ -343,7 +344,7 @@ const UploadDetail = ({ record: batch, setReload }) => {
     setRawValues((rv) =>
       rv.map((rI) => (rI.id === record?.id ? { ...rI, loading: true } : rI))
     );
-    const qg = window.forms.find((f) => f.id === record?.form).content
+    const qg = getForms().find((f) => f.id === record?.form).content
       .question_group;
     setQuestionGroups(qg);
     fetchData(record?.id, qg);

--- a/frontend/src/setupTests.js
+++ b/frontend/src/setupTests.js
@@ -4,6 +4,7 @@
 // learn more: https://github.com/testing-library/jest-dom
 import "@testing-library/jest-dom";
 import "jest-canvas-mock";
+import store from "./lib/store";
 
 window.topojson = { objects: { fiji: { geometries: [{ properties: {} }] } } };
 window.levels = [
@@ -12,10 +13,17 @@ window.levels = [
   { id: 3, name: "Sub-County", level: 2 },
   { id: 4, name: "Ward", level: 3 },
 ];
-window.forms = [
+const formsFixture = [
   { id: 1, name: "Example 1", type: 1, version: 1, type_text: "County" },
   { id: 2, name: "Example 2", type: 2, version: 1, type_text: "National" },
 ];
+// Forms are no longer a window global; components read them from the store
+// (populated at runtime from GET /api/v1/forms/published). Seed both the
+// full list (allForms) and the rendered list (forms) for tests.
+store.update((s) => {
+  s.allForms = formsFixture;
+  s.forms = formsFixture;
+});
 
 window.visualisation = [];
 

--- a/frontend/src/util/form.js
+++ b/frontend/src/util/form.js
@@ -1,4 +1,4 @@
-import { store } from "../lib";
+import { store, api } from "../lib";
 
 export const sortArray = (x, y) => {
   const nameOne = x.name.toLowerCase();
@@ -12,17 +12,23 @@ export const sortArray = (x, y) => {
   return 0;
 };
 
-const filterFormByAssigment = (profile = {}) => {
+// Snapshot accessor for non-component code (helpers, lookups) that used to
+// read the window.forms global. Components should prefer
+// store.useState((s) => s.allForms) so they re-render on updates.
+export const getForms = () => store.getRawState().allForms || [];
+
+const filterFormByAssigment = (profile = {}, allForms = []) => {
   if (!Object.keys(profile).length) {
-    return window.forms;
+    return allForms;
   }
   return profile.forms.length
-    ? window.forms.filter((x) => profile.forms.map((f) => f.id).includes(x.id))
-    : window.forms;
+    ? allForms.filter((x) => profile.forms.map((f) => f.id).includes(x.id))
+    : allForms;
 };
 
 export const reloadData = (profile = {}, dataset = []) => {
-  const filterForms = filterFormByAssigment(profile);
+  const allForms = getForms();
+  const filterForms = filterFormByAssigment(profile, allForms);
   const updatedForms = dataset.length
     ? filterForms.map((x) => {
         const newForm = dataset.find((d) => d.id === x.id);
@@ -36,3 +42,19 @@ export const reloadData = (profile = {}, dataset = []) => {
     s.forms = updatedForms;
   });
 };
+
+// Fetch the published forms (with full content) once at app bootstrap and
+// populate the store. Replaces the window.forms global baked into config.js.
+export const fetchPublishedForms = () =>
+  api.get("forms/published").then((res) => {
+    const data = Array.isArray(res?.data) ? res.data : [];
+    const allForms = data.slice().sort(sortArray);
+    store.update((s) => {
+      s.allForms = allForms;
+    });
+    // Recompute the assignment-filtered list now that allForms is available,
+    // covering the case where the profile fetch resolved before this one.
+    const { user } = store.getRawState();
+    reloadData(user || {});
+    return allForms;
+  });


### PR DESCRIPTION
### Problem

Newly published forms didn't appear in the web app without a config rebuild and a hard reload. Forms were baked into a load-once global script: config.js → config.min.js sets var forms = \[...] as window\.forms. Two staleness layers:

1. Load order — the SPA reads window\.forms once at startup, so forms published after page load never appear in the open tab.

2. No cache-busting — get\_config\_file sets no Cache-Control, so the browser heuristically caches config.js and serves the stale bundle even on reload.

The backend was already regenerating config.min.js correctly — this was purely a delivery-model problem.


### Solution

Replace the baked window\.forms global with a runtime fetch into the pullstate store, so published/unpublished forms reflect on next load (and in place after a publish action) with no config rebuild.


### Backend

- New endpoint GET /api/v1/forms/published (AllowAny, Cache-Control: no-cache) returning all published forms — parents and children — with full content, shape-identical to the old baked list (differs from /forms, which filters out children).

- get\_published\_forms\_payload() helper in v1\_forms/functions.py, shared with generate\_config (DRY) and cached via the existing get\_cache/create\_cache (date-prefixed, bypassed under TEST\_ENV).

- generate\_config no longer emits var forms= → smaller config.min.js.

- refresh\_form\_config slimmed to clear\_cache only (drops generate\_config from the publish path). The cached payload is invalidated by clear\_cache and the existing form-mutation post\_save/post\_delete → cache.clear() signal.


### Frontend

- Store: allForms (full published list) + forms (assignment-filtered), both init \[] instead of seeding from window\.forms.

- util/form.js: fetchPublishedForms() populates allForms; getForms() snapshot accessor for non-component code; reloadData now sources from the store.

- App.js: fetches on mount and gates render until forms load (no flash of empty dropdowns).

- Migrated every window\.forms / window?.forms consumer to the store/getForms(): dashboard (escalation, filters, map, individual-overview helpers), filters (FormDropdown, DataFilters), submissions, manage-data, manage-draft, approvals, header. (The optional-chaining window?.forms?.… variants were silently crashing components like MonitoringDetail once the global was gone — all fixed.)

- FormBuilderEdit: replaced window\.location.reload() on publish / unpublish / activate-version with fetchPublishedForms() — refreshes the global store in place instead of a full page reload.


### Out of scope

window\.levels, window\.topojson, window\.appConfig, window\.roleFeatures stay baked in config.min.js (they change only on reseed/deploy). Mobile app and websocket/poll live-push to open tabs are not touched.


### Testing

- Backend: 5 new endpoint tests (public access, no-cache header, item shape, parents+children parity, excludes unpublished) — pass; flake8 + manage.py check clean.

- Frontend: store / util/form / helpers / App / login / filters suites pass; snapshots updated; eslint clean across all 36 changed files.

- No window\.forms references remain in frontend/src (excluding explanatory comments).
