### PR TITLE
[#244] Re-enable bulk upload button & fix non-superadmin bulk Excel upload

### DIFF
--- a/backend/api/v1/v1_jobs/seed_data.py
+++ b/backend/api/v1/v1_jobs/seed_data.py
@@ -22,7 +22,12 @@ from api.v1.v1_profile.models import (
     DataAccessTypes,
 )
 from api.v1.v1_users.models import SystemUser
-from api.v1.v1_approval.models import DataBatch
+from api.v1.v1_approval.models import (
+    DataBatch,
+    DataBatchList,
+    DataApproval,
+)
+from api.v1.v1_approval.constants import DataApprovalStatus
 from utils.email_helper import send_email, EmailTypes
 from uuid import uuid4
 
@@ -295,8 +300,12 @@ def save_data(
             parent=parent,
             is_pending=True,
         )
-        batch.batch_data_list.add(data)
-        batch.save()
+        # DataBatchList is a through model (OneToOneField to FormData), so the
+        # entry must be created explicitly. batch.batch_data_list.add(data)
+        # raises TypeError (expects a DataBatchList, not a FormData) and aborts
+        # the whole seed after the first datapoint — leaving a datapoint with
+        # no answers behind.
+        DataBatchList.objects.create(batch=batch, data=data)
 
     # Always create Answers objects (not PendingAnswers)
     answer_to_create = []
@@ -391,11 +400,22 @@ def seed_excel_data(job: Jobs, test: bool = False):
         if not test:
             os.remove(file)
         return None
-    if batch and len(batch.approvers()):
+    approvers = batch.approvers() if batch else []
+    if approvers:
+        # Assign approvers so the batch can move through the approval workflow.
+        # This mirrors the POST /batch flow; without it, bulk-uploaded batches
+        # have no DataApproval rows, so their approver list shows empty and the
+        # batch can never be approved.
+        for approver in approvers:
+            DataApproval.objects.create(
+                batch=batch,
+                administration=approver["administration"],
+                role=approver["role"],
+                user=approver["user"],
+                status=DataApprovalStatus.pending,
+            )
         # Send email to all approvers
-        emails = [
-            approver.user.email for approver in batch.approvers()
-        ]
+        emails = [approver["user"].email for approver in approvers]
         number_of_records = batch.batch_data_list.count()
         data = {
             "send_to": emails,

--- a/backend/api/v1/v1_jobs/tests/tests_bulk_data_upload.py
+++ b/backend/api/v1/v1_jobs/tests/tests_bulk_data_upload.py
@@ -5,10 +5,12 @@ from api.v1.v1_jobs.functions import ValidationText
 from api.v1.v1_jobs.validate_upload import validate
 from api.v1.v1_jobs.models import Jobs, JobTypes, JobStatus
 from api.v1.v1_jobs.seed_data import seed_excel_data
-from api.v1.v1_forms.models import Forms
+from api.v1.v1_forms.models import Forms, UserForms
 from api.v1.v1_data.models import FormData
 from api.v1.v1_users.models import SystemUser
-from api.v1.v1_profile.models import Administration
+from api.v1.v1_profile.models import Administration, Role, UserRole
+from api.v1.v1_profile.constants import DataAccessTypes
+from api.v1.v1_approval.models import DataBatch, DataBatchList
 from api.v1.v1_profile.tests.mixins import ProfileTestHelperMixin
 from api.v1.v1_data.management.commands.fake_complete_data_seeder import (
     add_fake_answers
@@ -33,6 +35,171 @@ class BulkUploadDataTestCase(TestCase, ProfileTestHelperMixin):
         ).first()
 
         self.test_folder = "api/v1/v1_jobs/tests/fixtures"
+
+    def _make_user(self, email, data_access, administration, form):
+        """Create a non-superadmin user with a role that has the given data
+        access at ``administration`` plus access to ``form``."""
+        user = SystemUser.objects.create(
+            email=email,
+            first_name=email.split("@")[0],
+            last_name="Test",
+            is_superuser=False,
+        )
+        user.set_password("test")
+        user.save()
+        role = Role.objects.filter(
+            role_role_access__data_access=data_access
+        ).first()
+        UserRole.objects.create(
+            user=user, role=role, administration=administration
+        )
+        UserForms.objects.get_or_create(user=user, form=form)
+        return user
+
+    def _seed_as(self, user, form, administration, upload_file):
+        job = Jobs.objects.create(
+            type=JobTypes.seed_data,
+            status=JobStatus.done,
+            user=user,
+            info={
+                "file": upload_file,
+                "form": form.id,
+                "administration": administration.id,
+                "is_update": False,
+            },
+        )
+        return seed_excel_data(job=job, test=True)
+
+    def test_non_super_bulk_upload_seeds_all_rows_with_answers(self):
+        """Regression: a non-superadmin bulk upload must turn EVERY row into a
+        pending datapoint WITH answers, linked to a batch.
+
+        Previously ``seed_excel_data`` called
+        ``batch.batch_data_list.add(data)`` which raised ``TypeError``
+        (``DataBatchList`` is a through model, not an m2m to ``FormData``),
+        aborting the seed after the first datapoint — leaving a single
+        answerless datapoint behind.
+        """
+        call_command("default_roles_seeder", "--test", 1)
+        form = Forms.objects.get(pk=1)
+        administration = Administration.objects.filter(name="Cawang").first()
+        submitter = self._make_user(
+            "bulk.submitter@test.com",
+            DataAccessTypes.submit,
+            administration,
+            form,
+        )
+        upload_file = "{0}/test-success-new-registration.xlsx".format(
+            self.test_folder
+        )
+        self.assertEqual(
+            len(
+                validate(
+                    form=form,
+                    administration=administration.id,
+                    file=upload_file,
+                )
+            ),
+            0,
+        )
+        records = self._seed_as(submitter, form, administration, upload_file)
+
+        datapoints = FormData.objects.filter(
+            form=form, created_by=submitter, is_pending=True
+        )
+        # Fixture has 2 rows: both must be seeded (not just the first).
+        self.assertEqual(datapoints.count(), 2)
+        self.assertEqual(len(records), 2)
+        for dp in datapoints:
+            self.assertGreater(
+                dp.data_answer.count(),
+                0,
+                "pending datapoint must have answers",
+            )
+            self.assertTrue(
+                DataBatchList.objects.filter(data=dp).exists(),
+                "datapoint must be linked to a batch",
+            )
+
+    def test_non_super_bulk_upload_notifies_approvers(self):
+        """The approver-notification path must resolve emails from
+        ``batch.approvers()`` (which returns dicts, not model instances).
+
+        Previously it did ``approver.user.email`` and raised
+        ``AttributeError: 'dict' object has no attribute 'user'``.
+        """
+        call_command("default_roles_seeder", "--test", 1)
+        form = Forms.objects.get(pk=1)
+        administration = Administration.objects.filter(name="Cawang").first()
+        submitter = self._make_user(
+            "bulk.submitter2@test.com",
+            DataAccessTypes.submit,
+            administration,
+            form,
+        )
+        approver = self._make_user(
+            "bulk.approver@test.com",
+            DataAccessTypes.approve,
+            administration,
+            form,
+        )
+        upload_file = "{0}/test-success-new-registration.xlsx".format(
+            self.test_folder
+        )
+        records = self._seed_as(submitter, form, administration, upload_file)
+        self.assertTrue(records)
+
+        batch = DataBatch.objects.filter(user=submitter).last()
+        self.assertIsNotNone(batch)
+        approver_emails = [a["user"].email for a in batch.approvers()]
+        self.assertIn(approver.email, approver_emails)
+
+        # DataApproval rows must be created so the batch is approvable and its
+        # approvers show up in the /batch/ list (batch_approval relation).
+        self.assertTrue(
+            batch.batch_approval.filter(user=approver).exists(),
+            "a DataApproval must be assigned to the approver",
+        )
+
+    def test_bulk_uploaded_batch_lists_approvers_via_endpoint(self):
+        """End-to-end: the /batch/ list endpoint must show the approvers of a
+        bulk-uploaded batch.
+
+        The endpoint's serializer reads ``batch_approval`` (DataApproval rows),
+        not ``batch.approvers()``. Bulk-uploaded batches previously had no
+        DataApproval rows, so the ``approvers`` field came back empty.
+        """
+        call_command("default_roles_seeder", "--test", 1)
+        form = Forms.objects.get(pk=1)
+        administration = Administration.objects.filter(name="Cawang").first()
+        submitter = self._make_user(
+            "bulk.submitter3@test.com",
+            DataAccessTypes.submit,
+            administration,
+            form,
+        )
+        approver = self._make_user(
+            "bulk.approver2@test.com",
+            DataAccessTypes.approve,
+            administration,
+            form,
+        )
+        upload_file = "{0}/test-success-new-registration.xlsx".format(
+            self.test_folder
+        )
+        self._seed_as(submitter, form, administration, upload_file)
+
+        token = self.get_auth_token(submitter.email, "test")
+        response = self.client.get(
+            f"/api/v1/batch/?form={form.id}&page=1",
+            HTTP_AUTHORIZATION=f"Bearer {token}",
+        )
+        self.assertEqual(response.status_code, 200)
+        body = response.json()
+        self.assertGreaterEqual(len(body["data"]), 1)
+        batch_json = body["data"][0]
+        approver_names = [a["name"] for a in batch_json["approvers"]]
+        self.assertIn(approver.get_full_name(), approver_names)
 
     def test_upload_empty_data(self):
         form = Forms.objects.get(pk=1)

--- a/frontend/src/components/can/ability.js
+++ b/frontend/src/components/can/ability.js
@@ -14,7 +14,7 @@ const defineAbilityFor = (user) => {
     const roles = user?.roles || [];
     const is_approver = roles.filter((r) => r?.is_approver).length > 0;
     const is_submitter = roles.filter((r) => r?.is_submitter).length > 0;
-    const is_editor = roles.filter((r) => r?.is_mobile).length > 0;
+    const is_editor = roles.filter((r) => r?.is_editor).length > 0;
     const can_delete = roles.filter((r) => r?.can_delete).length > 0;
     const can_invite_user = roles.filter((r) => r?.can_invite_user).length > 0;
     const can_form_builder =
@@ -34,6 +34,7 @@ const defineAbilityFor = (user) => {
       can("manage", "mobile");
       can("create", "downloads");
       can("edit", "data");
+      can("upload", "data");
     }
     if (is_editor) {
       can("edit", "data");

--- a/frontend/src/components/filters/DataFilters.js
+++ b/frontend/src/components/filters/DataFilters.js
@@ -13,7 +13,7 @@ import {
   Input,
   DatePicker,
 } from "antd";
-import { useLocation, useNavigate } from "react-router-dom";
+import { useLocation, useNavigate, Link } from "react-router-dom";
 import AdministrationDropdown from "./AdministrationDropdown";
 import FormDropdown from "./FormDropdown.js";
 import { useNotification } from "../../util/hooks";
@@ -24,7 +24,7 @@ import AdvancedFilters from "./AdvancedFilters";
 import {
   PlusOutlined,
   DownloadOutlined,
-  // UploadOutlined,
+  UploadOutlined,
   FileWordOutlined,
   DownOutlined,
   SearchOutlined,
@@ -346,13 +346,13 @@ const DataFilters = ({
         </Col>
         <Col>
           <Space>
-            {/* <Can I="upload" a="data">
+            <Can I="upload" a="data">
               <Link to="/control-center/data/upload">
                 <Button shape="round" icon={<UploadOutlined />}>
                   {text.bulkUpload}
                 </Button>
               </Link>
-            </Can> */}
+            </Can>
             {pathname === "/control-center/data" && (
               <Space>
                 {selectedRowKeys.length === 0 ? (


### PR DESCRIPTION
## Overview

This branch re-enables the **Bulk Upload** button on the Manage Data page and
fixes the backend bulk Excel upload flow, which was broken for **non-superadmin**
users (the primary users of bulk upload). Previously a data-entry user's upload
would create a single answerless datapoint and silently fail; the resulting
batch could never be approved.

## Acceptance Criteria

- [x] Bulk Upload button visible on Manage Data page (`/control-center/data`)
- [x] Button respects CASL permissions (only visible to users with "upload" on "data")
- [x] Clicking button navigates to `/control-center/data/upload`

## Changes

### Frontend — re-enable bulk upload entry point

| File | Change |
|------|--------|
| `frontend/src/components/filters/DataFilters.js` | Uncomment the `<Can I="upload" a="data">` bulk-upload button (and its `Link` / `UploadOutlined` imports) on the Manage Data page. |
| `frontend/src/components/can/ability.js` | Fix the editor ability check: derive `is_editor` from `r?.is_editor` instead of the wrong `r?.is_mobile` flag. Also grant `upload data` to **submitters** (previously only editors could bulk upload), matching the backend flow where a data submitter is the one who performs the upload. |


### Backend — fix non-superadmin bulk Excel seeding

All three bugs live on the non-superadmin path in
`backend/api/v1/v1_jobs/seed_data.py` (`seed_excel_data` / `save_data`), which is
why superadmin uploads worked and the existing (superadmin-only) tests stayed
green.

1. **`TypeError` aborted the seed after the first row → "1 row inserted, no answers".**
   `batch.batch_data_list.add(data)` passed a `FormData` where a `DataBatchList`
   is expected (`DataBatchList` is a through model with a `OneToOneField` to
   `FormData`, not an m2m). The exception fired **after** the first `FormData`
   was created but **before** its answers were `bulk_create`d and before the
   "delete if 0 answers" cleanup, leaving one answerless pending datapoint
   behind. Fixed to `DataBatchList.objects.create(batch=batch, data=data)`
   (the canonical pattern used by `POST /batch`).

2. **`AttributeError` on the approver-notification path.**
   `batch.approvers()` returns a list of dicts, but the code did
   `approver.user.email`. Fixed to `approver["user"].email`.

3. **No approvers assigned to bulk-uploaded batches.**
   The seed created the `DataBatch` and `DataBatchList` and sent the approver
   email, but never created the `DataApproval` rows. As a result the `/batch/`
   endpoint (`ListBatchSerializer.get_approvers`, which reads `batch_approval`)
   returned an empty approver list and the batch could never move through the
   approval workflow. Now creates a pending `DataApproval` per approver,
   mirroring the `POST /batch` flow.

### Tests

Added to `backend/api/v1/v1_jobs/tests/tests_bulk_data_upload.py` (each fails
without the corresponding fix, verified by temporarily reverting):

- `test_non_super_bulk_upload_seeds_all_rows_with_answers` — every row becomes a
  pending datapoint **with** answers, linked to a batch (covers bug 1).
- `test_non_super_bulk_upload_notifies_approvers` — the approver path resolves
  emails and a `DataApproval` is assigned (covers bugs 2 & 3).
- `test_bulk_uploaded_batch_lists_approvers_via_endpoint` — end-to-end
  `GET /api/v1/batch/?form=<id>` returns the batch's approvers (covers bug 3 at
  the API boundary — the exact reported symptom).
