### PR TITLE
Feature/245 sync app changes from iwsims to akvo mis

### DIFF
--- a/app/App.js
+++ b/app/App.js
@@ -6,7 +6,6 @@ import * as TaskManager from 'expo-task-manager';
 import * as BackgroundTask from 'expo-background-task';
 import * as Sentry from '@sentry/react-native';
 import * as Location from 'expo-location';
-import * as SQLite from 'expo-sqlite';
 import { SENTRY_DSN, SENTRY_ENV } from '@env';
 import { SQLiteProvider } from 'expo-sqlite';
 
@@ -29,7 +28,7 @@ import {
   MAX_ATTEMPT,
   jobStatus,
 } from './src/lib/constants';
-import { tables } from './src/database';
+import { tables, openDatabase } from './src/database';
 import sql from './src/database/sql';
 import { m03, m04, m05 } from './src/database/migrations';
 
@@ -48,9 +47,7 @@ defineSyncDatapointBackgroundTask();
 
 TaskManager.defineTask(SYNC_FORM_SUBMISSION_TASK_NAME, async () => {
   try {
-    const db = await SQLite.openDatabaseAsync(DATABASE_NAME, {
-      useNewConnection: true,
-    });
+    const db = await openDatabase();
     const pendingToSync = await crudDataPoints.selectSubmissionToSync(db);
     const activeJob = await crudJobs.getActiveJob(db, SYNC_FORM_SUBMISSION_TASK_NAME);
 
@@ -192,6 +189,9 @@ const App = () => {
   };
 
   const migrateDbIfNeeded = async (db) => {
+    // Connection-level pragma: wait up to 5s for a concurrent writer instead of
+    // failing immediately with "database is locked" (SQLITE_BUSY).
+    await db.execAsync('PRAGMA busy_timeout = 5000;');
     let { user_version: currentDbVersion } = await db.getFirstAsync('PRAGMA user_version');
     if (currentDbVersion >= DATABASE_VERSION) {
       await handleInitConfig(db);

--- a/app/src/build.prod.js
+++ b/app/src/build.prod.js
@@ -3,7 +3,7 @@ import buildJson from './build.json';
 const defaultBuildParams = {
   ...buildJson,
   serverURL: '', // Configure: https://<your-domain>/api/v1/device
-  apkURL: '',    // Configure: https://<your-domain>/app
+  apkURL: '', // Configure: https://<your-domain>/app
 };
 
 export default defaultBuildParams;

--- a/app/src/build.staging.js
+++ b/app/src/build.staging.js
@@ -3,7 +3,7 @@ import buildJson from './build.json';
 const defaultBuildParams = {
   ...buildJson,
   serverURL: '', // Configure: https://<your-domain>/api/v1/device
-  apkURL: '',    // Configure: https://<your-domain>/app
+  apkURL: '', // Configure: https://<your-domain>/app
 };
 
 export default defaultBuildParams;

--- a/app/src/components/LogoutButton.js
+++ b/app/src/components/LogoutButton.js
@@ -2,10 +2,9 @@ import React, { useState } from 'react';
 import { View, TouchableOpacity, StyleSheet } from 'react-native';
 import { Dialog, Text, Icon } from '@rneui/themed';
 import { useNavigation } from '@react-navigation/native';
-import * as SQLite from 'expo-sqlite';
 import { AuthState, UserState, FormState, UIState, DatapointSyncState } from '../store';
 import { api, cascades, i18n } from '../lib';
-import { DATABASE_NAME } from '../lib/constants';
+import { openDatabase } from '../database';
 import sql from '../database/sql';
 
 const LogoutButton = () => {
@@ -20,9 +19,7 @@ const LogoutButton = () => {
   };
 
   const handleYesPress = async () => {
-    const db = await SQLite.openDatabaseAsync(DATABASE_NAME, {
-      useNewConnection: true,
-    });
+    const db = await openDatabase();
     const tables = [
       'sessions',
       'users',

--- a/app/src/database/crud/crud-forms.js
+++ b/app/src/database/crud/crud-forms.js
@@ -139,7 +139,7 @@ const formsQuery = () => ({
         LEFT JOIN datapoints dp ON f.id = dp.form AND dp.uuid = ?
         WHERE f.parentId = ?
         GROUP BY f.id, f.formId, f.version, f.name, f.json;`;
-    const rows = await sql.executeQuery(db, selectJoin, [uuid, parentId, uuid]);
+    const rows = await sql.executeQuery(db, selectJoin, [uuid, parentId]);
     return rows;
   },
 });

--- a/app/src/database/index.js
+++ b/app/src/database/index.js
@@ -1,2 +1,20 @@
-// eslint-disable-next-line import/prefer-default-export
+import * as SQLite from 'expo-sqlite';
+import { DATABASE_NAME } from '../lib/constants';
+
 export { default as tables } from './tables';
+
+/**
+ * Opens a dedicated connection to the app database with PRAGMAs applied.
+ * busy_timeout makes concurrent writers wait instead of failing immediately
+ * with "database is locked" (the app uses multiple connections: the
+ * SQLiteProvider one plus background-task connections).
+ *
+ * @returns {Promise<Object>} The database connection object.
+ */
+export const openDatabase = async () => {
+  const db = await SQLite.openDatabaseAsync(DATABASE_NAME, {
+    useNewConnection: true,
+  });
+  await db.execAsync('PRAGMA busy_timeout = 5000;');
+  return db;
+};

--- a/app/src/database/sql.js
+++ b/app/src/database/sql.js
@@ -311,7 +311,10 @@ const dropColumn = async (db, table, columnName) => {
  */
 const withTransaction = async (db, fn) => {
   try {
-    await db.execAsync('BEGIN TRANSACTION');
+    // BEGIN IMMEDIATE acquires the write lock up front so busy_timeout applies.
+    // A deferred BEGIN can fail with SQLITE_BUSY on lock upgrade, which
+    // busy_timeout does not retry in WAL mode.
+    await db.execAsync('BEGIN IMMEDIATE TRANSACTION');
     const result = await fn(db);
     await db.execAsync('COMMIT');
     return result;

--- a/app/src/form/components/QuestionGroup.js
+++ b/app/src/form/components/QuestionGroup.js
@@ -5,6 +5,7 @@ import { KeyboardAwareFlatList } from 'react-native-keyboard-aware-scroll-view';
 
 import QuestionField from './QuestionField';
 import { FieldGroupHeader, RepeatSection } from '../support';
+import { generateValidationSchemaFieldLevel } from '../lib';
 import { FormState } from '../../store';
 import styles from '../styles';
 
@@ -50,11 +51,28 @@ const QuestionGroup = ({ index, group, activeQuestions, dependantQuestions = [] 
   }, [group, activeQuestions]);
 
   // Handle onChange for all questions
-  const handleOnChange = (id, value) => {
+  const handleOnChange = (id, value, question) => {
     // Handle dependencies with dependantQuestions
     FormState.update((s) => {
       s.currentValues = { ...s.currentValues, [id]: value };
     });
+    /**
+     * Clear a stale "... is required" message as soon as the field is answered.
+     * Only act when an error is currently shown for this field: this avoids
+     * re-validating and re-rendering every field on each keystroke for fields
+     * that have no active error.
+     */
+    const currentFeedback = FormState.getRawState().feedback?.[id];
+    if (question?.id && currentFeedback && currentFeedback !== true) {
+      generateValidationSchemaFieldLevel(value, question).then((result) => {
+        const nextFeedback = result?.[question.id];
+        FormState.update((s) => {
+          if (s.feedback?.[id] !== nextFeedback) {
+            s.feedback = { ...s.feedback, [id]: nextFeedback };
+          }
+        });
+      });
+    }
   };
 
   const handleContentSizeChange = (width, height) => {

--- a/app/src/form/styles.js
+++ b/app/src/form/styles.js
@@ -178,7 +178,7 @@ const styles = StyleSheet.create({
     marginBottom: 18,
   },
   questionGroupListContainer: {
-    paddingVertical: 24,
+    paddingTop: 24,
     flex: 1,
     width: '100%',
   },

--- a/app/src/form/support/QuestionGroupList.js
+++ b/app/src/form/support/QuestionGroupList.js
@@ -1,8 +1,12 @@
-import React, { useMemo } from 'react';
-import { View } from 'react-native';
+import React, { useMemo, useState, useEffect } from 'react';
+import { ScrollView, View } from 'react-native';
 import { Text, Divider } from '@rneui/themed';
 import QuestionGroupListItem from './QuestionGroupListItem';
-import { onFilterDependency, generateDataPointName } from '../lib';
+import {
+  onFilterDependency,
+  generateDataPointName,
+  generateValidationSchemaFieldLevel,
+} from '../lib';
 import styles from '../styles';
 import { FormState } from '../../store';
 
@@ -29,6 +33,50 @@ export const checkCompleteQuestionGroup = (form, values) => {
         .filter((x) => x).length === filteredQuestions.length
     );
   });
+};
+
+/**
+ * Schema-based counter that mirrors the Submit gate (validateAllGroups in
+ * FormNavigation). A required question counts as "filled" only if it passes the
+ * same Yup field-level schema used at submit time, so reaching totalFilled ===
+ * totalRequired guarantees the form is actually submittable.
+ */
+export const countValidRequiredQuestions = async (form, values) => {
+  // Extract all questions for recursive dependency checking
+  const allQuestions = form.question_group.flatMap((qg) => qg.question).filter((q) => q);
+
+  let totalRequired = 0;
+  const validations = [];
+  form.question_group.forEach((questionGroup) => {
+    const requiredQuestions = questionGroup.question.filter((q) => q.required);
+    requiredQuestions.forEach((question) => {
+      // Skip dependent questions whose dependency is not currently satisfied
+      if (
+        question?.dependency &&
+        !onFilterDependency(questionGroup, values, question, 0, allQuestions)
+      ) {
+        return;
+      }
+      // Mirror validateAllGroups: entity questions without a value are skipped
+      // (their options depend on prevAdmAnswer and are not gated at submit).
+      if (question?.extra?.type === 'entity' && values?.[question.id] === undefined) {
+        return;
+      }
+      totalRequired += 1;
+      const defaultVal = ['cascade', 'multiple_option', 'option', 'geo'].includes(question?.type)
+        ? null
+        : '';
+      const fieldValue = values?.[question.id] === undefined ? defaultVal : values[question.id];
+      validations.push(generateValidationSchemaFieldLevel(fieldValue, question));
+    });
+  });
+
+  const results = await Promise.allSettled(validations);
+  const totalFilled = results.filter(
+    ({ status, value }) => status === 'fulfilled' && Object.values(value || {})[0] === true,
+  ).length;
+
+  return { totalFilled, totalRequired };
 };
 
 export const checkGroupHasErrors = (form, values) => {
@@ -80,11 +128,34 @@ const QuestionGroupList = ({
   };
 
   const dataPointNameText = generateDataPointName(forms, currentValues, cascades)?.dpName;
+  const [requiredCount, setRequiredCount] = useState({ totalFilled: 0, totalRequired: 0 });
+  useEffect(() => {
+    let ignore = false;
+    /**
+     * Validating every required field (Yup schema) is expensive and currentValues
+     * changes on each keystroke, so debounce the run. The `ignore` flag ensures
+     * only the latest run commits its result and prevents setState after unmount;
+     * clearTimeout drops the pending timer so it cannot leak past unmount.
+     */
+    const timer = setTimeout(() => {
+      countValidRequiredQuestions(form, currentValues).then((res) => {
+        if (!ignore) {
+          setRequiredCount(res);
+        }
+      });
+    }, 300);
+    return () => {
+      ignore = true;
+      clearTimeout(timer);
+    };
+  }, [form, currentValues]);
+  const { totalFilled, totalRequired } = requiredCount;
 
   return (
     <View style={styles.questionGroupListContainer}>
       <Text style={styles.questionGroupListFormTitle} testID="form-name">
         {form.name}
+        {totalRequired ? ` (${totalFilled}/${totalRequired})` : ''}
       </Text>
       <Divider style={styles.divider} />
       {dataPointNameText && (
@@ -95,19 +166,21 @@ const QuestionGroupList = ({
           <Divider style={styles.divider} />
         </>
       )}
-      {form.question_group.map((questionGroup, qx) => (
-        <QuestionGroupListItem
-          key={questionGroup.id}
-          label={questionGroup.label}
-          active={activeQuestionGroup === qx}
-          completedQuestionGroup={
-            completedQuestionGroup[qx] && visitedQuestionGroup.includes(questionGroup.id)
-          }
-          hasErrors={groupHasErrors[qx]}
-          visited={visitedQuestionGroup.includes(questionGroup.id)}
-          onPress={() => handleOnPress(qx)}
-        />
-      ))}
+      <ScrollView>
+        {form.question_group.map((questionGroup, qx) => (
+          <QuestionGroupListItem
+            key={questionGroup.id}
+            label={questionGroup.label}
+            active={activeQuestionGroup === qx}
+            completedQuestionGroup={
+              completedQuestionGroup[qx] && visitedQuestionGroup.includes(questionGroup.id)
+            }
+            hasErrors={groupHasErrors[qx]}
+            visited={visitedQuestionGroup.includes(questionGroup.id)}
+            onPress={() => handleOnPress(qx)}
+          />
+        ))}
+      </ScrollView>
     </View>
   );
 };

--- a/app/src/lib/background-task.js
+++ b/app/src/lib/background-task.js
@@ -2,8 +2,8 @@ import * as BackgroundTask from 'expo-background-task';
 import * as TaskManager from 'expo-task-manager';
 import * as Network from 'expo-network';
 import * as Sentry from '@sentry/react-native';
-import * as SQLite from 'expo-sqlite';
 import api from './api';
+import { openDatabase } from '../database';
 import { crudForms, crudDataPoints, crudUsers, crudConfig, crudSyncQueue } from '../database/crud';
 import {
   downloadDatapointsJson,
@@ -14,7 +14,6 @@ import notification from './notification';
 import crudJobs from '../database/crud/crud-jobs';
 import { UIState, DatapointSyncState } from '../store';
 import {
-  DATABASE_NAME,
   QUESTION_TYPES,
   SYNC_DATAPOINT_BACKGROUND_TASK_NAME,
   SYNC_DATAPOINT_JOB_NAME,
@@ -73,9 +72,7 @@ const syncFormVersion = async (
 };
 
 const registerBackgroundTask = async (TASK_NAME, settingsValue = null) => {
-  const db = await SQLite.openDatabaseAsync(DATABASE_NAME, {
-    useNewConnection: true,
-  });
+  const db = await openDatabase();
   try {
     const config = await crudConfig.getConfig(db);
     const syncIntervalSec = settingsValue || parseInt(config?.syncInterval, 10) || 3600;
@@ -339,9 +336,7 @@ const backgroundTask = backgroundTaskHandler();
 
 export const defineSyncFormVersionTask = () =>
   TaskManager.defineTask(SYNC_FORM_VERSION_TASK_NAME, async () => {
-    const db = await SQLite.openDatabaseAsync(DATABASE_NAME, {
-      useNewConnection: true,
-    });
+    const db = await openDatabase();
     try {
       await syncFormVersion(db, {
         sendPushNotification: notification.sendPushNotification,
@@ -362,9 +357,7 @@ export const defineSyncFormVersionTask = () =>
  * Each background trigger continues from where the last one left off.
  */
 const syncDatapointsBackground = async () => {
-  const db = await SQLite.openDatabaseAsync(DATABASE_NAME, {
-    useNewConnection: true,
-  });
+  const db = await openDatabase();
   try {
     const session = await crudUsers.getActiveUser(db);
     if (!session?.token) {
@@ -457,7 +450,7 @@ export const defineSyncDatapointBackgroundTask = () =>
 
 export const defineSyncFormSubmissionTask = () => {
   TaskManager.defineTask(SYNC_FORM_SUBMISSION_TASK_NAME, async () => {
-    const db = await SQLite.openDatabaseAsync(DATABASE_NAME, { useNewConnection: true });
+    const db = await openDatabase();
     try {
       await syncFormSubmission(db);
       return BackgroundTask.BackgroundTaskResult.Success;

--- a/app/src/pages/Submission.js
+++ b/app/src/pages/Submission.js
@@ -6,10 +6,13 @@ import {
   Text,
   TouchableOpacity,
   ActivityIndicator,
+  Platform,
+  ToastAndroid,
 } from 'react-native';
 import Icon from 'react-native-vector-icons/Ionicons';
 import LucideIcon from '@react-native-vector-icons/lucide';
 import * as SQLite from 'expo-sqlite';
+import * as Sentry from '@sentry/react-native';
 import moment from 'moment';
 import { FormState, UIState, UserState } from '../store';
 import { i18n } from '../lib';
@@ -112,49 +115,53 @@ const Submission = ({ navigation, route }) => {
   };
 
   const fetchData = useCallback(async () => {
-    if (!activeForm.id) {
-      return;
-    }
-    const draftCount = await crudDataPoints.totalSavedData(
-      db,
-      activeForm.id,
-      route?.params?.uuid || null,
-    );
-    setTotalSavedData(draftCount);
-    /**
-     * Fetch data points from the database based on the active form ID and user ID.
-     * The data points are filtered by the submitted status (1 for submitted).
-     * The results are then formatted to include
-     * createdAt and syncedAt dates in a readable format.
-     * The syncedAt date is set to '-' if it is null.
-     * The isSynced property is set to true if syncedAt is not null.
-     * The data points are then set to the state variable 'data'.
-     */
-    let rows = await crudDataPoints.selectDataPointsByFormAndSubmitted(db, {
-      form: activeForm.id,
-      submitted: isSubmitted,
-      user: activeUserId,
-      uuid: route?.params?.uuid || null,
-    });
-    rows = rows.map((res) => {
-      const createdAt = moment(res.createdAt).format('DD/MM/YYYY hh:mm A');
-      const syncedAt = res.syncedAt ? moment(res.syncedAt).format('DD/MM/YYYY hh:mm A') : '-';
-      return {
-        ...res,
-        createdAt,
-        syncedAt,
-        isSynced: !!res.syncedAt,
-      };
-    });
-    setData(rows);
-    if (rows.length === 0) {
+    if (!activeForm?.id) {
       setLoading(false);
       return;
     }
-    setTimeout(() => {
+    try {
+      const draftCount = await crudDataPoints.totalSavedData(
+        db,
+        activeForm.id,
+        route?.params?.uuid || null,
+      );
+      setTotalSavedData(draftCount);
+      /**
+       * Fetch data points from the database based on the active form ID and user ID.
+       * The data points are filtered by the submitted status (1 for submitted).
+       * The results are then formatted to include
+       * createdAt and syncedAt dates in a readable format.
+       * The syncedAt date is set to '-' if it is null.
+       * The isSynced property is set to true if syncedAt is not null.
+       * The data points are then set to the state variable 'data'.
+       */
+      let rows = await crudDataPoints.selectDataPointsByFormAndSubmitted(db, {
+        form: activeForm.id,
+        submitted: isSubmitted,
+        user: activeUserId,
+        uuid: route?.params?.uuid || null,
+      });
+      rows = rows.map((res) => {
+        const createdAt = moment(res.createdAt).format('DD/MM/YYYY hh:mm A');
+        const syncedAt = res.syncedAt ? moment(res.syncedAt).format('DD/MM/YYYY hh:mm A') : '-';
+        return {
+          ...res,
+          createdAt,
+          syncedAt,
+          isSynced: !!res.syncedAt,
+        };
+      });
+      setData(rows);
+    } catch (error) {
+      Sentry.captureMessage('[Submission] Unable to fetch data points');
+      Sentry.captureException(error);
+      if (Platform.OS === 'android') {
+        ToastAndroid.show(`SQL: ${error}`, ToastAndroid.LONG);
+      }
+    } finally {
       setLoading(false);
-    }, 1000);
-  }, [activeForm.id, activeUserId, db, isSubmitted, route?.params?.uuid]);
+    }
+  }, [activeForm?.id, activeUserId, db, isSubmitted, route?.params?.uuid]);
 
   useEffect(() => {
     fetchData();


### PR DESCRIPTION
## Overview

This branch ports two mobile-app fixes from iwsims into this tenant:

1. Eliminate intermittent **`database is locked` (SQLITE_BUSY)** failures on
   submit and a **"Fetching data" spinner that could stay stuck forever**.
2. Make the **question group list scrollable** and fix **stale "… is required"**
   validation messages, with an accurate required-question counter.

All changes are in `app/` (React Native / Expo).

## Changes

### Commit `3bbebb88` — SQLite busy errors & stuck spinner

| File | Change |
|------|--------|
| `app/src/database/index.js` | Add `openDatabase()` helper that applies `PRAGMA busy_timeout = 5000` to every `app.db` connection, so concurrent writers wait instead of failing with `SQLITE_BUSY`. Set `busy_timeout` on the `SQLiteProvider` connection in `migrateDbIfNeeded` on every launch. |
| `app/src/database/sql.js` | Use `BEGIN IMMEDIATE` in `withTransaction` so the write lock is acquired where `busy_timeout` applies, avoiding WAL lock-upgrade busy failures. |
| `app/src/lib/background-task.js`, `app/src/components/LogoutButton.js`, `app/App.js` | Route all `useNewConnection` call sites (background tasks, inline submission task, logout) through the `openDatabase()` helper. |
| `app/src/database/crud/crud-forms.js` | Fix `getFormOptions` binding 3 params to a 2-placeholder query. |
| `app/src/pages/Submission.js` | Wrap `fetchData` in `try/catch/finally`: the loading state always clears, errors are reported to Sentry and shown as a toast instead of leaving the spinner stuck; drop the cosmetic 1s delay. |
| `app/src/build.prod.js`, `app/src/build.staging.js` | Build-config bumps. |

### Commit `3e271eca` — scrollable group list & stale required errors

| File | Change |
|------|--------|
| `app/src/form/support/QuestionGroupList.js` | Wrap the question group list in a `ScrollView` and adjust container padding. Add a schema-based required-question counter (X/Y) in the group-list header, validating each required field with the same Yup schema used at submit so the count reflects actual submittability. The counter is computed via a debounced, leak-safe effect (ignore flag + `clearTimeout`) to avoid revalidating the whole form on every keystroke. |
| `app/src/form/components/QuestionGroup.js` | Clear a stale "… is required" message as soon as a field is answered, by refreshing that field's feedback on change — only when an error is currently shown (avoids per-keystroke validation/re-render). |
| `app/src/form/styles.js` | Minor style adjustment for the scrollable layout. |

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1216278543459687