### PR TITLE
fix(mobile): inject APK server URL from APP_DOMAIN secret (#252)

### DIFF
--- a/.github/workflows/apk-release.yml
+++ b/.github/workflows/apk-release.yml
@@ -28,9 +28,13 @@ jobs:
           token: ${{ secrets.EXPO_TOKEN }}
 
       - name: 📦 Install dependencies
+        env:
+          APP_DOMAIN: ${{ secrets.APP_DOMAIN }}
         run: |
           cd ./app/
           cp ./src/build.testing.js ./src/build.js
+          sed -i "s|http://localhost:3000|https://${APP_DOMAIN}.akvotest.org|" ./src/build.js
+          sed -i "s|apkURL: ''|apkURL: 'https://${APP_DOMAIN}.akvotest.org/app'|" ./src/build.js
           npm install --legacy-peer-deps
 
       - name: 🚀 Release to Expo Dev


### PR DESCRIPTION
Fixes #252.

The APK build copies `build.testing.js` (hardcoded `localhost:3000`) over `build.js`, so production APKs point at localhost and fail login with "undefined: network".

This injects the real URL from the existing `APP_DOMAIN` secret via `sed` after the copy — `build.js` becomes `https://<domain>.akvotest.org/api/v1/device` (and `/app` for apkURL). Keeps the existing tracked-file mechanism (no `.env`, which is gitignored and not uploaded to EAS cloud builds).

Verified locally with `act`: `build.js` resolves to `https://mis.akvotest.org/api/v1/device`.