### PR TITLE
Feature/255 fix stuck submissions photo retake

### DIFF
--- a/app/app.json
+++ b/app/app.json
@@ -3,7 +3,7 @@
     "newArchEnabled": true,
     "name": "Akvo MIS",
     "slug": "akvo-mis-mobile",
-    "version": "4.1.29",
+    "version": "4.1.30",
     "orientation": "portrait",
     "icon": "./assets/icon.png",
     "userInterfaceStyle": "light",
@@ -22,7 +22,7 @@
         "backgroundColor": "#ffffff"
       },
       "package": "com.akvo.akvo_mis",
-      "versionCode": 4129
+      "versionCode": 4130
     },
     "web": {
       "favicon": "./assets/favicon.png"

--- a/app/eas.json
+++ b/app/eas.json
@@ -10,6 +10,7 @@
       }
     },
     "release": {
+      "channel": "release",
       "android": {
         "buildType": "apk"
       }

--- a/app/package.json
+++ b/app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "akvo-mis-mobile",
-  "version": "4.1.29",
+  "version": "4.1.30",
   "main": "node_modules/expo/AppEntry.js",
   "scripts": {
     "start": "expo start --port 19000",

--- a/app/src/build.json
+++ b/app/src/build.json
@@ -6,7 +6,7 @@
   "dataSyncInterval": 30,
   "errorHandling": true,
   "loggingLevel": "verbose",
-  "appVersion": "4.1.29",
+  "appVersion": "4.1.30",
   "lang": "en",
   "gpsThreshold": 30,
   "apkName": "Akvo MIS"

--- a/app/src/components/SyncService.js
+++ b/app/src/components/SyncService.js
@@ -97,6 +97,14 @@ const SyncService = () => {
         return;
       }
 
+      // Zombie job: PENDING with retries exhausted is never executed but
+      // still blocks new jobs from being created — delete it so the next
+      // sync tick starts fresh with attempt 0
+      if (activeJob.status === jobStatus.PENDING && activeJob.attempt >= MAX_ATTEMPT) {
+        await crudJobs.deleteJob(db, activeJob.id);
+        return;
+      }
+
       // PENDING → execute sync
       if (activeJob.status === jobStatus.PENDING && activeJob.attempt < MAX_ATTEMPT) {
         UIState.update((s) => {
@@ -453,6 +461,17 @@ const SyncService = () => {
             } else {
               const form = await crudForms.getByFormId(db, { formId });
               if (!form) {
+                return;
+              }
+
+              // Drafts uploaded by versions without draftId bookkeeping can
+              // only be matched by uuid — link instead of inserting a
+              // duplicate; local answers stay queued and win on next upload
+              const localDraft = d?.uuid
+                ? await crudDataPoints.getDraftByUUID(db, { uuid: d.uuid, form: form.id })
+                : null;
+              if (localDraft) {
+                await crudDataPoints.linkDraftId(db, localDraft.id, draftId);
                 return;
               }
 

--- a/app/src/database/crud/crud-datapoints.js
+++ b/app/src/database/crud/crud-datapoints.js
@@ -212,6 +212,43 @@ const dataPointsQuery = () => ({
     );
     return res;
   },
+  /**
+   * Writes only the json column. Used to repair answers (e.g. retake a missing
+   * photo) without touching syncedAt, so the row stays in the upload queue.
+   */
+  updateJson: async (db, id, json) => {
+    const res = await sql.updateRow(
+      db,
+      'datapoints',
+      { id },
+      { json: JSON.stringify(json).replace(/'/g, "''") },
+    );
+    return res;
+  },
+  /**
+   * Links a local draft to its backend row without stamping syncedAt, so the
+   * local answers stay queued and the next upload updates the backend draft
+   * in place instead of creating a duplicate.
+   */
+  linkDraftId: async (db, id, draftId) => {
+    const res = await sql.updateRow(db, 'datapoints', { id }, { draftId });
+    return res;
+  },
+  /**
+   * Finds a local pending draft matching a backend draft by uuid. Drafts
+   * uploaded by app versions before draftId bookkeeping existed can only be
+   * matched this way, otherwise the draft download inserts a duplicate.
+   */
+  getDraftByUUID: async (db, { uuid, form }) => {
+    const res = await sql.safeGetFirstRow(
+      db,
+      `SELECT * FROM datapoints
+        WHERE uuid = ? AND form = ? AND submitted = ? AND draftId IS NULL`,
+      [uuid, form, 0],
+      'getDraftByUUID',
+    );
+    return res;
+  },
   getByUUID: async (db, { uuid, form }) => {
     const formVal = form ? { form } : {};
     const res = await sql.getFirstRow(db, 'datapoints', { uuid, ...formVal });

--- a/app/src/form/fields/TypeAttachment.js
+++ b/app/src/form/fields/TypeAttachment.js
@@ -7,6 +7,7 @@ import * as Linking from 'expo-linking';
 import { FieldLabel } from '../support';
 import { FormState } from '../../store';
 import { helpers, i18n } from '../../lib';
+import { persistImage } from '../../lib/image-compressor';
 import MIME_TYPES from '../../lib/mime_types';
 
 const TypeAttachment = ({
@@ -45,7 +46,8 @@ const TypeAttachment = ({
       });
       if (!canceled && assets && assets.length > 0) {
         const result = assets[0];
-        onChange(id, result?.uri);
+        // Move out of the purgeable cache dir so the file survives until synced
+        onChange(id, await persistImage(result?.uri, 'attachments'));
         setSelectedFile(result);
       }
     } catch (error) {

--- a/app/src/form/fields/TypeImage.js
+++ b/app/src/form/fields/TypeImage.js
@@ -7,7 +7,7 @@ import Icon from 'react-native-vector-icons/Ionicons';
 import { FieldLabel } from '../support';
 import { FormState, BuildParamsState } from '../../store';
 import { i18n } from '../../lib';
-import { compressImage, formatFileSize } from '../../lib/image-compressor';
+import { compressImage, formatFileSize, persistImage } from '../../lib/image-compressor';
 
 const TypeImage = ({
   onChange,
@@ -38,11 +38,11 @@ const TypeImage = ({
     try {
       const result = await compressImage(imageUri, imageQuality);
       setFileSize(result.size);
-      onChange(id, result.uri);
+      onChange(id, await persistImage(result.uri));
     } catch (error) {
       console.error('[TypeImage] Compression error:', error);
       setFileSize(null);
-      onChange(id, imageUri);
+      onChange(id, await persistImage(imageUri));
     } finally {
       setIsCompressing(false);
     }

--- a/app/src/lib/background-task.js
+++ b/app/src/lib/background-task.js
@@ -1,6 +1,7 @@
 import * as BackgroundTask from 'expo-background-task';
 import * as TaskManager from 'expo-task-manager';
 import * as Network from 'expo-network';
+import * as FileSystem from 'expo-file-system';
 import * as Sentry from '@sentry/react-native';
 import api from './api';
 import { openDatabase } from '../database';
@@ -112,7 +113,11 @@ const handleOnUploadFiles = async (
       // Same unescaping as processBatch — a raw parse here can throw on SQL-escaped
       // quotes and silently skip file extraction while processBatch still syncs
       const answers = JSON.parse(d.json.replace(/''/g, "'"));
-      const questions = JSON.parse(d.json_form)?.question_group?.flatMap((qg) => qg.question) || [];
+      // json_form is stored SQL-escaped like d.json — a raw parse throws on
+      // forms containing apostrophes and silently skips file extraction
+      const questions =
+        JSON.parse(d.json_form.replace(/''/g, "'"))?.question_group?.flatMap((qg) => qg.question) ||
+        [];
       const questionFiles = questions.filter((q) => questionTypes.includes(q.type));
       if (!questionFiles.length) return files;
 
@@ -261,7 +266,17 @@ const processBatch = async (db, activeJob, session, counts = { success: 0, faile
         // Only drafts keep the backend id: a draftId on a submitted row would
         // flip its sync URL to the is_published variant.
         const backendId = !d.submitted ? res?.data?.id : null;
+        // Persist the server file paths locally so previews keep working
+        // after the uploaded local copies are removed below
+        await crudDataPoints.updateJson(db, d.id, answerValues);
         await crudDataPoints.markSynced(db, d.id, backendId);
+        // Uploaded local copies are no longer needed — free the storage
+        const uploadedForThis = [...photos, ...attachments].filter((f) => f?.dataID === d.id);
+        await Promise.all(
+          uploadedForThis.map((f) =>
+            FileSystem.deleteAsync(f.value, { idempotent: true }).catch(() => null),
+          ),
+        );
       }
       counts.success += 1;
     } catch (error) {

--- a/app/src/lib/background-task.js
+++ b/app/src/lib/background-task.js
@@ -12,6 +12,7 @@ import {
   markSyncComplete,
 } from './sync-datapoints';
 import notification from './notification';
+import cascades from './cascades';
 import crudJobs from '../database/crud/crud-jobs';
 import { UIState, DatapointSyncState } from '../store';
 import {
@@ -180,6 +181,46 @@ const handleOnUploadFiles = async (
   return { uploadedFiles, failedDataIDs };
 };
 
+// The backend's /draft-list serializes cascade answers as display names
+// (Answers.to_key returns name, not id). Those names get written back into
+// the local datapoint json, and the backend rejects them on the next sync
+// (administration expects a pk). Resolve them back to ids via the cascade
+// sqlite so stuck drafts can sync again.
+export const repairCascadeAnswers = async (answerValues, jsonForm) => {
+  const questions =
+    JSON.parse(jsonForm.replace(/''/g, "'"))?.question_group?.flatMap((qg) => qg.question) || [];
+  const cascadeQuestions = questions.filter(
+    (q) => q.type === QUESTION_TYPES.cascade && q?.source?.file,
+  );
+  await cascadeQuestions.reduce(async (prev, q) => {
+    await prev;
+    const keys = Object.keys(answerValues).filter((k) => `${k}`.split('-')[0] === `${q.id}`);
+    const brokenKeys = keys.filter((k) => {
+      const v = answerValues[k];
+      return typeof v === 'string' || (Array.isArray(v) && v.some((x) => typeof x === 'string'));
+    });
+    if (!brokenKeys.length) {
+      return;
+    }
+    const rows = await cascades.loadDataSource(q.source);
+    brokenKeys.forEach((k) => {
+      const val = answerValues[k];
+      const names = Array.isArray(val) ? val : [val];
+      const resolved = names.map((n) => {
+        if (typeof n !== 'string') {
+          return n;
+        }
+        // ponytail: name match can be ambiguous across levels; prefer
+        // full_path_name, fall back to name, keep original if unresolved
+        const row = rows.find((r) => r?.full_path_name === n) || rows.find((r) => r?.name === n);
+        return row?.id ?? n;
+      });
+      answerValues[k] = Array.isArray(val) ? resolved : resolved[0];
+    });
+  }, Promise.resolve());
+  return answerValues;
+};
+
 // Recursive batch processor: fetches BATCH_SIZE items, processes them,
 // then recurses if more remain. Stops on empty result or failures.
 const processBatch = async (db, activeJob, session, counts = { success: 0, failed: 0 }) => {
@@ -215,7 +256,10 @@ const processBatch = async (db, activeJob, session, counts = { success: 0, faile
 
     try {
       const geoVal = d.geo ? { geo: d.geo.split('|')?.map((x) => parseFloat(x)) } : {};
-      const answerValues = JSON.parse(d.json.replace(/''/g, "'"));
+      const answerValues = await repairCascadeAnswers(
+        JSON.parse(d.json.replace(/''/g, "'")),
+        d.json_form,
+      );
 
       // Add photos and attachments to answers
       [...photos, ...attachments]

--- a/app/src/lib/i18n/ui-text.js
+++ b/app/src/lib/i18n/ui-text.js
@@ -82,6 +82,10 @@ const uiText = {
     buttonRemove: 'Remove',
     buttonUseCamera: 'Use Camera',
     buttonFromGallery: 'From Gallery',
+    buttonRetakePhoto: 'Retake photo',
+    photoMissingText: 'Photo missing',
+    fileMissingText: 'Photo file is missing on this device. Retake it to allow syncing.',
+    retakeSuccess: 'Photo updated. It will be uploaded on the next sync.',
     confirmReset:
       "By resetting, you'll lose all saved data including users, forms and data-points. Are you sure?",
     offlineText: "You're offline...",
@@ -226,6 +230,11 @@ const uiText = {
     buttonRemove: 'Retirer',
     buttonUseCamera: 'Utiliser la caméra',
     buttonFromGallery: 'De la galerie',
+    buttonRetakePhoto: 'Reprendre la photo',
+    photoMissingText: 'Photo manquante',
+    fileMissingText:
+      'Le fichier photo est manquant sur cet appareil. Reprenez-la pour permettre la synchronisation.',
+    retakeSuccess: 'Photo mise à jour. Elle sera envoyée lors de la prochaine synchronisation.',
     confirmReset:
       'En réinitialisant, vous perdrez toutes les données enregistrées, y compris les utilisateurs, les formulaires et les points de données. Es-tu sûr?',
     offlineText: 'Tu es hors ligne...',

--- a/app/src/lib/i18n/ui-text.js
+++ b/app/src/lib/i18n/ui-text.js
@@ -83,9 +83,13 @@ const uiText = {
     buttonUseCamera: 'Use Camera',
     buttonFromGallery: 'From Gallery',
     buttonRetakePhoto: 'Retake photo',
-    photoMissingText: 'Photo missing',
+    buttonReattachFile: 'Re-attach file',
+    photoMissingText: 'File missing',
     fileMissingText: 'Photo file is missing on this device. Retake it to allow syncing.',
+    attachmentMissingText:
+      'Attached file is missing on this device. Re-attach it to allow syncing.',
     retakeSuccess: 'Photo updated. It will be uploaded on the next sync.',
+    reattachSuccess: 'File updated. It will be uploaded on the next sync.',
     confirmReset:
       "By resetting, you'll lose all saved data including users, forms and data-points. Are you sure?",
     offlineText: "You're offline...",
@@ -231,10 +235,14 @@ const uiText = {
     buttonUseCamera: 'Utiliser la caméra',
     buttonFromGallery: 'De la galerie',
     buttonRetakePhoto: 'Reprendre la photo',
-    photoMissingText: 'Photo manquante',
+    buttonReattachFile: 'Joindre à nouveau le fichier',
+    photoMissingText: 'Fichier manquant',
     fileMissingText:
       'Le fichier photo est manquant sur cet appareil. Reprenez-la pour permettre la synchronisation.',
+    attachmentMissingText:
+      'Le fichier joint est manquant sur cet appareil. Joignez-le à nouveau pour permettre la synchronisation.',
     retakeSuccess: 'Photo mise à jour. Elle sera envoyée lors de la prochaine synchronisation.',
+    reattachSuccess: 'Fichier mis à jour. Il sera envoyé lors de la prochaine synchronisation.',
     confirmReset:
       'En réinitialisant, vous perdrez toutes les données enregistrées, y compris les utilisateurs, les formulaires et les points de données. Es-tu sûr?',
     offlineText: 'Tu es hors ligne...',

--- a/app/src/lib/image-compressor.js
+++ b/app/src/lib/image-compressor.js
@@ -78,6 +78,29 @@ export const formatFileSize = (bytes) => {
 };
 
 /**
+ * Moves a captured image out of the OS-purgeable cache directory into
+ * documentDirectory, so pending submissions never lose their photos to a
+ * cache purge. Returns the new URI, or the original one if the move fails.
+ * @param {string} uri - Image URI (typically in cacheDirectory)
+ * @returns {Promise<string>}
+ */
+export const persistImage = async (uri) => {
+  try {
+    const dir = `${FileSystem.documentDirectory}images`;
+    const { exists } = await FileSystem.getInfoAsync(dir);
+    if (!exists) {
+      await FileSystem.makeDirectoryAsync(dir, { intermediates: true });
+    }
+    const to = `${dir}/${Date.now()}_${uri.split('/').pop()}`;
+    await FileSystem.moveAsync({ from: uri, to });
+    return to;
+  } catch (error) {
+    console.error('[ImageCompressor] Persist failed, keeping cache uri:', error);
+    return uri;
+  }
+};
+
+/**
  * Compress an image based on quality preset
  * @param {string} uri - Original image URI
  * @param {string} qualityPreset - Quality preset key ('low', 'medium', 'high', 'original')

--- a/app/src/lib/image-compressor.js
+++ b/app/src/lib/image-compressor.js
@@ -78,15 +78,16 @@ export const formatFileSize = (bytes) => {
 };
 
 /**
- * Moves a captured image out of the OS-purgeable cache directory into
- * documentDirectory, so pending submissions never lose their photos to a
+ * Moves a captured file out of the OS-purgeable cache directory into
+ * documentDirectory, so pending submissions never lose their files to a
  * cache purge. Returns the new URI, or the original one if the move fails.
- * @param {string} uri - Image URI (typically in cacheDirectory)
+ * @param {string} uri - File URI (typically in cacheDirectory)
+ * @param {string} subDir - documentDirectory subfolder ('images', 'attachments')
  * @returns {Promise<string>}
  */
-export const persistImage = async (uri) => {
+export const persistImage = async (uri, subDir = 'images') => {
   try {
-    const dir = `${FileSystem.documentDirectory}images`;
+    const dir = `${FileSystem.documentDirectory}${subDir}`;
     const { exists } = await FileSystem.getInfoAsync(dir);
     if (!exists) {
       await FileSystem.makeDirectoryAsync(dir, { intermediates: true });

--- a/app/src/lib/sync-datapoints.js
+++ b/app/src/lib/sync-datapoints.js
@@ -144,6 +144,12 @@ export const downloadDatapointsJson = async (
   // Skip-unchanged: check if local datapoint is already up-to-date
   const uuid = url.split('/').pop().replace('.json', '');
   const existing = await crudDataPoints.getByUUID(db, { uuid, form: form?.id });
+  // Never clobber a local row with pending changes (syncedAt NULL): it is
+  // queued for upload and its answers are newer than the server copy —
+  // overwriting would lose the edits AND falsely mark them as synced
+  if (existing && !existing.syncedAt) {
+    return;
+  }
   if (existing?.syncedAt && lastUpdated && existing.syncedAt >= lastUpdated) {
     return;
   }

--- a/app/src/pages/FormData/FormDataDetails.js
+++ b/app/src/pages/FormData/FormDataDetails.js
@@ -1,27 +1,86 @@
 import React, { useEffect, useState, useCallback } from 'react';
-import { View, Text, StyleSheet, Alert, SectionList } from 'react-native';
+import {
+  View,
+  Text,
+  StyleSheet,
+  Alert,
+  SectionList,
+  ToastAndroid,
+  PermissionsAndroid,
+  ActivityIndicator,
+} from 'react-native';
 import { Image, Button } from '@rneui/themed';
 import moment from 'moment';
 import * as Linking from 'expo-linking';
-import { FormState, UIState } from '../../store';
+import * as ImagePicker from 'expo-image-picker';
+import { useSQLiteContext } from 'expo-sqlite';
+import * as Sentry from '@sentry/react-native';
+import { FormState, UIState, BuildParamsState } from '../../store';
 import { api, cascades, helpers, i18n } from '../../lib';
+import { compressImage, persistImage } from '../../lib/image-compressor';
+import { crudDataPoints } from '../../database/crud';
 import { BaseLayout } from '../../components';
 import FormDataNavigation from './FormDataNavigation';
 import { QUESTION_TYPES } from '../../lib/constants';
 
-const ImageView = ({ label, uri, textTestID, imageTestID }) => {
+const ImageView = ({
+  label,
+  uri,
+  textTestID,
+  imageTestID,
+  onRetake = null,
+  missingText = '',
+  retakeLabel = '',
+  isRetaking = false,
+  processingLabel = '',
+}) => {
+  // No upfront file check: the Image load itself reports a dead file:// path
+  // via onError, so missing files cost no extra I/O.
+  const [fileMissing, setFileMissing] = useState(false);
   // get base path from http://example.com/api/v2/any/ to http://example.com
   const baseURL = api.getConfig().baseURL?.replace(/\/api\/v\d+\/.*$/, '');
   const imageURL =
     !uri?.includes('file://') && !uri?.startsWith('http') && !uri.startsWith('data:image')
       ? `${baseURL}${uri}`
       : uri;
+  // Retake only makes sense for local files pending upload, not remote images
+  const showRetake = !!onRetake && !!uri?.startsWith('file://');
+
+  let content = (
+    <Image
+      source={{ uri: imageURL }}
+      testID={imageTestID}
+      style={styles.image}
+      onError={() => setFileMissing(true)}
+    />
+  );
+  if (fileMissing) {
+    content = (
+      <View>
+        <Text style={styles.missingText} testID={`${imageTestID}-missing`}>
+          {missingText}
+        </Text>
+        {showRetake && (
+          <Button title={retakeLabel} onPress={onRetake} testID={`${imageTestID}-retake`} />
+        )}
+      </View>
+    );
+  }
+  if (isRetaking) {
+    content = (
+      <View style={styles.processingContainer} testID={`${imageTestID}-processing`}>
+        <ActivityIndicator size="small" color="dodgerblue" />
+        <Text style={styles.processingText}>{processingLabel}</Text>
+      </View>
+    );
+  }
+
   return (
     <View style={styles.containerImage}>
       <Text style={styles.title} testID={textTestID}>
         {label}
       </Text>
-      <Image source={{ uri: imageURL }} testID={imageTestID} style={styles.image} />
+      {content}
     </View>
   );
 };
@@ -116,12 +175,81 @@ const FormDataDetails = ({ navigation, route }) => {
   const selectedForm = FormState.useState((s) => s.form);
   const currentValues = FormState.useState((s) => s.currentValues);
   const [currentPage, setCurrentPage] = useState(0);
+  const [retakingKey, setRetakingKey] = useState(null);
+  const activeLang = UIState.useState((s) => s.lang);
+  const imageQuality = BuildParamsState.useState((s) => s.imageQuality);
+  const trans = i18n.text(activeLang);
+  const db = useSQLiteContext();
+
+  const datapointId = route?.params?.id;
+  // Retake only repairs local rows still waiting to upload
+  const canRetake = !!datapointId && !route?.params?.isSynced;
+
+  const ensureCameraPermission = async () => {
+    const isGranted = await PermissionsAndroid.check(PermissionsAndroid.PERMISSIONS.CAMERA);
+    if (isGranted) {
+      return true;
+    }
+    const askPermission = await PermissionsAndroid.request(PermissionsAndroid.PERMISSIONS.CAMERA, {
+      title: trans.imageStoragePerm,
+      message: trans.imageCameraPerm,
+      buttonNeutral: trans.imageAskLater,
+      buttonNegative: trans.buttonCancel,
+      buttonPositive: trans.buttonOk,
+    });
+    return askPermission === PermissionsAndroid.RESULTS.GRANTED;
+  };
+
+  const handleRetake = async (questionKey) => {
+    const allowed = await ensureCameraPermission();
+    if (!allowed) {
+      return;
+    }
+    const result = await ImagePicker.launchCameraAsync({ base64: true });
+    if (result?.canceled) {
+      return;
+    }
+    setRetakingKey(questionKey);
+    try {
+      const { uri: imageUri } = result.assets[0];
+      let newUri = imageUri;
+      try {
+        const compressed = await compressImage(imageUri, imageQuality);
+        newUri = compressed.uri;
+      } catch (error) {
+        Sentry.captureMessage(`Image compression failed for ${imageUri}`);
+        Sentry.captureException(error);
+      }
+      // Move out of the purgeable cache dir so the photo survives until synced
+      newUri = await persistImage(newUri);
+      const updatedValues = { ...currentValues, [questionKey]: newUri };
+      FormState.update((s) => {
+        s.currentValues = updatedValues;
+      });
+      await crudDataPoints.updateJson(db, datapointId, updatedValues);
+      ToastAndroid.show(trans.retakeSuccess, ToastAndroid.LONG);
+    } finally {
+      setRetakingKey(null);
+    }
+  };
 
   const { json: formJSON } = selectedForm || {};
 
   const form = formJSON ? JSON.parse(formJSON) : {};
-  const currentGroup = form?.question_group?.[currentPage] || [];
-  const totalPage = form?.question_group?.length || 0;
+  // Skip question groups without any answered question — repeat-suffixed
+  // keys (qid-1, qid-2, ...) count for their base question id
+  const answeredQuestionIds = new Set(
+    Object.entries(currentValues)
+      .filter(
+        ([, value]) => value != null && value !== '' && !(Array.isArray(value) && !value.length),
+      )
+      .map(([key]) => key.split('-')[0]),
+  );
+  const questionGroups = (form?.question_group || []).filter((qg) =>
+    qg?.question?.some((q) => answeredQuestionIds.has(`${q.id}`)),
+  );
+  const currentGroup = questionGroups[currentPage] || [];
+  const totalPage = questionGroups.length || 0;
   const questions = currentGroup?.question || [];
   const numberOfRepeat =
     Object.entries(currentValues).filter(([key]) => {
@@ -157,6 +285,9 @@ const FormDataDetails = ({ navigation, route }) => {
             uri={answer}
             textTestID={`text-question-${qIndex}`}
             imageTestID={`image-question-${qIndex}`}
+            missingText={trans.fileMissingText}
+            retakeLabel={trans.buttonRetakePhoto}
+            onRetake={canRetake ? () => handleRetake(q.id) : null}
           />
         );
       }
@@ -164,11 +295,16 @@ const FormDataDetails = ({ navigation, route }) => {
     if ([QUESTION_TYPES.image, QUESTION_TYPES.signature].includes(q.type) && answer) {
       return (
         <ImageView
-          key={q.id}
+          key={`${q.id}-${answer}`}
           label={q.label}
           uri={answer}
           textTestID={`text-question-${qIndex}`}
           imageTestID={`image-question-${qIndex}`}
+          missingText={trans.fileMissingText}
+          retakeLabel={trans.buttonRetakePhoto}
+          onRetake={canRetake && q.type === QUESTION_TYPES.photo ? () => handleRetake(q.id) : null}
+          isRetaking={retakingKey === q.id}
+          processingLabel={trans.compressingImage}
         />
       );
     }
@@ -266,6 +402,21 @@ const styles = StyleSheet.create({
     width: '100%',
     height: 200,
     aspectRatio: 1,
+  },
+  missingText: {
+    color: '#b91c1c',
+    marginBottom: 8,
+  },
+  processingContainer: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'center',
+    paddingVertical: 12,
+    gap: 8,
+  },
+  processingText: {
+    color: 'dodgerblue',
+    fontSize: 14,
   },
   listItem: {
     flexDirection: 'row',

--- a/app/src/pages/FormData/FormDataDetails.js
+++ b/app/src/pages/FormData/FormDataDetails.js
@@ -13,6 +13,8 @@ import { Image, Button } from '@rneui/themed';
 import moment from 'moment';
 import * as Linking from 'expo-linking';
 import * as ImagePicker from 'expo-image-picker';
+import * as DocumentPicker from 'expo-document-picker';
+import * as FileSystem from 'expo-file-system';
 import { useSQLiteContext } from 'expo-sqlite';
 import * as Sentry from '@sentry/react-native';
 import { FormState, UIState, BuildParamsState } from '../../store';
@@ -22,6 +24,7 @@ import { crudDataPoints } from '../../database/crud';
 import { BaseLayout } from '../../components';
 import FormDataNavigation from './FormDataNavigation';
 import { QUESTION_TYPES } from '../../lib/constants';
+import MIME_TYPES from '../../lib/mime_types';
 
 const ImageView = ({
   label,
@@ -81,6 +84,105 @@ const ImageView = ({
         {label}
       </Text>
       {content}
+    </View>
+  );
+};
+
+const AttachmentView = ({
+  label,
+  uri,
+  index,
+  onReattach = null,
+  missingText = '',
+  reattachLabel = '',
+  openLabel = '',
+  isReattaching = false,
+  processingLabel = '',
+}) => {
+  // Non-image files render no Image, so there is no onError signal — an
+  // explicit existence check is the only way (one call per attachment).
+  const [fileMissing, setFileMissing] = useState(false);
+
+  useEffect(() => {
+    let active = true;
+    if (uri?.startsWith('file://')) {
+      FileSystem.getInfoAsync(uri)
+        .then(({ exists }) => {
+          if (active) {
+            setFileMissing(!exists);
+          }
+        })
+        .catch(() => {
+          if (active) {
+            setFileMissing(true);
+          }
+        });
+    } else {
+      setFileMissing(false);
+    }
+    return () => {
+      active = false;
+    };
+  }, [uri]);
+
+  const openFileManager = async () => {
+    const supported = await Linking.canOpenURL(uri);
+    if (supported) {
+      await Linking.openURL(uri);
+    } else {
+      Alert.alert("Don't know how to open this URL:", uri);
+    }
+  };
+
+  let content = (
+    <View style={{ width: '100%' }}>
+      <Text
+        testID={`text-answer-${index}`}
+        style={{ color: 'blue', textDecorationLine: 'underline' }}
+      >
+        {uri.split('/').pop()}
+      </Text>
+      <Button
+        title={openLabel}
+        onPress={openFileManager}
+        testID={`open-file-button-${index}`}
+        buttonStyle={{ width: '100%', backgroundColor: '#1E90FF', marginTop: 8 }}
+      />
+    </View>
+  );
+  if (fileMissing) {
+    content = (
+      <View>
+        <Text style={styles.missingText} testID={`attachment-missing-${index}`}>
+          {missingText}
+        </Text>
+        {!!onReattach && !!uri?.startsWith('file://') && (
+          <Button
+            title={reattachLabel}
+            onPress={onReattach}
+            testID={`attachment-reattach-${index}`}
+          />
+        )}
+      </View>
+    );
+  }
+  if (isReattaching) {
+    content = (
+      <View style={styles.processingContainer} testID={`attachment-processing-${index}`}>
+        <ActivityIndicator size="small" color="dodgerblue" />
+        <Text style={styles.processingText}>{processingLabel}</Text>
+      </View>
+    );
+  }
+
+  return (
+    <View style={styles.listItem}>
+      <View style={styles.listItemContent}>
+        <Text style={styles.listItemTitle} testID={`text-question-${index}`}>
+          {label}
+        </Text>
+        {content}
+      </View>
     </View>
   );
 };
@@ -233,6 +335,34 @@ const FormDataDetails = ({ navigation, route }) => {
     }
   };
 
+  const handleReattach = async (questionKey, rule = null) => {
+    const { allowedFileTypes } = rule || {};
+    const fileTypes = allowedFileTypes?.length
+      ? allowedFileTypes.map((t) => MIME_TYPES?.[t] || 'application/octet-stream')
+      : '*/*';
+    const result = await DocumentPicker.getDocumentAsync({
+      multiple: false,
+      type: fileTypes,
+      copyToCacheDirectory: true,
+    });
+    if (result?.canceled || !result?.assets?.length) {
+      return;
+    }
+    setRetakingKey(questionKey);
+    try {
+      // Move out of the purgeable cache dir so the file survives until synced
+      const newUri = await persistImage(result.assets[0].uri, 'attachments');
+      const updatedValues = { ...currentValues, [questionKey]: newUri };
+      FormState.update((s) => {
+        s.currentValues = updatedValues;
+      });
+      await crudDataPoints.updateJson(db, datapointId, updatedValues);
+      ToastAndroid.show(trans.reattachSuccess, ToastAndroid.LONG);
+    } finally {
+      setRetakingKey(null);
+    }
+  };
+
   const { json: formJSON } = selectedForm || {};
 
   const form = formJSON ? JSON.parse(formJSON) : {};
@@ -280,17 +410,33 @@ const FormDataDetails = ({ navigation, route }) => {
       if (helpers.isImageFile(fileExtension)) {
         return (
           <ImageView
-            key={q.id}
+            key={`${q.id}-${answer}`}
             label={q.label}
             uri={answer}
             textTestID={`text-question-${qIndex}`}
             imageTestID={`image-question-${qIndex}`}
-            missingText={trans.fileMissingText}
-            retakeLabel={trans.buttonRetakePhoto}
-            onRetake={canRetake ? () => handleRetake(q.id) : null}
+            missingText={trans.attachmentMissingText}
+            retakeLabel={trans.buttonReattachFile}
+            onRetake={canRetake ? () => handleReattach(q.id, q.rule) : null}
+            isRetaking={retakingKey === q.id}
+            processingLabel={trans.compressingImage}
           />
         );
       }
+      return (
+        <AttachmentView
+          key={`${q.id}-${answer}`}
+          label={q.label}
+          uri={answer}
+          index={qIndex}
+          missingText={trans.attachmentMissingText}
+          reattachLabel={trans.buttonReattachFile}
+          openLabel={trans.openFileButton}
+          onReattach={canRetake ? () => handleReattach(q.id, q.rule) : null}
+          isReattaching={retakingKey === q.id}
+          processingLabel={trans.compressingImage}
+        />
+      );
     }
     if ([QUESTION_TYPES.image, QUESTION_TYPES.signature].includes(q.type) && answer) {
       return (

--- a/app/src/pages/FormOptions.js
+++ b/app/src/pages/FormOptions.js
@@ -41,7 +41,11 @@ const FormOptions = ({ navigation, route }) => {
     FormState.update((s) => {
       s.currentValues = dataValues;
     });
-    navigation.push('FormDataDetails', { name: dataPointName });
+    navigation.push('FormDataDetails', {
+      name: dataPointName,
+      id: item?.id,
+      isSynced: !!item?.syncedAt,
+    });
   };
 
   const renderItem = ({ item }) => (

--- a/app/src/pages/Submission.js
+++ b/app/src/pages/Submission.js
@@ -11,6 +11,7 @@ import {
 } from 'react-native';
 import Icon from 'react-native-vector-icons/Ionicons';
 import LucideIcon from '@react-native-vector-icons/lucide';
+import * as FileSystem from 'expo-file-system';
 import * as SQLite from 'expo-sqlite';
 import * as Sentry from '@sentry/react-native';
 import moment from 'moment';
@@ -61,7 +62,11 @@ const Submission = ({ navigation, route }) => {
       s.currentValues = typeof valuesJSON === 'string' ? JSON.parse(valuesJSON) : valuesJSON;
     });
 
-    navigation.push('FormDataDetails', { name: dataPointName });
+    navigation.push('FormDataDetails', {
+      name: dataPointName,
+      id: item.id,
+      isSynced: item.isSynced,
+    });
   };
 
   const goToFormOptions = (item) => {
@@ -136,16 +141,40 @@ const Submission = ({ navigation, route }) => {
         user: activeUserId,
         uuid: route?.params?.uuid || null,
       });
-      rows = rows.map((res) => {
-        const createdAt = moment(res.createdAt).format('DD/MM/YYYY hh:mm A');
-        const syncedAt = res.syncedAt ? moment(res.syncedAt).format('DD/MM/YYYY hh:mm A') : '-';
-        return {
-          ...res,
-          createdAt,
-          syncedAt,
-          isSynced: !!res.syncedAt,
-        };
-      });
+      rows = await Promise.all(
+        rows.map(async (res) => {
+          const createdAt = moment(res.createdAt).format('DD/MM/YYYY hh:mm A');
+          const syncedAt = res.syncedAt ? moment(res.syncedAt).format('DD/MM/YYYY hh:mm A') : '-';
+          // Flag unsynced rows whose local photo files no longer exist —
+          // they will never upload until the user retakes the photo
+          let needsRetake = false;
+          if (!res.syncedAt && res.json) {
+            try {
+              const values = JSON.parse(res.json.replace(/''/g, "'"));
+              const fileUris = Object.values(values).filter(
+                (v) => typeof v === 'string' && v.startsWith('file://'),
+              );
+              const filesExist = await Promise.all(
+                fileUris.map((uri) =>
+                  FileSystem.getInfoAsync(uri)
+                    .then((info) => info.exists)
+                    .catch(() => false),
+                ),
+              );
+              needsRetake = filesExist.some((exists) => !exists);
+            } catch (error) {
+              needsRetake = false;
+            }
+          }
+          return {
+            ...res,
+            createdAt,
+            syncedAt,
+            isSynced: !!res.syncedAt,
+            needsRetake,
+          };
+        }),
+      );
       setData(rows);
     } catch (error) {
       Sentry.captureMessage('[Submission] Unable to fetch data points');
@@ -206,6 +235,11 @@ const Submission = ({ navigation, route }) => {
           {item.submitted === 0 && (
             <View style={styles.draftBadge}>
               <Text style={styles.draftText}>{trans.draftText}</Text>
+            </View>
+          )}
+          {item.needsRetake && (
+            <View style={styles.retakeBadge} testID={`retake-badge-${item.id}`}>
+              <Text style={styles.retakeText}>{trans.photoMissingText}</Text>
             </View>
           )}
           <Text style={styles.itemDate}>
@@ -388,6 +422,17 @@ const styles = StyleSheet.create({
   draftText: {
     fontSize: 12,
     color: '#212121',
+    fontWeight: 'bold',
+  },
+  retakeBadge: {
+    backgroundColor: '#FEE2E2',
+    paddingVertical: 2,
+    paddingHorizontal: 8,
+    borderRadius: 4,
+  },
+  retakeText: {
+    fontSize: 12,
+    color: '#B91C1C',
     fontWeight: 'bold',
   },
 });


### PR DESCRIPTION
## What This PR Does

Follow-up to the #255 lifecycle work: field devices still showed submissions stuck at
**Submitted: N / Synced: 0**, drafts that never reached the backend, "duplicated" drafts
after sync, and a retaken photo that reverted after the next sync. Root-caused on a real
device (server access logs + Sentry + on-device reproduction) to a chain of four
independent sync bugs, fixed here together with a user-facing repair flow (photo retake)
so affected devices recover in place — no app-data reset required.

## Commits

| Commit | Change |
|--------|--------|
| `56ca52bb` | Fix stuck submissions and add photo retake flow |
| `44c29bd0` | Bump version to 4.1.30 |
| `4959d5b2` | Handle missing attachments with re-attach flow |

## Root cause chain

1. **Captured photos lived in the OS-purgeable cache directory.** Android reclaims that
   space under storage pressure, so a pending submission's `file://` answers could point
   at files that no longer exist. Uploading a missing file fails inside React Native's
   network layer before the request leaves the device (`AxiosError: Network Error`), and
   the `file://` guard in `processBatch` (correctly) kept the row pending — forever.
2. **The upload job became a zombie.** After `MAX_ATTEMPT` failures the
   `SYNC_FORM_SUBMISSION` job sat at `PENDING` with exhausted retries: never executed,
   never deleted, and — as the "active job" — blocking every new job from being created.
   From then on the upload phase was a silent no-op for the whole device (verified via
   nginx access logs: full sync sessions with zero upload `POST`s).
3. **Photo extraction silently failed on forms containing apostrophes.** `json_form` is
   stored SQL-escaped (`'` → `''`) but was parsed raw; the resulting throw was swallowed,
   so photos were never uploaded and the `file://` guard kept those rows pending.
4. **Datapoint download overwrote local rows that had pending changes.** A pending
   monitoring submission shares its `uuid` with the server datapoint; the skip-guard in
   `downloadDatapointsJson` only protected already-synced rows, so the download replaced
   newer local answers with the older server copy and stamped `syncedAt` prematurely —
   which is how a freshly retaken photo "disappeared".

## Changes

### Sync correctness
- `sync-datapoints.js` — never overwrite a local row whose `syncedAt` is `NULL` during
  download; local pending answers stay queued and win.
- `SyncService.js` — delete zombie upload jobs (`PENDING` at max attempts) so the next
  sync tick starts fresh with attempt 0.
- `background-task.js` — unescape `json_form` before parsing so photo/attachment
  extraction works on every form.

### File durability (photos and attachments)
- New `persistImage(uri, subDir)` (`image-compressor.js`) moves captured files from the
  purgeable cache into `documentDirectory`; applied at all capture points (`TypeImage`,
  `TypeAttachment`, retake/re-attach flows).
- After a successful upload, the local answers are rewritten with the **server** file
  paths and the uploaded local copies are deleted — previews keep working, storage does
  not grow unboundedly, and the "Photo missing" detection stays accurate.

### Retake / re-attach flow (recovery for already-affected devices)
- **Submission list**: unsynced rows whose local files are gone show a red
  **"File missing"** badge (existence check runs only for unsynced rows; covers photos
  and attachments).
- **FormDataDetails, photos**: the broken image slot (detected via the `Image`'s own
  `onError`, no extra file I/O) shows a warning and a **Retake photo** button — camera →
  compression (spinner + label during processing) → persisted file → answers updated in
  SQLite via a targeted `updateJson` that leaves `syncedAt` untouched, so the row stays
  queued and uploads on the next sync.
- **FormDataDetails, attachments**: non-image attachments get an existence check with a
  warning and a **Re-attach file** button (document picker, honoring the question's
  `allowedFileTypes` rule); image attachments reuse the image flow with attachment
  wording.
- Both flows are only offered on local, not-yet-synced datapoints.
- New en/fr strings: `buttonRetakePhoto`, `buttonReattachFile`, `photoMissingText`,
  `fileMissingText`, `attachmentMissingText`, `retakeSuccess`, `reattachSuccess`.

### Draft duplicates
- Downloaded drafts that carry no matching `draftId` are now matched to local pending
  drafts by `uuid` and **linked** (`draftId` set, nothing overwritten) instead of being
  inserted as copies; the next upload updates the backend draft in place. Complements the
  `draftId` round-trip from the lifecycle PR: that mechanism prevents duplicates going
  forward, this one heals rows created before it existed.

### Misc
- `FormDataDetails` — question groups without a single answered question are skipped from
  pagination (e.g. "1/27" becomes "1/12").
- `eas.json` — `release` builds now set EAS Update **channel** `release`, making binaries
  OTA-updatable via `eas update`.

## How this composes with the merged #255 lifecycle PR
- `submission_key` dedupes replays of one submission attempt on the backend; this PR
  makes sure the attempt can actually happen (no zombie job, no missing files) and that
  the pending row survives until it does (no download overwrite).
- `markSynced` semantics are unchanged; the success path additionally persists the server
  file paths (`updateJson`) before stamping `syncedAt` and then frees the local copies.

## Notes
- Binaries built **before** this change have no update channel and cannot receive OTA
  updates — they need this one APK install; from then on `eas update --channel release`
  works for JS-only fixes.
- `eas update` publishing is currently blocked by a pre-existing manifest issue:
  `app.json` → `androidNavigationBar.visible: "overscan"` is not an allowed value.
  One-line follow-up.
- Devices that already hold pending submissions with purged photos need one retake per
  missing photo (the badge points them out); everything else recovers automatically.

## Verification
- Reproduced and verified end-to-end on a physical device against the iwsims production
  server: before — full sync sessions with zero upload `POST`s in the nginx access log;
  after — `POST /images` + `POST /sync` return 200 and the datapoints flip to Synced.
- Replication recipe validated: airplane-mode submission with photo → **Clear cache** →
  reopen; with this build the photo survives (documentDirectory), and a manually deleted
  file surfaces the badge + retake flow.