### PR TITLE
[#262] Allow empty answers when syncing draft submissions

### DIFF
--- a/backend/api/v1/v1_mobile/serializers.py
+++ b/backend/api/v1/v1_mobile/serializers.py
@@ -260,16 +260,11 @@ class SyncDeviceFormDataSerializer(serializers.Serializer):
             "nothing and still returns 200."
         ),
     )
-    answers = serializers.DictField()
+    answers = serializers.DictField(required=False, default=dict)
 
     def __init__(self, **kwargs):
         super().__init__(**kwargs)
         self.fields.get("formId").queryset = Forms.objects.all()
-
-    def validate(self, attrs):
-        if not attrs.get("answers"):
-            raise serializers.ValidationError("Answers cannot be empty.")
-        return attrs
 
     class Meta:
         fields = [

--- a/backend/api/v1/v1_mobile/tests/tests_api_sync_draft_data.py
+++ b/backend/api/v1/v1_mobile/tests/tests_api_sync_draft_data.py
@@ -66,6 +66,64 @@ class MobileAssignmentApiSyncNewDraftTest(
         self.mobile_assignment.forms.add(self.form)
         self.mobile_token = self.get_assignment_token(passcode)
 
+    def test_sync_new_draft_with_empty_answers(self):
+        """
+        Test creating a new draft with empty answers (blank form exit).
+        This scenario happens when user opens a form and exits without
+        entering any data.
+        """
+        payload = {
+            "formId": self.form.id,
+            "name": "Blank Draft",
+            "duration": 0,
+            "submittedAt": "2021-01-01T00:00:00.000Z",
+            "geo": self.geo,
+            "uuid": "blank-draft-uuid-1234",
+            "answers": {},
+        }
+
+        response = self.client.post(
+            "/api/v1/device/sync?is_draft=true",
+            payload,
+            content_type="application/json",
+            **{"HTTP_AUTHORIZATION": f"Bearer {self.mobile_token}"},
+        )
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        data = response.json()
+
+        draft = FormData.objects_draft.filter(
+            uuid="blank-draft-uuid-1234"
+        ).first()
+        self.assertIsNotNone(draft)
+        self.assertEqual(draft.name, "Blank Draft")
+        self.assertEqual(draft.data_answer.count(), 0)
+        self.assertEqual(data, {"message": "ok", "id": draft.id})
+
+    def test_sync_submission_with_empty_answers_returns_400(self):
+        """
+        Test that non-draft submissions with empty answers return 400.
+        Empty answers should only be allowed for drafts.
+        """
+        payload = {
+            "formId": self.form.id,
+            "name": "Empty Submission",
+            "duration": 0,
+            "submittedAt": "2021-01-01T00:00:00.000Z",
+            "geo": self.geo,
+            "uuid": "empty-submission-uuid",
+            "answers": {},
+        }
+
+        response = self.client.post(
+            "/api/v1/device/sync",
+            payload,
+            content_type="application/json",
+            **{"HTTP_AUTHORIZATION": f"Bearer {self.mobile_token}"},
+        )
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        data = response.json()
+        self.assertEqual(data["message"], "Answers is required.")
+
     def test_sync_new_draft(self):
         """
         Test creating a new draft submission.

--- a/backend/api/v1/v1_mobile/views.py
+++ b/backend/api/v1/v1_mobile/views.py
@@ -204,13 +204,16 @@ def sync_pending_form_data(request, version):
             # If user has a role with data access, use that administration
             administration = user_role.administration
 
-    if not request.data.get("answers"):
+    is_draft = request.GET.get("is_draft", False)
+    is_draft = True if is_draft in ["true", "True", "1"] else False
+    # Allow empty answers for drafts only
+    if not request.data.get("answers") and not is_draft:
         return Response(
             {"message": "Answers is required."},
             status=status.HTTP_400_BAD_REQUEST,
         )
     answers = []
-    qna = request.data.get("answers")
+    qna = request.data.get("answers") or {}
     adm_id = administration.id
     adm_qs = Questions.objects.filter(
         type=QuestionTypes.cascade, form_id=form.id
@@ -253,8 +256,6 @@ def sync_pending_form_data(request, version):
         "data": payload,
         "answer": answers,
     }
-    is_draft = request.GET.get("is_draft", False)
-    is_draft = True if is_draft in ["true", "True", "1"] else False
     serializer = SubmitPendingFormSerializer(
         data=data,
         context={

--- a/backend/api/v1/v1_mobile/views.py
+++ b/backend/api/v1/v1_mobile/views.py
@@ -204,8 +204,7 @@ def sync_pending_form_data(request, version):
             # If user has a role with data access, use that administration
             administration = user_role.administration
 
-    is_draft = request.GET.get("is_draft", False)
-    is_draft = True if is_draft in ["true", "True", "1"] else False
+    is_draft = params.validated_data["is_draft"]
     # Allow empty answers for drafts only
     if not request.data.get("answers") and not is_draft:
         return Response(


### PR DESCRIPTION
## Summary

- Allow mobile app to sync drafts with empty answers (blank form exit scenario)
- Move `is_draft` parameter parsing earlier in the sync endpoint
- Only enforce "answers required" validation for non-draft submissions
- Backend-only fix - no mobile app update required

Fixes #262

## Test plan

- [x] Run existing draft sync tests: `python manage.py test api.v1.v1_mobile.tests.tests_api_sync_draft_data`
- [x] New test: `test_sync_new_draft_with_empty_answers` - verifies blank drafts are accepted
- [x] New test: `test_sync_submission_with_empty_answers_returns_400` - verifies non-draft submissions still require answers
- [ ] Manual test: Open form in mobile app, exit without entering data, verify sync succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)