### PR TITLE
[#265] Port the client's seeder forms into the product

### DIFF
--- a/backend/api/v1/v1_forms/functions.py
+++ b/backend/api/v1/v1_forms/functions.py
@@ -1529,10 +1529,13 @@ def _apply_import_update_path(
     """Update an existing form's live structure to match the normalized def.
 
     Semantics identical to restore_from_snapshot:
-    - Pass 1: soft-delete groups/questions absent from the file.
+    - Pass 1: soft-delete groups/questions absent from the file. With
+      never_delete=True this pass is answer-aware: a stale question that
+      carries answers is kept, and so is a stale group that still holds
+      such a question. Everything else is still pruned.
     - Pass 2: upsert by exported id; create new rows for unknown ids.
     - Options are recreated wholesale.
-    - status and active_version are NOT touched (D-6).
+    - status and active_version are NOT touched.
 
     With claim_foreign_questions=True (seeder/CLI only), file question ids
     are matched globally and rows currently attached to another form are
@@ -1564,13 +1567,33 @@ def _apply_import_update_path(
         # and pruning it is what frees the (form, name) slot that
         # unique_active_form_question requires before a cross-form move can
         # claim that name. Protecting those too would make moves impossible.
+        #
+        # The flip side: moving a question into a form that already holds a
+        # live, ANSWERED question of the same name raises IntegrityError on
+        # unique_active_form_question, because the incumbent cannot be
+        # pruned to free the slot. That is deliberate. The whole import runs
+        # inside transaction.atomic(), so the run fails loudly and rolls
+        # back; the only alternative would be to silently delete answered
+        # structure — and the submissions hanging off it — to make room.
+        #
+        # Only questions the file has ACTUALLY dropped may protect a group.
+        # A question the file still declares is about to be (re)written by
+        # pass 2, possibly into a different, still-declared group. Counting
+        # it here would keep its former group alive as a permanently empty
+        # phantom that /form/web/{id}, the mobile SQLite export and
+        # _build_schema_snapshot all still serve.
         answered_q_ids = Answers.objects.filter(
             question__form=form
+        ).exclude(
+            question_id__in=snapshot_q_ids
         ).values_list("question_id", flat=True)
+        # stale_questions is already restricted to ids absent from
+        # snapshot_q_ids, so the same carve-out is a no-op there and is
+        # left off deliberately.
         stale_questions = stale_questions.exclude(id__in=answered_q_ids)
         stale_groups = stale_groups.exclude(
             question_group_question__id__in=answered_q_ids
-        ).distinct()
+        )
     stale_questions.soft_delete()
     stale_groups.soft_delete()
 

--- a/backend/api/v1/v1_forms/functions.py
+++ b/backend/api/v1/v1_forms/functions.py
@@ -1253,12 +1253,14 @@ def import_form_definition(
         form (cross-form question moves, seeder/CLI only). The API must
         keep this False so an import can never steal questions from an
         unrelated form.
-    never_delete : bool — when True, groups and questions present in the
-        database but absent from the file are left untouched instead of
-        being soft-deleted (seeder only). Options are still replaced
-        wholesale: QuestionOptions rows carry no submission data, since
-        Answers.options stores option values as a JSON list rather than
-        foreign keys.
+    never_delete : bool — when True, a question/group absent from the file
+        is protected from soft-delete only while it still carries
+        submission data (an answered question, or a group holding one).
+        An unanswered question or empty group is still pruned — that is
+        what frees the (form, name) slot a cross-form move needs to claim
+        (seeder only). Options are still replaced wholesale: QuestionOptions
+        rows carry no submission data, since Answers.options stores option
+        values as a JSON list rather than foreign keys.
 
     Returns
     -------
@@ -1549,16 +1551,28 @@ def _apply_import_update_path(
         if q.get("id") is not None
     }
 
-    # never_delete makes the seeder additive: a question or group the file
-    # stops mentioning keeps its row, and therefore keeps its answers. The
-    # form-import job leaves the flag off and still prunes.
-    if not never_delete:
-        Questions.objects.filter(form=form).exclude(
-            id__in=snapshot_q_ids
-        ).soft_delete()
-        form.form_question_group.exclude(
-            id__in=snapshot_group_ids
-        ).soft_delete()
+    stale_questions = Questions.objects.filter(form=form).exclude(
+        id__in=snapshot_q_ids
+    )
+    stale_groups = form.form_question_group.exclude(
+        id__in=snapshot_group_ids
+    )
+    if never_delete:
+        # Protect what carries submission data, and only that. A question
+        # with answers must survive a re-seed — deleting it would take the
+        # answers with it. A question without answers has nothing to lose,
+        # and pruning it is what frees the (form, name) slot that
+        # unique_active_form_question requires before a cross-form move can
+        # claim that name. Protecting those too would make moves impossible.
+        answered_q_ids = Answers.objects.filter(
+            question__form=form
+        ).values_list("question_id", flat=True)
+        stale_questions = stale_questions.exclude(id__in=answered_q_ids)
+        stale_groups = stale_groups.exclude(
+            question_group_question__id__in=answered_q_ids
+        ).distinct()
+    stale_questions.soft_delete()
+    stale_groups.soft_delete()
 
     group_db = {
         g.id: g

--- a/backend/api/v1/v1_forms/functions.py
+++ b/backend/api/v1/v1_forms/functions.py
@@ -1235,6 +1235,7 @@ def import_form_definition(
     parent_id=None,
     require_parent=True,
     claim_foreign_questions=False,
+    never_delete=False,
 ):
     """Create or update a form from a normalized definition.
 
@@ -1252,6 +1253,12 @@ def import_form_definition(
         form (cross-form question moves, seeder/CLI only). The API must
         keep this False so an import can never steal questions from an
         unrelated form.
+    never_delete : bool — when True, groups and questions present in the
+        database but absent from the file are left untouched instead of
+        being soft-deleted (seeder only). Options are still replaced
+        wholesale: QuestionOptions rows carry no submission data, since
+        Answers.options stores option values as a JSON list rather than
+        foreign keys.
 
     Returns
     -------
@@ -1272,6 +1279,7 @@ def import_form_definition(
         _apply_import_update_path(
             existing_form, norm, user,
             claim_foreign_questions=claim_foreign_questions,
+            never_delete=never_delete,
         )
         return existing_form, "updated"
     else:
@@ -1513,7 +1521,9 @@ def _fixup_import_dependency_refs(form, final_q_id_map):
             q_obj.save(update_fields=["dependency"])
 
 
-def _apply_import_update_path(form, norm, user, claim_foreign_questions=False):
+def _apply_import_update_path(
+    form, norm, user, claim_foreign_questions=False, never_delete=False
+):
     """Update an existing form's live structure to match the normalized def.
 
     Semantics identical to restore_from_snapshot:
@@ -1539,12 +1549,16 @@ def _apply_import_update_path(form, norm, user, claim_foreign_questions=False):
         if q.get("id") is not None
     }
 
-    Questions.objects.filter(form=form).exclude(
-        id__in=snapshot_q_ids
-    ).soft_delete()
-    form.form_question_group.exclude(
-        id__in=snapshot_group_ids
-    ).soft_delete()
+    # never_delete makes the seeder additive: a question or group the file
+    # stops mentioning keeps its row, and therefore keeps its answers. The
+    # form-import job leaves the flag off and still prunes.
+    if not never_delete:
+        Questions.objects.filter(form=form).exclude(
+            id__in=snapshot_q_ids
+        ).soft_delete()
+        form.form_question_group.exclude(
+            id__in=snapshot_group_ids
+        ).soft_delete()
 
     group_db = {
         g.id: g

--- a/backend/api/v1/v1_forms/management/commands/form_seeder.py
+++ b/backend/api/v1/v1_forms/management/commands/form_seeder.py
@@ -13,7 +13,6 @@ from api.v1.v1_forms.functions import (
 )
 from api.v1.v1_forms.models import (
     Forms, Questions,
-    QuestionGroup as QG,
     QuestionAttribute as QA)
 from api.v1.v1_data.models import (
     Answers, AnswerHistory, FormData)
@@ -155,8 +154,6 @@ class Command(BaseCommand):
 
         # Process all form sources in the correct order
         # (parents first, then children)
-        all_question_group_ids = []
-        all_form_ids = []
         with transaction.atomic():
             for source in parent_forms + child_forms:
                 norm = norms[source]
@@ -206,33 +203,29 @@ class Command(BaseCommand):
                 # Collect IDs from the file before processing
                 list_of_question_ids = []
                 list_of_question_group_ids = []
-                all_form_ids.append(norm["form_id"])
                 for g in norm["question_group"]:
                     list_of_question_group_ids.append(g["id"])
                     list_of_question_ids += [
                         q["id"] for q in g["question"]
                     ]
-                all_question_group_ids += list_of_question_group_ids
 
-                # Handle removed questions BEFORE the import runs:
-                # a question moving to another form keeps its row (the
-                # target form claims it via claim_foreign_questions); a
-                # truly removed question is hard-deleted.
+                # A question this form no longer declares is left alone:
+                # deleting it would cascade to its answers, and a re-seed
+                # must never cost a submission. The one exception is a
+                # question moving to another form. `claim_foreign_questions`
+                # reassigns the row by primary key, so without this its
+                # answers would stay bound to submissions of the form it
+                # left. migrate_question_answers copies them down to the
+                # monitoring children first and only then drops the
+                # originals — it deletes strictly what it has already
+                # copied.
                 removed_qs = Questions.objects.filter(
                     form=form
                 ).exclude(id__in=list_of_question_ids)
                 for question in removed_qs:
                     target_form_id = question_target_map.get(question.id)
                     if target_form_id and target_form_id != form.id:
-                        # Question is moving to another form;
-                        # migrate answers before it gets reassigned
-                        migrate_question_answers(
-                            question, target_form_id)
-                    else:
-                        # Question truly removed — delete it
-                        question.delete()
-
-                QA.objects.filter(question__form=form).all().delete()
+                        migrate_question_answers(question, target_form_id)
 
                 # Shared write path (D-8): groups/questions/options upsert
                 # by exported id; cross-form moves claimed by PK so answers
@@ -243,26 +236,39 @@ class Command(BaseCommand):
                     mode="create_or_update",
                     require_parent=False,
                     claim_foreign_questions=True,
+                    never_delete=True,
                 )
 
                 # Question attributes stay a seeder concern (not part of
-                # the FB-007 export format).
+                # the FB-007 export format). Reconcile rather than wipe and
+                # rebuild, and only for questions this file declares —
+                # attributes of any other question are none of its business.
+                #
+                # Dropping an attribute here is not a data-loss exception:
+                # QuestionAttribute rows are form metadata, nothing
+                # references them, and no answer depends on one.
                 qa_rows = []
                 for g in norm["question_group"]:
                     for q in g["question"]:
-                        attrs = q.get("attributes")
-                        if not attrs:
-                            continue
                         db_q = Questions.objects.filter(
                             form=form, name=q["name"]
                         ).first()
                         if not db_q:
                             continue
+                        declared = set()
+                        for a in q.get("attributes") or []:
+                            declared.add(getattr(AttributeTypes, a))
+                        current = set(
+                            QA.objects.filter(
+                                question=db_q
+                            ).values_list("attribute", flat=True)
+                        )
+                        QA.objects.filter(question=db_q).exclude(
+                            attribute__in=declared
+                        ).delete()
                         qa_rows += [
-                            QA(
-                                attribute=getattr(AttributeTypes, a),
-                                question=db_q,
-                            ) for a in attrs
+                            QA(attribute=a, question=db_q)
+                            for a in declared - current
                         ]
                 if qa_rows:
                     QA.objects.bulk_create(qa_rows)
@@ -271,14 +277,3 @@ class Command(BaseCommand):
                     verb = "Created" if created else "Updated"
                     self.stdout.write(
                         f"Form {verb} | {norm['name']} V{form.version}")
-
-            # Final cleanup: delete question groups not present in any
-            # JSON and with no remaining questions. This catches groups
-            # emptied by cross-form question moves.
-            QG.objects.filter(
-                form_id__in=all_form_ids
-            ).exclude(
-                id__in=all_question_group_ids
-            ).filter(
-                question_group_question__isnull=True
-            ).delete()

--- a/backend/api/v1/v1_forms/management/commands/form_seeder.py
+++ b/backend/api/v1/v1_forms/management/commands/form_seeder.py
@@ -3,6 +3,7 @@ import os
 
 from mis.settings import PROD
 from django.core.management import BaseCommand
+from django.core.management.base import CommandError
 from django.db import transaction
 
 from api.v1.v1_forms.constants import AttributeTypes, FormStatus
@@ -82,10 +83,21 @@ def structure_fingerprint(form):
     the form?" without hand-maintaining a field list that would drift
     every time a column is added.
 
-    `version` is dropped because it is the very thing being decided.
+    The `version` pop is purely defensive: _build_schema_snapshot does not
+    emit a version key today, and it must never leak into the comparison
+    if that ever changes, since the version is the thing being decided.
+
+    `type` and `parent_id` are folded in by hand because the snapshot
+    builder covers only the structure below the form row, yet both are
+    columns the seeder writes from the file. Without them a definition
+    that only retypes a form — registration to monitoring, or a
+    re-parenting — would never bump the version and so would never reach
+    a mobile device, which re-downloads on version change alone.
     """
     schema = _build_schema_snapshot(form)
     schema.pop("version", None)
+    schema["type"] = form.type
+    schema["parent_id"] = form.parent_id
     return json.dumps(schema, sort_keys=True, default=str)
 
 
@@ -171,6 +183,7 @@ class Command(BaseCommand):
 
         # Process all form sources in the correct order
         # (parents first, then children)
+        failed_sources = []
         with transaction.atomic():
             for source in parent_forms + child_forms:
                 norm = norms[source]
@@ -178,11 +191,15 @@ class Command(BaseCommand):
                 issues = validate_form_definition(norm, check_entities=False)
                 errors = [i for i in issues if i.get("level") == "error"]
                 if errors:
+                    # Report every problem in every file rather than
+                    # stopping at the first, so one pass tells the operator
+                    # everything that needs fixing.
                     for e in errors:
                         self.stderr.write(
                             f"{source}: [{e['code']}] "
                             f"{e['path']}: {e['message']}"
                         )
+                    failed_sources.append(source)
                     continue
 
                 form = Forms.objects.filter(id=norm["form_id"]).first()
@@ -213,34 +230,40 @@ class Command(BaseCommand):
                     # against; it is new, so its version stands at 1.
                     before_fingerprint = None
                 else:
+                    # Snapshot before anything is written, so the
+                    # post-import comparison can tell a real edit from a
+                    # no-op re-run. It has to happen ahead of the save
+                    # below: that save applies the file's parent/type, and
+                    # those are part of the fingerprint, so capturing
+                    # afterwards would compare the new values against
+                    # themselves and hide the change.
+                    before_fingerprint = structure_fingerprint(form)
                     if parent:
                         form.parent = parent
                     if norm.get("type"):
                         form.type = norm.get("type")
                     form.save()
-                    # Snapshot before the import so the post-import
-                    # comparison can tell a real edit from a no-op re-run.
-                    before_fingerprint = structure_fingerprint(form)
 
                 # Collect IDs from the file before processing
                 list_of_question_ids = []
-                list_of_question_group_ids = []
                 for g in norm["question_group"]:
-                    list_of_question_group_ids.append(g["id"])
                     list_of_question_ids += [
                         q["id"] for q in g["question"]
                     ]
 
-                # A question this form no longer declares is left alone:
-                # deleting it would cascade to its answers, and a re-seed
-                # must never cost a submission. The one exception is a
-                # question moving to another form. `claim_foreign_questions`
-                # reassigns the row by primary key, so without this its
-                # answers would stay bound to submissions of the form it
-                # left. migrate_question_answers copies them down to the
-                # monitoring children first and only then drops the
-                # originals — it deletes strictly what it has already
-                # copied.
+                # A question this form no longer declares is left alone as
+                # long as it carries answers: deleting it would cascade to
+                # them, and a re-seed must never cost a submission. An
+                # unanswered one is still pruned by the import writer's
+                # never_delete pass, which has nothing to protect and needs
+                # the freed (form, name) slot. The one exception to leaving
+                # answered questions alone is a question moving to another
+                # form. `claim_foreign_questions` reassigns the row by
+                # primary key, so without this its answers would stay bound
+                # to submissions of the form it left. The migration helper
+                # below copies them down to the monitoring children first
+                # and only then drops the originals — it deletes strictly
+                # what it has already copied.
                 removed_qs = Questions.objects.filter(
                     form=form
                 ).exclude(id__in=list_of_question_ids)
@@ -307,3 +330,26 @@ class Command(BaseCommand):
                     verb = "Created" if created else "Updated"
                     self.stdout.write(
                         f"Form {verb} | {norm['name']} V{form.version}")
+
+            # A file that failed validation must not be a silent skip.
+            # seeder.sh calls this command bare and reports success on
+            # exit 0, so without this a client's real form could go
+            # missing while the install looks clean.
+            #
+            # The raise sits inside the atomic block on purpose. Every
+            # file was still attempted, so the operator gets the complete
+            # list of failures in one run — but the run as a whole is
+            # rolled back rather than committed half-applied. That matters
+            # because question_target_map is built from all files
+            # including the invalid ones: committing here could leave
+            # answers migrated towards a form that was never written.
+            if failed_sources:
+                raise CommandError(
+                    "form_seeder failed to load {0} of {1} definition(s): "
+                    "{2}. See the errors above; no forms were written."
+                    .format(
+                        len(failed_sources),
+                        len(source_files),
+                        ", ".join(failed_sources),
+                    )
+                )

--- a/backend/api/v1/v1_forms/management/commands/form_seeder.py
+++ b/backend/api/v1/v1_forms/management/commands/form_seeder.py
@@ -7,6 +7,7 @@ from django.db import transaction
 
 from api.v1.v1_forms.constants import AttributeTypes, FormStatus
 from api.v1.v1_forms.functions import (
+    _build_schema_snapshot,
     import_form_definition,
     normalize_form_definition,
     validate_form_definition,
@@ -70,6 +71,22 @@ def migrate_question_answers(question, target_form_id):
                     updated=history.updated,
                 )
             history.delete()
+
+
+def structure_fingerprint(form):
+    """Comparable view of a form's live structure.
+
+    Used to decide whether a re-seed actually changed anything. The
+    snapshot builder already walks groups → questions → options in a
+    fixed order, so comparing two of them answers "did this file change
+    the form?" without hand-maintaining a field list that would drift
+    every time a column is added.
+
+    `version` is dropped because it is the very thing being decided.
+    """
+    schema = _build_schema_snapshot(form)
+    schema.pop("version", None)
+    return json.dumps(schema, sort_keys=True, default=str)
 
 
 class Command(BaseCommand):
@@ -192,13 +209,18 @@ class Command(BaseCommand):
                         status=FormStatus.published,
                         parent=parent,
                     )
+                    # A form that did not exist has nothing to compare
+                    # against; it is new, so its version stands at 1.
+                    before_fingerprint = None
                 else:
-                    form.version += 1
                     if parent:
                         form.parent = parent
                     if norm.get("type"):
                         form.type = norm.get("type")
                     form.save()
+                    # Snapshot before the import so the post-import
+                    # comparison can tell a real edit from a no-op re-run.
+                    before_fingerprint = structure_fingerprint(form)
 
                 # Collect IDs from the file before processing
                 list_of_question_ids = []
@@ -272,6 +294,14 @@ class Command(BaseCommand):
                         ]
                 if qa_rows:
                     QA.objects.bulk_create(qa_rows)
+
+                # Bump only for a definition that actually differs. See
+                # structure_fingerprint for why this matters to mobile.
+                if before_fingerprint is not None:
+                    form.refresh_from_db()
+                    if structure_fingerprint(form) != before_fingerprint:
+                        form.version += 1
+                        form.save(update_fields=["version"])
 
                 if not TEST:
                     verb = "Created" if created else "Updated"

--- a/backend/api/v1/v1_forms/management/commands/form_seeder.py
+++ b/backend/api/v1/v1_forms/management/commands/form_seeder.py
@@ -107,9 +107,14 @@ class Command(BaseCommand):
             if (os.path.isfile(os.path.join(source_folder, json_file))
                 and json_file.endswith('.json'))
         ]
-        source_files = list(
-            filter(lambda x: "example" in x
-                   if TEST else "example" not in x, source_files))
+        # --test narrows to the bundled example fixtures. Without it every
+        # JSON in the folder is seeded: a real deployment drops its own form
+        # definitions here and should not have to encode "not an example" in
+        # the filename. The old `else` branch did exactly that, and since the
+        # folder holds nothing but example-* files it made a plain run seed
+        # nothing at all and exit 0.
+        if TEST:
+            source_files = [f for f in source_files if "example" in f]
         if PROD:
             source_files = list(filter(lambda x: "prod" in x, source_files))
         if JSON_FILE:

--- a/backend/api/v1/v1_forms/management/commands/reset_forms.py
+++ b/backend/api/v1/v1_forms/management/commands/reset_forms.py
@@ -1,5 +1,6 @@
 from django.core.management import call_command
 from django.core.management import BaseCommand
+from django.db import transaction
 from api.v1.v1_forms.models import Forms
 from api.v1.v1_profile.models import SystemUser
 
@@ -20,6 +21,13 @@ class Command(BaseCommand):
             type=int
         )
 
+    # This command destroys every Forms row before it repopulates them
+    # (hard_delete below cascades to submissions), so a failure partway
+    # through — e.g. form_seeder raising CommandError on an invalid
+    # source file — must not leave the database with the wipe committed
+    # and nothing restored. Wrapping the whole method in one transaction
+    # makes the destroy-and-repopulate sequence all-or-nothing.
+    @transaction.atomic
     def handle(self, *args, **options):
         # Get all non-test users
         users = SystemUser.objects.exclude(

--- a/backend/api/v1/v1_forms/tests/tests_form_seeder.py
+++ b/backend/api/v1/v1_forms/tests/tests_form_seeder.py
@@ -56,6 +56,17 @@ class FormSeederTestCase(TestCase):
         return user.get("token")
 
     def test_call_command(self):
+        """A plain run (no --test) seeds every JSON in the real
+        default source folder. That folder currently holds only the
+        bundled example fixtures, so this deliberately covers the
+        plain-run path: 10 forms in, 10 "Form Created | ..." lines
+        out. Before Task 1's fix this test pinned the opposite
+        (buggy) behaviour -- a plain run matching zero files and
+        printing nothing -- so its assertions are updated to match
+        the corrected behaviour rather than the bug. Asserting on
+        count and line shape, not the exact 10 strings, so this
+        doesn't become a tripwire again as fixtures are added.
+        """
 
         self.maxDiff = None
         forms = Forms.objects.all().delete()
@@ -64,9 +75,11 @@ class FormSeederTestCase(TestCase):
         output = self.call_command()
         output = list(filter(lambda x: len(x), output.split("\n")))
         forms = Forms.objects.all()
-        self.assertEqual(forms.count(), 0)
-        # assert output contains expected log messages
-        self.assertListEqual(output, [])
+        self.assertEqual(forms.count(), 10)
+        # Every seeded form logs "Form Created | <name> V<version>".
+        self.assertEqual(len(output), 10)
+        for line in output:
+            self.assertTrue(line.startswith("Form Created | "))
 
     def test_additional_attributes(self):
         seed_administration_test()

--- a/backend/api/v1/v1_forms/tests/tests_form_seeder_upsert.py
+++ b/backend/api/v1/v1_forms/tests/tests_form_seeder_upsert.py
@@ -251,3 +251,47 @@ class FormSeederNoDataLossTestCase(TestCase):
         self.assertTrue(
             Answers.objects.filter(question_id=82002, data=data).exists()
         )
+
+
+@override_settings(USE_TZ=False, TEST_ENV=True)
+class FormSeederVersionTestCase(TestCase):
+    def setUp(self):
+        self.source = tempfile.mkdtemp(prefix="form_seeder_version_")
+        self.addCleanup(shutil.rmtree, self.source, ignore_errors=True)
+
+    def write_form(self, label="Full Name"):
+        payload = minimal_form(830, "Version Form", 83001)
+        payload["question_groups"][0]["questions"][0]["label"] = label
+        path = os.path.join(self.source, "client-version.json")
+        with open(path, "w") as handle:
+            json.dump(payload, handle)
+
+    def seed(self):
+        call_command(
+            "form_seeder",
+            source=self.source,
+            stdout=StringIO(),
+            stderr=StringIO(),
+        )
+
+    def test_unchanged_reseed_keeps_version(self):
+        """Re-seeding an untouched file must not move the version. The
+        form cache is keyed form-{id}-v{version} and mobile devices
+        compare versions to decide whether to re-download, so a
+        gratuitous bump makes every device in the field re-sync."""
+        self.write_form()
+        self.seed()
+        first = Forms.objects.get(pk=830).version
+
+        self.seed()
+        self.assertEqual(Forms.objects.get(pk=830).version, first)
+
+    def test_changed_definition_bumps_version_once(self):
+        """A real edit must still reach devices."""
+        self.write_form()
+        self.seed()
+        first = Forms.objects.get(pk=830).version
+
+        self.write_form(label="Full Legal Name")
+        self.seed()
+        self.assertEqual(Forms.objects.get(pk=830).version, first + 1)

--- a/backend/api/v1/v1_forms/tests/tests_form_seeder_upsert.py
+++ b/backend/api/v1/v1_forms/tests/tests_form_seeder_upsert.py
@@ -13,6 +13,9 @@ from api.v1.v1_forms.functions import (
     normalize_form_definition,
 )
 from api.v1.v1_forms.models import Forms, Questions
+from api.v1.v1_data.models import Answers, FormData
+from api.v1.v1_profile.models import Administration, Levels
+from api.v1.v1_users.models import SystemUser
 
 
 def minimal_form(form_id, name, question_id):
@@ -119,14 +122,51 @@ class ImportNeverDeleteTestCase(TestCase):
 
     def test_never_delete_keeps_absent_question(self):
         """With never_delete=True a question missing from the payload
-        survives, so the answers hanging off it survive too."""
+        survives when it has answers, so the submissions that answered
+        it stay intact. An unanswered question has nothing to protect —
+        see test_never_delete_still_prunes_unanswered_question."""
         self.build_form()
+        level = Levels.objects.create(name="country", level=1)
+        administration = Administration.objects.create(
+            id=1, name="Indonesia", parent=None, level=level
+        )
+        user = SystemUser.objects.create_superuser(
+            email="never-delete@test.com",
+            password="Test105*",
+            first_name="Never",
+            last_name="Delete",
+        )
+        data = FormData.objects.create(
+            name="Submission",
+            form=Forms.objects.get(pk=810),
+            administration=administration,
+            created_by=user,
+        )
+        Answers.objects.create(
+            data=data,
+            question=Questions.objects.get(pk=81002),
+            name="kept",
+            created_by=user,
+        )
+
         import_form_definition(
             self.shrunk_norm(), None, mode="create_or_update",
             require_parent=False, never_delete=True,
         )
         question = Questions.objects_with_deleted.get(pk=81002)
         self.assertIsNone(question.deleted_at)
+
+    def test_never_delete_still_prunes_unanswered_question(self):
+        """never_delete protects submission data, not structure. An
+        unanswered question is still pruned — that is what frees the
+        (form, name) slot a cross-form move needs."""
+        self.build_form()
+        import_form_definition(
+            self.shrunk_norm(), None, mode="create_or_update",
+            require_parent=False, never_delete=True,
+        )
+        question = Questions.objects_with_deleted.get(pk=81002)
+        self.assertIsNotNone(question.deleted_at)
 
     def test_default_still_deletes_absent_question(self):
         """Without the flag the writer behaves exactly as before. This
@@ -139,3 +179,75 @@ class ImportNeverDeleteTestCase(TestCase):
         )
         question = Questions.objects_with_deleted.get(pk=81002)
         self.assertIsNotNone(question.deleted_at)
+
+
+@override_settings(USE_TZ=False, TEST_ENV=True)
+class FormSeederNoDataLossTestCase(TestCase):
+    def setUp(self):
+        self.source = tempfile.mkdtemp(prefix="form_seeder_upsert_")
+        self.addCleanup(shutil.rmtree, self.source, ignore_errors=True)
+        level = Levels.objects.create(name="country", level=1)
+        self.administration = Administration.objects.create(
+            id=1, name="Indonesia", parent=None, level=level
+        )
+        self.user = SystemUser.objects.create_superuser(
+            email="upsert@test.com",
+            password="Test105*",
+            first_name="Up",
+            last_name="Sert",
+        )
+
+    def write_form(self, question_ids):
+        """Write form 820 to the source folder with the given questions."""
+        payload = minimal_form(820, "Upsert Form", question_ids[0])
+        group = payload["question_groups"][0]
+        for order, q_id in enumerate(question_ids[1:], start=2):
+            group["questions"].append({
+                "id": q_id,
+                "order": order,
+                "name": "extra_{0}".format(q_id),
+                "label": "Extra {0}".format(q_id),
+                "short_label": None,
+                "meta": False,
+                "type": "text",
+                "required": False,
+            })
+        path = os.path.join(self.source, "client-upsert.json")
+        with open(path, "w") as handle:
+            json.dump(payload, handle)
+
+    def seed(self):
+        call_command(
+            "form_seeder",
+            source=self.source,
+            stdout=StringIO(),
+            stderr=StringIO(),
+        )
+
+    def test_reseed_keeps_dropped_question_and_its_answers(self):
+        """The whole point: a question the file stops declaring keeps
+        its row, so submissions that answered it stay intact."""
+        self.write_form([82001, 82002])
+        self.seed()
+
+        data = FormData.objects.create(
+            name="Submission",
+            form=Forms.objects.get(pk=820),
+            administration=self.administration,
+            created_by=self.user,
+        )
+        Answers.objects.create(
+            data=data,
+            question=Questions.objects.get(pk=82002),
+            name="kept",
+            created_by=self.user,
+        )
+
+        self.write_form([82001])
+        self.seed()
+
+        question = Questions.objects_with_deleted.get(pk=82002)
+        self.assertIsNone(question.deleted_at)
+        self.assertTrue(
+            Answers.objects.filter(question_id=82002, data=data).exists()
+        )

--- a/backend/api/v1/v1_forms/tests/tests_form_seeder_upsert.py
+++ b/backend/api/v1/v1_forms/tests/tests_form_seeder_upsert.py
@@ -8,7 +8,11 @@ from django.core.management import call_command
 from django.test import TestCase
 from django.test.utils import override_settings
 
-from api.v1.v1_forms.models import Forms
+from api.v1.v1_forms.functions import (
+    import_form_definition,
+    normalize_form_definition,
+)
+from api.v1.v1_forms.models import Forms, Questions
 
 
 def minimal_form(form_id, name, question_id):
@@ -83,3 +87,55 @@ class FormSeederFileSelectionTestCase(TestCase):
         self.seed("--test", 1)
         self.assertTrue(Forms.objects.filter(pk=801).exists())
         self.assertFalse(Forms.objects.filter(pk=802).exists())
+
+
+@override_settings(USE_TZ=False, TEST_ENV=True)
+class ImportNeverDeleteTestCase(TestCase):
+    def build_form(self):
+        """Seed form 810 with two questions via the import writer."""
+        payload = minimal_form(810, "Never Delete", 81001)
+        group = payload["question_groups"][0]
+        group["questions"].append({
+            "id": 81002,
+            "order": 2,
+            "name": "age",
+            "label": "Age",
+            "short_label": "Age",
+            "meta": False,
+            "type": "number",
+            "required": False,
+        })
+        norm = normalize_form_definition(payload)
+        Forms.objects.create(id=810, name="Never Delete", version=1)
+        import_form_definition(
+            norm, None, mode="create_or_update", require_parent=False
+        )
+
+    def shrunk_norm(self):
+        """Same form with question 81002 dropped from the definition."""
+        return normalize_form_definition(
+            minimal_form(810, "Never Delete", 81001)
+        )
+
+    def test_never_delete_keeps_absent_question(self):
+        """With never_delete=True a question missing from the payload
+        survives, so the answers hanging off it survive too."""
+        self.build_form()
+        import_form_definition(
+            self.shrunk_norm(), None, mode="create_or_update",
+            require_parent=False, never_delete=True,
+        )
+        question = Questions.objects_with_deleted.get(pk=81002)
+        self.assertIsNone(question.deleted_at)
+
+    def test_default_still_deletes_absent_question(self):
+        """Without the flag the writer behaves exactly as before. This
+        pins the form-import job path (v1_forms/tasks.py), the only
+        other caller of import_form_definition."""
+        self.build_form()
+        import_form_definition(
+            self.shrunk_norm(), None, mode="create_or_update",
+            require_parent=False,
+        )
+        question = Questions.objects_with_deleted.get(pk=81002)
+        self.assertIsNotNone(question.deleted_at)

--- a/backend/api/v1/v1_forms/tests/tests_form_seeder_upsert.py
+++ b/backend/api/v1/v1_forms/tests/tests_form_seeder_upsert.py
@@ -1,0 +1,85 @@
+import json
+import os
+import shutil
+import tempfile
+from io import StringIO
+
+from django.core.management import call_command
+from django.test import TestCase
+from django.test.utils import override_settings
+
+from api.v1.v1_forms.models import Forms
+
+
+def minimal_form(form_id, name, question_id):
+    """Smallest definition normalize_form_definition() accepts.
+
+    Legacy seeder shape: form/question_groups/questions. Types are strings
+    here because the normalizer maps them to QuestionTypes constants.
+    """
+    return {
+        "id": form_id,
+        "form": name,
+        "version": 1,
+        "type": 1,
+        "question_groups": [
+            {
+                "id": form_id * 100,
+                "order": 1,
+                "name": "group_01",
+                "label": "Group 01",
+                "questions": [
+                    {
+                        "id": question_id,
+                        "order": 1,
+                        "name": "full_name",
+                        "label": "Full Name",
+                        "short_label": "Name",
+                        "meta": True,
+                        "type": "text",
+                        "required": True,
+                    }
+                ],
+            }
+        ],
+    }
+
+
+@override_settings(USE_TZ=False, TEST_ENV=True)
+class FormSeederFileSelectionTestCase(TestCase):
+    def setUp(self):
+        self.source = tempfile.mkdtemp(prefix="form_seeder_select_")
+        self.addCleanup(shutil.rmtree, self.source, ignore_errors=True)
+        self.write("example-alpha.json", minimal_form(801, "Alpha", 80101))
+        self.write("client-beta.json", minimal_form(802, "Beta", 80201))
+
+    def write(self, filename, payload):
+        path = os.path.join(self.source, filename)
+        with open(path, "w") as handle:
+            json.dump(payload, handle)
+
+    def seed(self, *args):
+        out = StringIO()
+        call_command(
+            "form_seeder",
+            *args,
+            source=self.source,
+            stdout=out,
+            stderr=StringIO(),
+        )
+        return out.getvalue()
+
+    def test_plain_run_loads_every_json(self):
+        """No flag: every *.json in the folder is seeded, whatever it
+        is named. This is the point of the change — real deployments
+        drop their own definitions here."""
+        self.seed()
+        self.assertTrue(Forms.objects.filter(pk=801).exists())
+        self.assertTrue(Forms.objects.filter(pk=802).exists())
+
+    def test_test_flag_narrows_to_examples(self):
+        """--test still selects only the bundled example fixtures, so
+        the 110 existing call sites keep their current meaning."""
+        self.seed("--test", 1)
+        self.assertTrue(Forms.objects.filter(pk=801).exists())
+        self.assertFalse(Forms.objects.filter(pk=802).exists())

--- a/backend/api/v1/v1_forms/tests/tests_form_seeder_upsert.py
+++ b/backend/api/v1/v1_forms/tests/tests_form_seeder_upsert.py
@@ -5,14 +5,16 @@ import tempfile
 from io import StringIO
 
 from django.core.management import call_command
+from django.core.management.base import CommandError
 from django.test import TestCase
 from django.test.utils import override_settings
 
 from api.v1.v1_forms.functions import (
+    _build_schema_snapshot,
     import_form_definition,
     normalize_form_definition,
 )
-from api.v1.v1_forms.models import Forms, Questions
+from api.v1.v1_forms.models import Forms, QuestionGroup, Questions
 from api.v1.v1_data.models import Answers, FormData
 from api.v1.v1_profile.models import Administration, Levels
 from api.v1.v1_users.models import SystemUser
@@ -90,6 +92,20 @@ class FormSeederFileSelectionTestCase(TestCase):
         self.seed("--test", 1)
         self.assertTrue(Forms.objects.filter(pk=801).exists())
         self.assertFalse(Forms.objects.filter(pk=802).exists())
+
+    def test_invalid_definition_fails_the_command(self):
+        """An unloadable file must not be a silent skip. seeder.sh runs
+        the command bare and treats exit 0 as success, so a client form
+        that never loaded would otherwise look like a clean install."""
+        broken = minimal_form(803, "Broken", 80301)
+        broken["type"] = 9
+        self.write("client-broken.json", broken)
+
+        with self.assertRaises(CommandError) as caught:
+            self.seed()
+        self.assertIn("client-broken.json", str(caught.exception))
+        # Rolled back as a whole rather than committed half-applied.
+        self.assertFalse(Forms.objects.filter(pk=801).exists())
 
 
 @override_settings(USE_TZ=False, TEST_ENV=True)
@@ -182,6 +198,134 @@ class ImportNeverDeleteTestCase(TestCase):
 
 
 @override_settings(USE_TZ=False, TEST_ENV=True)
+class ImportNeverDeleteGroupTestCase(TestCase):
+    """The group half of the never_delete guard.
+
+    A group is worth protecting only for the submission data it still
+    holds. Both cases below start from form 840 with two groups, an
+    answer on the question in the second group, and a second file that
+    stops declaring that second group. What differs is where the
+    answered question ends up.
+    """
+
+    def setUp(self):
+        level = Levels.objects.create(name="country", level=1)
+        self.administration = Administration.objects.create(
+            id=1, name="Indonesia", parent=None, level=level
+        )
+        self.user = SystemUser.objects.create_superuser(
+            email="group-guard@test.com",
+            password="Test105*",
+            first_name="Group",
+            last_name="Guard",
+        )
+
+    def age_question(self, order=1):
+        return {
+            "id": 84102,
+            "order": order,
+            "name": "age",
+            "label": "Age",
+            "short_label": "Age",
+            "meta": False,
+            "type": "number",
+            "required": False,
+        }
+
+    def build_form(self):
+        """Group 84001 holds `full_name`, group 84002 holds `age`."""
+        payload = minimal_form(840, "Group Guard", 84101)
+        payload["question_groups"][0]["id"] = 84001
+        payload["question_groups"].append({
+            "id": 84002,
+            "order": 2,
+            "name": "group_02",
+            "label": "Group 02",
+            "questions": [self.age_question()],
+        })
+        Forms.objects.create(id=840, name="Group Guard", version=1)
+        self.reseed(payload)
+
+    def answer_age(self):
+        """Put a submission behind question 84102."""
+        data = FormData.objects.create(
+            name="Submission",
+            form=Forms.objects.get(pk=840),
+            administration=self.administration,
+            created_by=self.user,
+        )
+        Answers.objects.create(
+            data=data,
+            question=Questions.objects.get(pk=84102),
+            name="kept",
+            created_by=self.user,
+        )
+
+    def reseed(self, payload, **kwargs):
+        import_form_definition(
+            normalize_form_definition(payload),
+            None,
+            mode="create_or_update",
+            require_parent=False,
+            claim_foreign_questions=True,
+            **kwargs
+        )
+
+    def test_group_survives_while_it_holds_an_answered_question(self):
+        """Group 84002 is dropped from the file, but its question is
+        answered and is dropped too, so both must stay: soft-deleting
+        the group would hide a group that real submissions still
+        reference."""
+        self.build_form()
+        self.answer_age()
+
+        # Second file: only group 84001, `age` gone entirely.
+        self.reseed(
+            minimal_form(840, "Group Guard", 84101), never_delete=True
+        )
+
+        self.assertIsNone(
+            Questions.objects_with_deleted.get(pk=84102).deleted_at
+        )
+        self.assertIsNone(
+            QuestionGroup.objects_with_deleted.get(pk=84002).deleted_at
+        )
+
+    def test_group_is_pruned_when_its_answered_question_moved_away(self):
+        """Regression for the phantom-group bug.
+
+        Same dropped group, but this time the file still declares the
+        answered question — relocated into group 84001. Pass 2 moves the
+        question out, so group 84002 ends up empty. It must be pruned:
+        an answered question may only protect the group it is actually
+        left in, and this one is not.
+        """
+        self.build_form()
+        self.answer_age()
+
+        # Second file: group 84001 only, now holding `age` as well.
+        payload = minimal_form(840, "Group Guard", 84101)
+        payload["question_groups"][0]["id"] = 84001
+        payload["question_groups"][0]["questions"].append(
+            self.age_question(order=2)
+        )
+        self.reseed(payload, never_delete=True)
+
+        moved = Questions.objects_with_deleted.get(pk=84102)
+        self.assertIsNone(moved.deleted_at)
+        self.assertEqual(moved.question_group_id, 84001)
+        self.assertIsNotNone(
+            QuestionGroup.objects_with_deleted.get(pk=84002).deleted_at
+        )
+        # The symptom the soft-delete prevents: an empty group served to
+        # the webform, the mobile SQLite export and every schema snapshot.
+        snapshot = _build_schema_snapshot(Forms.objects.get(pk=840))
+        self.assertEqual(
+            [g["id"] for g in snapshot["question_group"]], [84001]
+        )
+
+
+@override_settings(USE_TZ=False, TEST_ENV=True)
 class FormSeederNoDataLossTestCase(TestCase):
     def setUp(self):
         self.source = tempfile.mkdtemp(prefix="form_seeder_upsert_")
@@ -259,8 +403,9 @@ class FormSeederVersionTestCase(TestCase):
         self.source = tempfile.mkdtemp(prefix="form_seeder_version_")
         self.addCleanup(shutil.rmtree, self.source, ignore_errors=True)
 
-    def write_form(self, label="Full Name"):
+    def write_form(self, label="Full Name", form_type=1):
         payload = minimal_form(830, "Version Form", 83001)
+        payload["type"] = form_type
         payload["question_groups"][0]["questions"][0]["label"] = label
         path = os.path.join(self.source, "client-version.json")
         with open(path, "w") as handle:
@@ -294,4 +439,17 @@ class FormSeederVersionTestCase(TestCase):
 
         self.write_form(label="Full Legal Name")
         self.seed()
+        self.assertEqual(Forms.objects.get(pk=830).version, first + 1)
+
+    def test_type_change_bumps_version(self):
+        """Retyping a form is a change devices must see. It is invisible
+        to _build_schema_snapshot, which describes only the structure
+        below the form row, so the fingerprint has to add it back."""
+        self.write_form()
+        self.seed()
+        first = Forms.objects.get(pk=830).version
+
+        self.write_form(form_type=2)
+        self.seed()
+        self.assertEqual(Forms.objects.get(pk=830).type, 2)
         self.assertEqual(Forms.objects.get(pk=830).version, first + 1)

--- a/backend/api/v1/v1_forms/tests/tests_reset_forms.py
+++ b/backend/api/v1/v1_forms/tests/tests_reset_forms.py
@@ -10,10 +10,14 @@ from api.v1.v1_profile.tests.mixins import ProfileTestHelperMixin
 @override_settings(USE_TZ=False)
 class FormSeederTestCase(TestCase, ProfileTestHelperMixin):
     def setUp(self):
-        # Run the form seeder twice to ensure forms
-        # are populated with the last version is 2
+        # reset_forms must return every form to version 1. Seed once, then
+        # set the version directly. What this test asserts is what
+        # reset_forms does to an already-versioned form, not how the seeder
+        # arrives at a version — double-seeding produced version 2 only
+        # because the seeder used to bump unconditionally, which it no
+        # longer does.
         call_command("form_seeder", "--test")
-        call_command("form_seeder", "--test")
+        Forms.objects.update(version=2)
 
     def call_command(self, *args, **kwargs):
         out = StringIO()

--- a/backend/seeder.sh
+++ b/backend/seeder.sh
@@ -52,16 +52,22 @@ if [[ "${fake_data}" == 'y' || "${fake_data}" == 'Y' ]]; then
         monitoring_data_count=2
     fi
 
-    echo "Do you want to include pending form data? [y/n]"
+    # Both extras default to "no". Pending and draft submissions are
+    # invisible in Manage Data, so a run that accepts the defaults must
+    # produce data the operator can actually see — otherwise a seeded
+    # environment looks broken.
+    echo "Also create pending (unapproved) data? [y/N]"
+    echo "  Needed only to exercise the approval workflow."
     read -r pending_data
-    # Invert the value of pending_data for --approved
     if [[ "${pending_data}" == 'y' || "${pending_data}" == 'Y' ]]; then
+        # --approved=false is what makes the seeder mark data pending.
         approved=false
     else
         approved=true
     fi
 
-    echo "Do you want to include draft form data? [y/n]"
+    echo "Also create draft data? [y/N]"
+    echo "  Drafts appear only under Manage Drafts, for their creator."
     read -r draft_data_input
     if [[ "${draft_data_input}" == 'y' || "${draft_data_input}" == 'Y' ]]; then
         draft_data=true

--- a/backend/seeder.sh
+++ b/backend/seeder.sh
@@ -10,7 +10,7 @@ fi
 echo "Seed Form? [y/n]"
 read -r seed_form
 if [[ "${seed_form}" == 'y' || "${seed_form}" == 'Y' ]]; then
-    python manage.py form_seeder
+    python manage.py form_seeder || { echo "Form seeding failed — aborting."; exit 1; }
     python manage.py generate_config
     python manage.py clear_cache
 fi


### PR DESCRIPTION
Closes #265.

FB-008's "migrate" means porting the client's seeder forms from their
previous project into the product — not a database migration. The first
attempt on this branch read it the second way; those commits were
discarded (reachable at `4aadd316`) and migration `0009` was never
applied anywhere.

## What changed

- **`form_seeder` loads every JSON in the source folder on a plain run.**
  The old filter inverted on `--test` and kept files *without* `example`
  in the name. Since `source/forms/` holds nothing but `example-*` files,
  a plain run matched nothing, seeded nothing and still exited 0 — which
  is why `seeder.sh` appeared to succeed while leaving the database
  without any forms. `reset_forms`' non-test path had the same bug and is
  fixed by the same change.
- **Re-seeding is add/update-only**, via a `never_delete` flag on
  `import_form_definition`. Previously a re-seed hard-deleted every
  question the file stopped declaring, cascading to that question's
  answers.
- **`form.version` moves only when the definition actually changed.** The
  form cache is keyed `form-{id}-v{version}` and devices compare versions
  to decide whether to re-download, so the old unconditional bump forced
  every device in the field to re-sync after any re-seed.
- **`seeder.sh`'s pending and draft prompts default to no**, and say
  where the data ends up. The command's own defaults were already
  correct; the wrapper's wording was the defect.

## `never_delete` is answer-aware, deliberately

A literal "delete nothing that is absent from the file" is impossible
here. `unique_active_form_question` is a *partial* unique constraint on
`(form, name)` where `deleted_at IS NULL`, so a cross-form question move
needs the target form's name slot vacated first — something the blanket
soft-delete used to do as a side effect. Protecting every absent question
makes moves raise `IntegrityError`.

So the rule is: a question with `answer` rows survives a re-seed; one
without is still pruned, which frees the name slot; a group survives only
while it still holds an answered question. That is the invariant that
actually matters — never delete anything an `answer` row depends on.

One consequence is intentional: a cross-form move into a form already
holding an *answered* question of the same name raises `IntegrityError`
and rolls the whole run back, rather than deleting answered structure to
make room. Fail-loud beats silent data loss.

## Unchanged on purpose

- The `PROD` source filter and the `--file` flag keep their meaning.
- `fake_complete_data_seeder`'s own defaults are untouched.
- The form-builder CRUD API (`save_form`) is not touched at all, and the
  async form-import job keeps pruning — only the seeder opts out.

## Tests

Full suite: **1367 tests, all apps, green.** Two pre-existing tests were
updated, both because they asserted the specific bug being fixed:

- `tests_form_seeder.py::test_call_command` asserted a plain run seeds
  *zero* forms with empty output.
- `tests_reset_forms.py`'s `setUp` double-seeded "to ensure forms are
  populated with the last version is 2" — a precondition that only held
  under the unconditional bump. Only `setUp` changed; every assertion in
  that file is byte-identical.

No other existing test was modified.

## Deployment note

A production seed now also loads any `example-*` fixtures present in
`source/forms/`. Remove them from the deployment if that is not wanted.