### PR TITLE
[#270] Filter every read by tenant

### DIFF
--- a/backend/api/v1/v1_data/management/commands/generate_config.py
+++ b/backend/api/v1/v1_data/management/commands/generate_config.py
@@ -9,15 +9,14 @@ from mis.settings import (
     APK_NAME,
     SHOW_LANDING_PAGE,
 )
-from api.v1.v1_profile.models import Levels
 from api.v1.v1_profile.constants import FeatureTypes, FeatureAccessTypes
 from api.v1.v1_visualization.functions import refresh_materialized_data
 
 
 class Command(BaseCommand):
     help = (
-        "Generate source/config/config.min.js (levels, "
-        "appConfig, roleFeatures) for the frontend bundle. "
+        "Generate source/config/config.min.js (appConfig, "
+        "roleFeatures) for the frontend bundle. "
         "Pass --refresh-views to also refresh the view_data_options "
         "materialized view (acquires an exclusive lock — see flag help)."
     )
@@ -45,19 +44,11 @@ class Command(BaseCommand):
 
         # write config
         config_file = jsmin(open("source/config/config.js").read())
-        levels = []
-        # NOTE: forms are no longer baked here. The web frontend fetches them
-        # at runtime from GET /api/v1/forms/published so newly published forms
-        # reflect without a config rebuild. See doc/claude/
-        # remove-window-forms-runtime-fetch.md
-        for level in Levels.objects.all():
-            levels.append(
-                {
-                    "id": level.id,
-                    "name": level.name,
-                    "level": level.level,
-                }
-            )
+        # NOTE: neither forms nor levels are baked here any more. The web
+        # frontend fetches both at runtime — forms from
+        # GET /api/v1/forms/published, levels from GET /api/v1/levels —
+        # because levels are tenant-owned and a global bake would show
+        # every tenant's tiers to everyone.
         role_features = []
         for key, value in FeatureTypes.FieldStr.items():
             role_features.append(
@@ -76,9 +67,6 @@ class Command(BaseCommand):
         min_config = jsmin(
             "".join(
                 [
-                    "var levels=",
-                    json.dumps(levels),
-                    ";",
                     config_file,
                     "var appConfig=",
                     json.dumps({
@@ -96,7 +84,6 @@ class Command(BaseCommand):
         )
         open("source/config/config.min.js", "w").write(min_config)
         # os.remove(administration_json)
-        del levels
         del min_config
         if options.get("refresh_views"):
             refresh_materialized_data()

--- a/backend/api/v1/v1_data/models.py
+++ b/backend/api/v1/v1_data/models.py
@@ -11,11 +11,13 @@ from api.v1.v1_profile.models import (
 )
 from api.v1.v1_users.models import SystemUser
 from utils.soft_deletes_model import SoftDeletes
+from utils.tenant_scoped_model import TenantManager
 from utils.draft_model import Draft, DraftSoftDeletesManager
 from utils import storage
 
 
 class FormData(SoftDeletes, Draft):
+    TENANT_PATH = "form__tenant"
     parent = models.ForeignKey(
         "self",
         on_delete=models.CASCADE,
@@ -178,6 +180,8 @@ class FormData(SoftDeletes, Draft):
 
 
 class Answers(models.Model):
+    TENANT_PATH = "data__form__tenant"
+    objects = TenantManager()
     data = models.ForeignKey(
         to=FormData, on_delete=models.CASCADE, related_name="data_answer"
     )

--- a/backend/api/v1/v1_data/tests/tests_tenant_isolation.py
+++ b/backend/api/v1/v1_data/tests/tests_tenant_isolation.py
@@ -1,0 +1,100 @@
+from django.test import TestCase
+from django.test.utils import override_settings
+from rest_framework_simplejwt.tokens import RefreshToken
+
+from api.v1.v1_forms.models import Forms
+from api.v1.v1_data.models import FormData
+from api.v1.v1_profile.models import Administration, Levels
+from api.v1.v1_users.models import SystemUser, Tenant
+
+
+@override_settings(USE_TZ=False)
+class DataTenantIsolationTestCase(TestCase):
+    """Two tenants, each with a form and a datapoint of their own.
+
+    Tenant A's superadmin must see only A's rows and must not be able to
+    reach B's objects by guessing an id.
+    """
+
+    def _tenant(self, sub):
+        tenant = Tenant.objects.create(subdomain=sub)
+        level = Levels.objects.create(name="", level=0, tenant=tenant)
+        child_level = Levels.objects.create(
+            name="district", level=1, tenant=tenant
+        )
+        root = Administration.objects.create(
+            parent=None, level=level, name=sub, tenant=tenant
+        )
+        # Datapoints hang off a child unit, not the root: the list filters
+        # on administration__path__startswith and a root's path is NULL.
+        child = Administration.objects.create(
+            parent=root, level=child_level, name=f"{sub}-d", tenant=tenant
+        )
+        user = SystemUser.objects.create_superuser(
+            email=f"admin@{sub}.org", password="Secret#Pass123",
+            first_name="A", last_name="A", tenant=tenant,
+        )
+        form = Forms.objects.create(name=f"{sub}-form", tenant=tenant)
+        data = FormData.objects.create(
+            name=f"{sub}-dp", form=form, administration=child,
+            created_by=user,
+        )
+        return {
+            "tenant": tenant, "user": user, "form": form,
+            "root": root, "child": child, "data": data,
+        }
+
+    def _auth(self, user):
+        return {
+            "HTTP_AUTHORIZATION":
+                f"Bearer {RefreshToken.for_user(user).access_token}"
+        }
+
+    def setUp(self):
+        self.a = self._tenant("acme")
+        self.b = self._tenant("beta")
+
+    def test_data_list_shows_only_own_tenant(self):
+        res = self.client.get(
+            f"/api/v1/form-data/{self.a['form'].id}",
+            **self._auth(self.a["user"]),
+        )
+        self.assertEqual(res.status_code, 200)
+        ids = [d["id"] for d in res.json()["data"]]
+        self.assertIn(self.a["data"].id, ids)
+        self.assertNotIn(self.b["data"].id, ids)
+
+    def test_data_list_404_on_foreign_form(self):
+        res = self.client.get(
+            f"/api/v1/form-data/{self.b['form'].id}",
+            **self._auth(self.a["user"]),
+        )
+        self.assertEqual(res.status_code, 404)
+
+    def test_data_detail_404_on_foreign_object(self):
+        res = self.client.get(
+            f"/api/v1/data-details/{self.b['data'].id}",
+            **self._auth(self.a["user"]),
+        )
+        self.assertEqual(res.status_code, 404)
+
+    def test_answer_detail_404_on_foreign_object(self):
+        res = self.client.get(
+            f"/api/v1/data/{self.b['data'].id}",
+            **self._auth(self.a["user"]),
+        )
+        self.assertEqual(res.status_code, 404)
+
+    def test_draft_list_404_on_foreign_form(self):
+        res = self.client.get(
+            f"/api/v1/draft-submissions/{self.b['form'].id}",
+            **self._auth(self.a["user"]),
+        )
+        self.assertEqual(res.status_code, 404)
+
+    def test_pending_list_404_on_foreign_form(self):
+        res = self.client.get(
+            f"/api/v1/form-pending-data/{self.b['form'].id}",
+            **self._auth(self.a["user"]),
+        )
+        self.assertEqual(res.status_code, 404)

--- a/backend/api/v1/v1_data/tests/tests_tenant_isolation.py
+++ b/backend/api/v1/v1_data/tests/tests_tenant_isolation.py
@@ -1,63 +1,25 @@
-from django.test import TestCase
 from django.test.utils import override_settings
-from rest_framework_simplejwt.tokens import RefreshToken
 
-from api.v1.v1_forms.models import Forms
 from api.v1.v1_data.models import FormData
-from api.v1.v1_profile.models import Administration, Levels
-from api.v1.v1_users.models import SystemUser, Tenant
+from utils.tenant_test_case import TenantIsolationTestCase
 
 
 @override_settings(USE_TZ=False)
-class DataTenantIsolationTestCase(TestCase):
-    """Two tenants, each with a form and a datapoint of their own.
-
-    Tenant A's superadmin must see only A's rows and must not be able to
-    reach B's objects by guessing an id.
-    """
-
-    def _tenant(self, sub):
-        tenant = Tenant.objects.create(subdomain=sub)
-        level = Levels.objects.create(name="", level=0, tenant=tenant)
-        child_level = Levels.objects.create(
-            name="district", level=1, tenant=tenant
+class DataTenantIsolationTestCase(TenantIsolationTestCase):
+    def make_tenant(self, sub):
+        tenant = super().make_tenant(sub)
+        tenant["data"] = FormData.objects.create(
+            name=f"{sub}-dp",
+            form=tenant["form"],
+            administration=tenant["child"],
+            created_by=tenant["user"],
         )
-        root = Administration.objects.create(
-            parent=None, level=level, name=sub, tenant=tenant
-        )
-        # Datapoints hang off a child unit, not the root: the list filters
-        # on administration__path__startswith and a root's path is NULL.
-        child = Administration.objects.create(
-            parent=root, level=child_level, name=f"{sub}-d", tenant=tenant
-        )
-        user = SystemUser.objects.create_superuser(
-            email=f"admin@{sub}.org", password="Secret#Pass123",
-            first_name="A", last_name="A", tenant=tenant,
-        )
-        form = Forms.objects.create(name=f"{sub}-form", tenant=tenant)
-        data = FormData.objects.create(
-            name=f"{sub}-dp", form=form, administration=child,
-            created_by=user,
-        )
-        return {
-            "tenant": tenant, "user": user, "form": form,
-            "root": root, "child": child, "data": data,
-        }
-
-    def _auth(self, user):
-        return {
-            "HTTP_AUTHORIZATION":
-                f"Bearer {RefreshToken.for_user(user).access_token}"
-        }
-
-    def setUp(self):
-        self.a = self._tenant("acme")
-        self.b = self._tenant("beta")
+        return tenant
 
     def test_data_list_shows_only_own_tenant(self):
         res = self.client.get(
             f"/api/v1/form-data/{self.a['form'].id}",
-            **self._auth(self.a["user"]),
+            **self.auth(self.a["user"]),
         )
         self.assertEqual(res.status_code, 200)
         ids = [d["id"] for d in res.json()["data"]]
@@ -67,34 +29,34 @@ class DataTenantIsolationTestCase(TestCase):
     def test_data_list_404_on_foreign_form(self):
         res = self.client.get(
             f"/api/v1/form-data/{self.b['form'].id}",
-            **self._auth(self.a["user"]),
+            **self.auth(self.a["user"]),
         )
         self.assertEqual(res.status_code, 404)
 
     def test_data_detail_404_on_foreign_object(self):
         res = self.client.get(
             f"/api/v1/data-details/{self.b['data'].id}",
-            **self._auth(self.a["user"]),
+            **self.auth(self.a["user"]),
         )
         self.assertEqual(res.status_code, 404)
 
     def test_answer_detail_404_on_foreign_object(self):
         res = self.client.get(
             f"/api/v1/data/{self.b['data'].id}",
-            **self._auth(self.a["user"]),
+            **self.auth(self.a["user"]),
         )
         self.assertEqual(res.status_code, 404)
 
     def test_draft_list_404_on_foreign_form(self):
         res = self.client.get(
             f"/api/v1/draft-submissions/{self.b['form'].id}",
-            **self._auth(self.a["user"]),
+            **self.auth(self.a["user"]),
         )
         self.assertEqual(res.status_code, 404)
 
     def test_pending_list_404_on_foreign_form(self):
         res = self.client.get(
             f"/api/v1/form-pending-data/{self.b['form'].id}",
-            **self._auth(self.a["user"]),
+            **self.auth(self.a["user"]),
         )
         self.assertEqual(res.status_code, 404)

--- a/backend/api/v1/v1_data/views.py
+++ b/backend/api/v1/v1_data/views.py
@@ -168,7 +168,9 @@ class FormDataAddListView(APIView):
         summary="To get list of form data",
     )
     def get(self, request, form_id, version):
-        form = get_object_or_404(Forms, pk=form_id)
+        form = get_object_or_404(
+            Forms.objects.for_user(request.user), pk=form_id
+        )
         serializer = ListFormDataRequestSerializer(
             data=request.GET, context={"form_id": form_id}
         )
@@ -255,8 +257,10 @@ class FormDataAddListView(APIView):
             filter_descendants.append(filter_administration.id)
             filter_data["administration_id__in"] = filter_descendants
         else:
-            # Filter data by user administration path
-            adm = Administration.objects.filter(
+            # Filter data by user administration path. The root is looked
+            # up within the tenant: an unscoped first() could pick another
+            # tenant's root and scope the whole list to it.
+            adm = Administration.objects.for_user(request.user).filter(
                 parent__isnull=True,
             ).first()
             if not request.user.is_superuser:
@@ -342,7 +346,9 @@ class FormDataAddListView(APIView):
         summary="Submit form data",
     )
     def post(self, request, form_id, version):
-        form = get_object_or_404(Forms, pk=form_id)
+        form = get_object_or_404(
+            Forms.objects.for_user(request.user), pk=form_id
+        )
         serializer = SubmitFormSerializer(
             data=request.data, context={"user": request.user, "form": form}
         )
@@ -375,7 +381,9 @@ class FormDataAddListView(APIView):
     def put(self, request, form_id, version):
         data_id = request.GET["data_id"]
         user = request.user
-        data = get_object_or_404(FormData, pk=data_id)
+        data = get_object_or_404(
+            FormData.objects.for_user(request.user), pk=data_id
+        )
         serializer = SubmitFormDataAnswerSerializer(
             data=request.data, many=True
         )
@@ -466,7 +474,9 @@ class DataAnswerDetailDeleteView(APIView):
         summary="To get answers for form data",
     )
     def get(self, request, data_id, version):
-        data = get_object_or_404(FormData, pk=data_id)
+        data = get_object_or_404(
+            FormData.objects.for_user(request.user), pk=data_id
+        )
         return Response(
             ListDataAnswerSerializer(
                 instance=data.data_answer.all(), many=True
@@ -482,7 +492,9 @@ class DataAnswerDetailDeleteView(APIView):
         summary="Delete datapoint include answer & history",
     )
     def delete(self, request, data_id, version):
-        instance = get_object_or_404(FormData, pk=data_id)
+        instance = get_object_or_404(
+            FormData.objects.for_user(request.user), pk=data_id
+        )
         answers = Answers.objects.filter(data_id=data_id)
         answers.delete()
         history = AnswerHistory.objects.filter(data_id=data_id)
@@ -501,7 +513,11 @@ class PendingDataDetailDeleteView(APIView):
         summary="To get list of answers for pending data",
     )
     def get(self, request, pending_data_id, version):
-        data = get_object_or_404(FormData, pk=pending_data_id, is_pending=True)
+        data = get_object_or_404(
+            FormData.objects.for_user(request.user),
+            pk=pending_data_id,
+            is_pending=True,
+        )
         # Get the last data from the last children
         last_data = data.parent.children.filter(is_pending=False).last() if \
             data.parent else None
@@ -528,9 +544,9 @@ class PendingDataDetailDeleteView(APIView):
     )
     def delete(self, request, pending_data_id, version):
         instance = get_object_or_404(
-            FormData,
+            FormData.objects.for_user(request.user),
             pk=pending_data_id,
-            is_pending=True
+            is_pending=True,
         )
         if instance.created_by_id != request.user.id:
             return Response(
@@ -550,7 +566,11 @@ class DataDetailDeleteView(APIView):
         summary="To get data by ID",
     )
     def get(self, request, data_id, version):
-        data = get_object_or_404(FormData, pk=data_id, is_pending=False)
+        data = get_object_or_404(
+            FormData.objects.for_user(request.user),
+            pk=data_id,
+            is_pending=False,
+        )
         return Response(
             FormDataSerializer(instance=data).data,
             status=status.HTTP_200_OK,
@@ -564,7 +584,11 @@ class DataDetailDeleteView(APIView):
         summary="To delete data",
     )
     def delete(self, request, data_id, version):
-        instance = get_object_or_404(FormData, pk=data_id, is_pending=False)
+        instance = get_object_or_404(
+            FormData.objects.for_user(request.user),
+            pk=data_id,
+            is_pending=False,
+        )
         if not request.user.is_superuser or request.user.user_role.filter(
             role__role_role_access__data_access=DataAccessTypes.delete
         ).exists():
@@ -580,7 +604,9 @@ class DataDetailDeleteView(APIView):
 @api_view(["GET"])
 @permission_classes([IsAuthenticated])
 def export_form_data(request, version, form_id):
-    form = get_object_or_404(Forms, pk=form_id)
+    form = get_object_or_404(
+            Forms.objects.for_user(request.user), pk=form_id
+        )
     form_name = form.name
     filename = f"{form.id}-{form_name}"
     directory = "tmp"
@@ -612,7 +638,9 @@ class PendingFormDataView(APIView):
         summary="Submit pending form data",
     )
     def post(self, request, form_id, version):
-        form = get_object_or_404(Forms, pk=form_id)
+        form = get_object_or_404(
+            Forms.objects.for_user(request.user), pk=form_id
+        )
         serializer = SubmitPendingFormSerializer(
             data=request.data, context={"user": request.user, "form": form}
         )
@@ -681,7 +709,9 @@ class PendingFormDataView(APIView):
         summary="To get list of pending form data",
     )
     def get(self, request, form_id, version):
-        form = get_object_or_404(Forms, pk=form_id)
+        form = get_object_or_404(
+            Forms.objects.for_user(request.user), pk=form_id
+        )
         serializer = ListPendingFormDataRequestSerializer(data=request.GET)
         if not serializer.is_valid():
             return Response(
@@ -769,13 +799,15 @@ class PendingFormDataView(APIView):
         summary="Edit pending form data",
     )
     def put(self, request, form_id, version):
-        get_object_or_404(Forms, pk=form_id)
+        get_object_or_404(
+            Forms.objects.for_user(request.user), pk=form_id
+        )
         pending_data_id = request.GET["pending_data_id"]
         user = request.user
         pending_data = get_object_or_404(
-            FormData,
+            FormData.objects.for_user(request.user),
             pk=pending_data_id,
-            is_pending=True
+            is_pending=True,
         )
         serializer = SubmitFormDataAnswerSerializer(
             data=request.data, many=True
@@ -898,7 +930,9 @@ class DraftFormDataListView(APIView):
         summary="To get list of draft form data",
     )
     def get(self, request, form_id, version):
-        form = get_object_or_404(Forms, pk=form_id)
+        form = get_object_or_404(
+            Forms.objects.for_user(request.user), pk=form_id
+        )
         page_size = REST_FRAMEWORK.get("PAGE_SIZE")
 
         serializer = FilterDraftFormDataSerializer(
@@ -958,7 +992,9 @@ class DraftFormDataListView(APIView):
         summary="Submit draft form data",
     )
     def post(self, request, form_id, version):
-        form = get_object_or_404(Forms, pk=form_id)
+        form = get_object_or_404(
+            Forms.objects.for_user(request.user), pk=form_id
+        )
         serializer = SubmitPendingFormSerializer(
             data=request.data,
             context={
@@ -993,7 +1029,9 @@ class DraftFormDataDetailView(APIView):
     )
     def get(self, request, data_id, version):
         draft_data = get_object_or_404(
-            FormData, pk=data_id, is_draft=True
+            FormData.objects.for_user(request.user),
+            pk=data_id,
+            is_draft=True,
         )
         if draft_data.created_by_id != request.user.id:
             return Response(
@@ -1016,7 +1054,9 @@ class DraftFormDataDetailView(APIView):
     )
     def put(self, request, data_id, version):
         draft_data = get_object_or_404(
-            FormData, pk=data_id, is_draft=True
+            FormData.objects.for_user(request.user),
+            pk=data_id,
+            is_draft=True,
         )
         if draft_data.created_by_id != request.user.id:
             return Response(
@@ -1053,7 +1093,9 @@ class DraftFormDataDetailView(APIView):
     )
     def delete(self, request, data_id, version):
         draft_data = get_object_or_404(
-            FormData, pk=data_id, is_draft=True
+            FormData.objects.for_user(request.user),
+            pk=data_id,
+            is_draft=True,
         )
         if draft_data.created_by_id != request.user.id:
             return Response(
@@ -1080,7 +1122,9 @@ class PublishDraftFormDataView(APIView):
     )
     def post(self, request, data_id, version):
         draft_data = get_object_or_404(
-            FormData, pk=data_id, is_draft=True
+            FormData.objects.for_user(request.user),
+            pk=data_id,
+            is_draft=True,
         )
         if draft_data.created_by_id != request.user.id:
             return Response(

--- a/backend/api/v1/v1_forms/functions.py
+++ b/backend/api/v1/v1_forms/functions.py
@@ -30,15 +30,22 @@ from api.v1.v1_data.functions import get_cache, create_cache
 from api.v1.v1_forms.serializers import FormDataSerializer
 
 
-def get_published_forms_payload():
-    """Return all published forms with full content for the web frontend.
+def get_published_forms_payload(user):
+    """Return the user's tenant's published forms with full content.
 
     Shape matches what generate_config used to bake into window.forms:
     [{"id", "name", "version", "content": FormDataSerializer(...)}].
     Cached via the shared date-prefixed cache (bypassed under TEST_ENV);
     invalidated by the form-mutation signal cache.clear() and clear_cache.
+
+    The cache key carries the tenant id. The payload used to be identical
+    for everyone, so one global key was right; now that it is scoped, a
+    shared key would hand the first caller's forms to every other tenant
+    — a worse leak than the unscoped list it replaces.
     """
-    cached = get_cache(PUBLISHED_FORMS_CACHE)
+    tenant = getattr(user, "tenant", None)
+    cache_name = f"{PUBLISHED_FORMS_CACHE}-{tenant.id if tenant else 'none'}"
+    cached = get_cache(cache_name)
     if cached is not None:
         return cached
     payload = [
@@ -48,9 +55,11 @@ def get_published_forms_payload():
             "version": form.version,
             "content": FormDataSerializer(instance=form).data,
         }
-        for form in Forms.objects.filter(status=FormStatus.published).all()
+        for form in Forms.objects.for_user(user).filter(
+            status=FormStatus.published
+        )
     ]
-    create_cache(PUBLISHED_FORMS_CACHE, payload)
+    create_cache(cache_name, payload)
     return payload
 
 

--- a/backend/api/v1/v1_forms/models.py
+++ b/backend/api/v1/v1_forms/models.py
@@ -11,10 +11,12 @@ from api.v1.v1_forms.constants import (
 )
 from api.v1.v1_users.models import SystemUser
 from utils.soft_deletes_model import SoftDeletes
+from utils.tenant_scoped_model import TenantManager
 from utils.tenant_model import tenant_fk
 
 
 class Forms(SoftDeletes):
+    TENANT_PATH = "tenant"
     name = models.TextField()
     description = models.TextField(default=None, null=True)
     tenant = tenant_fk("forms")
@@ -83,6 +85,7 @@ class Forms(SoftDeletes):
 
 
 class QuestionGroup(SoftDeletes):
+    TENANT_PATH = "form__tenant"
     form = models.ForeignKey(
         to=Forms, on_delete=models.CASCADE, related_name="form_question_group"
     )
@@ -113,6 +116,7 @@ class QuestionGroup(SoftDeletes):
 
 
 class Questions(SoftDeletes):
+    TENANT_PATH = "form__tenant"
     form = models.ForeignKey(
         to=Forms, on_delete=models.CASCADE, related_name="form_questions"
     )
@@ -224,6 +228,8 @@ class QuestionOptions(models.Model):
 
 
 class UserForms(models.Model):
+    TENANT_PATH = "user__tenant"
+    objects = TenantManager()
     user = models.ForeignKey(
         to=SystemUser, on_delete=models.CASCADE, related_name="user_form"
     )

--- a/backend/api/v1/v1_forms/tests/tests_tenant_isolation.py
+++ b/backend/api/v1/v1_forms/tests/tests_tenant_isolation.py
@@ -1,0 +1,81 @@
+from django.test import TestCase
+from django.test.utils import override_settings
+from rest_framework_simplejwt.tokens import RefreshToken
+
+from api.v1.v1_forms.constants import FormStatus
+from api.v1.v1_forms.models import Forms
+from api.v1.v1_profile.models import Administration, Levels
+from api.v1.v1_users.models import SystemUser, Tenant
+
+
+@override_settings(USE_TZ=False)
+class FormsTenantIsolationTestCase(TestCase):
+    def _tenant(self, sub):
+        tenant = Tenant.objects.create(subdomain=sub)
+        level = Levels.objects.create(name="", level=0, tenant=tenant)
+        Administration.objects.create(
+            parent=None, level=level, name=sub, tenant=tenant
+        )
+        user = SystemUser.objects.create_superuser(
+            email=f"admin@{sub}.org", password="Secret#Pass123",
+            first_name="A", last_name="A", tenant=tenant,
+        )
+        form = Forms.objects.create(
+            name=f"{sub}-form", tenant=tenant, status=FormStatus.published
+        )
+        return {"tenant": tenant, "user": user, "form": form}
+
+    def _auth(self, user):
+        return {
+            "HTTP_AUTHORIZATION":
+                f"Bearer {RefreshToken.for_user(user).access_token}"
+        }
+
+    def setUp(self):
+        self.a = self._tenant("acme")
+        self.b = self._tenant("beta")
+
+    def test_form_list_excludes_other_tenant(self):
+        res = self.client.get("/api/v1/forms", **self._auth(self.a["user"]))
+        self.assertEqual(res.status_code, 200)
+        ids = [f["id"] for f in res.json()]
+        self.assertIn(self.a["form"].id, ids)
+        self.assertNotIn(self.b["form"].id, ids)
+
+    def test_published_forms_excludes_other_tenant(self):
+        res = self.client.get(
+            "/api/v1/forms/published", **self._auth(self.a["user"])
+        )
+        self.assertEqual(res.status_code, 200)
+        ids = [f["id"] for f in res.json()]
+        self.assertIn(self.a["form"].id, ids)
+        self.assertNotIn(self.b["form"].id, ids)
+
+    def test_published_forms_cache_is_not_shared_between_tenants(self):
+        # The payload is cached; a key shared across tenants would hand the
+        # first caller's forms to the second.
+        self.client.get(
+            "/api/v1/forms/published", **self._auth(self.a["user"])
+        )
+        res = self.client.get(
+            "/api/v1/forms/published", **self._auth(self.b["user"])
+        )
+        ids = [f["id"] for f in res.json()]
+        self.assertIn(self.b["form"].id, ids)
+        self.assertNotIn(self.a["form"].id, ids)
+
+    def test_web_form_404_on_foreign_form(self):
+        res = self.client.get(
+            f"/api/v1/form/web/{self.b['form'].id}",
+            **self._auth(self.a["user"]),
+        )
+        self.assertEqual(res.status_code, 404)
+
+    def test_form_builder_list_excludes_other_tenant(self):
+        res = self.client.get(
+            "/api/v1/manage/forms", **self._auth(self.a["user"])
+        )
+        self.assertEqual(res.status_code, 200)
+        ids = [f["id"] for f in res.json()["data"]]
+        self.assertIn(self.a["form"].id, ids)
+        self.assertNotIn(self.b["form"].id, ids)

--- a/backend/api/v1/v1_forms/tests/tests_tenant_isolation.py
+++ b/backend/api/v1/v1_forms/tests/tests_tenant_isolation.py
@@ -1,42 +1,12 @@
-from django.test import TestCase
 from django.test.utils import override_settings
-from rest_framework_simplejwt.tokens import RefreshToken
 
-from api.v1.v1_forms.constants import FormStatus
-from api.v1.v1_forms.models import Forms
-from api.v1.v1_profile.models import Administration, Levels
-from api.v1.v1_users.models import SystemUser, Tenant
+from utils.tenant_test_case import TenantIsolationTestCase
 
 
 @override_settings(USE_TZ=False)
-class FormsTenantIsolationTestCase(TestCase):
-    def _tenant(self, sub):
-        tenant = Tenant.objects.create(subdomain=sub)
-        level = Levels.objects.create(name="", level=0, tenant=tenant)
-        Administration.objects.create(
-            parent=None, level=level, name=sub, tenant=tenant
-        )
-        user = SystemUser.objects.create_superuser(
-            email=f"admin@{sub}.org", password="Secret#Pass123",
-            first_name="A", last_name="A", tenant=tenant,
-        )
-        form = Forms.objects.create(
-            name=f"{sub}-form", tenant=tenant, status=FormStatus.published
-        )
-        return {"tenant": tenant, "user": user, "form": form}
-
-    def _auth(self, user):
-        return {
-            "HTTP_AUTHORIZATION":
-                f"Bearer {RefreshToken.for_user(user).access_token}"
-        }
-
-    def setUp(self):
-        self.a = self._tenant("acme")
-        self.b = self._tenant("beta")
-
+class FormsTenantIsolationTestCase(TenantIsolationTestCase):
     def test_form_list_excludes_other_tenant(self):
-        res = self.client.get("/api/v1/forms", **self._auth(self.a["user"]))
+        res = self.client.get("/api/v1/forms", **self.auth(self.a["user"]))
         self.assertEqual(res.status_code, 200)
         ids = [f["id"] for f in res.json()]
         self.assertIn(self.a["form"].id, ids)
@@ -44,7 +14,7 @@ class FormsTenantIsolationTestCase(TestCase):
 
     def test_published_forms_excludes_other_tenant(self):
         res = self.client.get(
-            "/api/v1/forms/published", **self._auth(self.a["user"])
+            "/api/v1/forms/published", **self.auth(self.a["user"])
         )
         self.assertEqual(res.status_code, 200)
         ids = [f["id"] for f in res.json()]
@@ -54,11 +24,9 @@ class FormsTenantIsolationTestCase(TestCase):
     def test_published_forms_cache_is_not_shared_between_tenants(self):
         # The payload is cached; a key shared across tenants would hand the
         # first caller's forms to the second.
-        self.client.get(
-            "/api/v1/forms/published", **self._auth(self.a["user"])
-        )
+        self.client.get("/api/v1/forms/published", **self.auth(self.a["user"]))
         res = self.client.get(
-            "/api/v1/forms/published", **self._auth(self.b["user"])
+            "/api/v1/forms/published", **self.auth(self.b["user"])
         )
         ids = [f["id"] for f in res.json()]
         self.assertIn(self.b["form"].id, ids)
@@ -67,13 +35,13 @@ class FormsTenantIsolationTestCase(TestCase):
     def test_web_form_404_on_foreign_form(self):
         res = self.client.get(
             f"/api/v1/form/web/{self.b['form'].id}",
-            **self._auth(self.a["user"]),
+            **self.auth(self.a["user"]),
         )
         self.assertEqual(res.status_code, 404)
 
     def test_form_builder_list_excludes_other_tenant(self):
         res = self.client.get(
-            "/api/v1/manage/forms", **self._auth(self.a["user"])
+            "/api/v1/manage/forms", **self.auth(self.a["user"])
         )
         self.assertEqual(res.status_code, 200)
         ids = [f["id"] for f in res.json()["data"]]

--- a/backend/api/v1/v1_forms/views.py
+++ b/backend/api/v1/v1_forms/views.py
@@ -313,7 +313,7 @@ def list_published_forms(request, version):
 @api_view(["GET"])
 @permission_classes([IsAuthenticated])
 def web_form_details(request, version, form_id):
-    administration = Administration.objects.filter(
+    administration = Administration.objects.for_user(request.user).filter(
         parent__isnull=True,
     ).first()
     if not request.user.is_superuser:

--- a/backend/api/v1/v1_forms/views.py
+++ b/backend/api/v1/v1_forms/views.py
@@ -274,10 +274,10 @@ def _to_editor_format(data):
 )
 @api_view(["GET"])
 def list_form(request, version):
-    instance = Forms.objects.filter(
+    instance = Forms.objects.for_user(request.user).filter(
         parent__isnull=True,
         status=FormStatus.published,
-    ).all()
+    )
     return Response(
         ListFormSerializer(instance=instance, many=True).data,
         status=status.HTTP_200_OK,
@@ -298,7 +298,7 @@ def list_form(request, version):
 @permission_classes([AllowAny])
 def list_published_forms(request, version):
     response = Response(
-        get_published_forms_payload(),
+        get_published_forms_payload(request.user),
         status=status.HTTP_200_OK,
     )
     response["Cache-Control"] = "no-cache"
@@ -322,7 +322,9 @@ def web_form_details(request, version, form_id):
         ).first()
         if user_role:
             administration = user_role.administration
-    instance = get_object_or_404(Forms, pk=form_id)
+    instance = get_object_or_404(
+        Forms.objects.for_user(request.user), pk=form_id
+    )
     # Include form.version in the cache key so that publishing, activating,
     # or editing a published form (which bumps the version) automatically
     # bypasses the stale cache entry without an explicit cache clear.
@@ -346,7 +348,9 @@ def web_form_details(request, version, form_id):
 )
 @api_view(["GET"])
 def form_data(request, version, form_id):
-    instance = get_object_or_404(Forms, pk=form_id)
+    instance = get_object_or_404(
+        Forms.objects.for_user(request.user), pk=form_id
+    )
     cache_name = f"form-{form_id}-v{instance.version}"
     cache_data = get_cache(cache_name)
     if cache_data:
@@ -419,7 +423,9 @@ def form_approver(request, version):
 @api_view(["GET"])
 @permission_classes([IsAuthenticated])
 def check_form_approver(request, form_id, version):
-    form = get_object_or_404(Forms, pk=form_id)
+    form = get_object_or_404(
+        Forms.objects.for_user(request.user), pk=form_id
+    )
     # Super admins bypass approver check
     if request.user.is_superuser:
         return Response({"count": 1}, status=status.HTTP_200_OK)
@@ -488,8 +494,8 @@ class FormBuilderViewSet(viewsets.ModelViewSet):
         # archive/restore/destroy operate on archived (soft-deleted) rows,
         # which the default manager cannot see (D-9, D-10).
         if self.action in ("archive", "restore", "destroy"):
-            return Forms.objects_with_deleted.all()
-        return Forms.objects.all()
+            return Forms.objects_with_deleted.for_user(self.request.user)
+        return Forms.objects.for_user(self.request.user)
 
     def get_serializer_class(self):
         if self.action == "list":
@@ -518,7 +524,7 @@ class FormBuilderViewSet(viewsets.ModelViewSet):
         status_param = params.get("status")
 
         base = Forms.objects_deleted if archived else Forms.objects
-        qs = base.all()
+        qs = base.for_user(request.user)
         if status_param in self._STATUS_MAP:
             qs = qs.filter(status=self._STATUS_MAP[status_param])
 

--- a/backend/api/v1/v1_jobs/models.py
+++ b/backend/api/v1/v1_jobs/models.py
@@ -1,11 +1,15 @@
 from django.db import models
 
+from utils.tenant_scoped_model import TenantManager
+
 # Create your models here.
 from api.v1.v1_jobs.constants import JobTypes, JobStatus
 from api.v1.v1_users.models import SystemUser
 
 
 class Jobs(models.Model):
+    TENANT_PATH = "user__tenant"
+    objects = TenantManager()
     task_id = models.CharField(
         max_length=50, unique=True, null=True, default=None
     )

--- a/backend/api/v1/v1_jobs/views.py
+++ b/backend/api/v1/v1_jobs/views.py
@@ -302,7 +302,7 @@ def upload_excel(request, form_id, version):
     form_name = re.sub(r"[\W_]+", "_", form.name)
     filename = f"{form_name}-{user_name}-{uuid}.xlsx"
     storage.upload(file=file_path, filename=filename, folder="upload")
-    adm = Administration.objects.filter(
+    adm = Administration.objects.for_user(request.user).filter(
         parent__isnull=True
     ).first()
     if (

--- a/backend/api/v1/v1_mobile/models.py
+++ b/backend/api/v1/v1_mobile/models.py
@@ -3,9 +3,10 @@ from api.v1.v1_users.models import SystemUser
 from api.v1.v1_profile.models import Administration
 from api.v1.v1_forms.models import Forms
 from utils.custom_helper import generate_random_string, CustomPasscode
+from utils.tenant_scoped_model import TenantManager
 
 
-class MobileAssignmentManager(models.Manager):
+class MobileAssignmentManager(TenantManager):
     def create_assignment(self, user, name, passcode=None):
         if not passcode:
             passcode = generate_random_string(8)
@@ -18,6 +19,7 @@ class MobileAssignmentManager(models.Manager):
 
 
 class MobileAssignment(models.Model):
+    TENANT_PATH = "user__tenant"
     name = models.CharField(max_length=255, null=True, blank=True)
     passcode = models.CharField(max_length=256)
     user = models.ForeignKey(

--- a/backend/api/v1/v1_mobile/tests/tests_tenant_isolation.py
+++ b/backend/api/v1/v1_mobile/tests/tests_tenant_isolation.py
@@ -1,0 +1,69 @@
+from django.test import TestCase
+from django.test.utils import override_settings
+from rest_framework_simplejwt.tokens import RefreshToken
+
+from api.v1.v1_data.models import FormData
+from api.v1.v1_forms.models import Forms
+from api.v1.v1_mobile.models import MobileAssignment
+from api.v1.v1_profile.models import Administration, Levels
+from api.v1.v1_users.models import SystemUser, Tenant
+
+
+@override_settings(USE_TZ=False)
+class MobileTenantIsolationTestCase(TestCase):
+    def _tenant(self, sub):
+        tenant = Tenant.objects.create(subdomain=sub)
+        level = Levels.objects.create(name="", level=0, tenant=tenant)
+        child_level = Levels.objects.create(
+            name="district", level=1, tenant=tenant
+        )
+        root = Administration.objects.create(
+            parent=None, level=level, name=sub, tenant=tenant
+        )
+        child = Administration.objects.create(
+            parent=root, level=child_level, name=f"{sub}-d", tenant=tenant
+        )
+        user = SystemUser.objects.create_superuser(
+            email=f"admin@{sub}.org", password="Secret#Pass123",
+            first_name="A", last_name="A", tenant=tenant,
+        )
+        form = Forms.objects.create(name=f"{sub}-form", tenant=tenant)
+        data = FormData.objects.create(
+            name=f"{sub}-dp", form=form, administration=child,
+            created_by=user,
+        )
+        assignment = MobileAssignment.objects.create_assignment(
+            user=user, name=f"{sub}-device"
+        )
+        assignment.administrations.add(child)
+        assignment.forms.add(form)
+        return {
+            "tenant": tenant, "user": user, "form": form, "data": data,
+            "assignment": assignment,
+        }
+
+    def _auth(self, user):
+        return {
+            "HTTP_AUTHORIZATION":
+                f"Bearer {RefreshToken.for_user(user).access_token}"
+        }
+
+    def setUp(self):
+        self.a = self._tenant("acme")
+        self.b = self._tenant("beta")
+
+    def test_mobile_assignment_list_excludes_other_tenant(self):
+        res = self.client.get(
+            "/api/v1/mobile-assignments", **self._auth(self.a["user"])
+        )
+        self.assertEqual(res.status_code, 200)
+        names = [m["name"] for m in res.json()["data"]]
+        self.assertIn(self.a["assignment"].name, names)
+        self.assertNotIn(self.b["assignment"].name, names)
+
+    def test_datapoint_detail_404_on_foreign_object(self):
+        res = self.client.get(
+            f"/api/v1/maps/datapoint/{self.b['data'].id}",
+            **self._auth(self.a["user"]),
+        )
+        self.assertEqual(res.status_code, 404)

--- a/backend/api/v1/v1_mobile/tests/tests_tenant_isolation.py
+++ b/backend/api/v1/v1_mobile/tests/tests_tenant_isolation.py
@@ -1,60 +1,31 @@
-from django.test import TestCase
 from django.test.utils import override_settings
-from rest_framework_simplejwt.tokens import RefreshToken
 
 from api.v1.v1_data.models import FormData
-from api.v1.v1_forms.models import Forms
 from api.v1.v1_mobile.models import MobileAssignment
-from api.v1.v1_profile.models import Administration, Levels
-from api.v1.v1_users.models import SystemUser, Tenant
+from utils.tenant_test_case import TenantIsolationTestCase
 
 
 @override_settings(USE_TZ=False)
-class MobileTenantIsolationTestCase(TestCase):
-    def _tenant(self, sub):
-        tenant = Tenant.objects.create(subdomain=sub)
-        level = Levels.objects.create(name="", level=0, tenant=tenant)
-        child_level = Levels.objects.create(
-            name="district", level=1, tenant=tenant
-        )
-        root = Administration.objects.create(
-            parent=None, level=level, name=sub, tenant=tenant
-        )
-        child = Administration.objects.create(
-            parent=root, level=child_level, name=f"{sub}-d", tenant=tenant
-        )
-        user = SystemUser.objects.create_superuser(
-            email=f"admin@{sub}.org", password="Secret#Pass123",
-            first_name="A", last_name="A", tenant=tenant,
-        )
-        form = Forms.objects.create(name=f"{sub}-form", tenant=tenant)
-        data = FormData.objects.create(
-            name=f"{sub}-dp", form=form, administration=child,
-            created_by=user,
+class MobileTenantIsolationTestCase(TenantIsolationTestCase):
+    def make_tenant(self, sub):
+        tenant = super().make_tenant(sub)
+        tenant["data"] = FormData.objects.create(
+            name=f"{sub}-dp",
+            form=tenant["form"],
+            administration=tenant["child"],
+            created_by=tenant["user"],
         )
         assignment = MobileAssignment.objects.create_assignment(
-            user=user, name=f"{sub}-device"
+            user=tenant["user"], name=f"{sub}-device"
         )
-        assignment.administrations.add(child)
-        assignment.forms.add(form)
-        return {
-            "tenant": tenant, "user": user, "form": form, "data": data,
-            "assignment": assignment,
-        }
-
-    def _auth(self, user):
-        return {
-            "HTTP_AUTHORIZATION":
-                f"Bearer {RefreshToken.for_user(user).access_token}"
-        }
-
-    def setUp(self):
-        self.a = self._tenant("acme")
-        self.b = self._tenant("beta")
+        assignment.administrations.add(tenant["child"])
+        assignment.forms.add(tenant["form"])
+        tenant["assignment"] = assignment
+        return tenant
 
     def test_mobile_assignment_list_excludes_other_tenant(self):
         res = self.client.get(
-            "/api/v1/mobile-assignments", **self._auth(self.a["user"])
+            "/api/v1/mobile-assignments", **self.auth(self.a["user"])
         )
         self.assertEqual(res.status_code, 200)
         names = [m["name"] for m in res.json()["data"]]
@@ -64,6 +35,6 @@ class MobileTenantIsolationTestCase(TestCase):
     def test_datapoint_detail_404_on_foreign_object(self):
         res = self.client.get(
             f"/api/v1/maps/datapoint/{self.b['data'].id}",
-            **self._auth(self.a["user"]),
+            **self.auth(self.a["user"]),
         )
         self.assertEqual(res.status_code, 404)

--- a/backend/api/v1/v1_mobile/views.py
+++ b/backend/api/v1/v1_mobile/views.py
@@ -137,8 +137,10 @@ def get_mobile_forms(request, version):
 @api_view(["GET"])
 @permission_classes([IsMobileAssignment])
 def get_mobile_form_details(request: Request, version, form_id):
-    instance = get_object_or_404(Forms, pk=form_id)
     assignment = cast(MobileAssignmentToken, request.auth).assignment
+    instance = get_object_or_404(
+        Forms.objects.for_user(assignment.user), pk=form_id
+    )
     data = WebFormDetailSerializer(
         instance=instance,
         context={
@@ -190,8 +192,11 @@ def sync_pending_form_data(request, version):
             },
             status=status.HTTP_400_BAD_REQUEST,
         )
-    form = get_object_or_404(Forms, pk=request.data.get("formId"))
     assignment = cast(MobileAssignmentToken, request.auth).assignment
+    form = get_object_or_404(
+        Forms.objects.for_user(assignment.user),
+        pk=request.data.get("formId"),
+    )
     user = assignment.user
     administration = assignment.administrations.order_by(
         "level__level"
@@ -567,12 +572,12 @@ class MobileAssignmentViewSet(ModelViewSet):
     def get_queryset(self):
         user = self.request.user
         search = getattr(self, "_validated_search", None)
-        mobile_users = MobileAssignment.objects.prefetch_related(
-            "administrations", "forms"
-        ).filter(user=user)
+        mobile_users = MobileAssignment.objects.for_user(
+            user
+        ).prefetch_related("administrations", "forms").filter(user=user)
         adm_q = Q()
         if user.is_superuser:
-            adm = Administration.objects.filter(
+            adm = Administration.objects.for_user(user).filter(
                 parent__isnull=True
             ).first()
             adm_q = Q(
@@ -586,7 +591,9 @@ class MobileAssignmentViewSet(ModelViewSet):
                 if adm.path else f"{adm.id}."
             adm_q |= Q(administrations__path__startswith=path)
         if adm_q:
-            descendant_users = MobileAssignment.objects.prefetch_related(
+            descendant_users = MobileAssignment.objects.for_user(
+                user
+            ).prefetch_related(
                 "administrations", "forms"
             ).filter(adm_q)
             mobile_users |= descendant_users
@@ -722,7 +729,7 @@ def get_datapoint_download_list(request, version):
             administration__path__startswith=admin["path"]
         )
     # Combine both queries with the form filter
-    queryset = FormData.objects.filter(
+    queryset = FormData.objects.for_user(assignment.user).filter(
         admin_id_query | (path_query & Q(form_id__in=forms))
     )
     if assignment.last_synced_at:
@@ -779,6 +786,6 @@ class DraftFormDataViewSet(ModelViewSet):
 
     def get_queryset(self):
         user = self.request.auth.assignment.user
-        return FormData.objects_draft.filter(
+        return FormData.objects_draft.for_user(user).filter(
             created_by=user
         ).order_by("-created")

--- a/backend/api/v1/v1_profile/models.py
+++ b/backend/api/v1/v1_profile/models.py
@@ -9,9 +9,12 @@ from api.v1.v1_profile.constants import (
 )
 from api.v1.v1_users.models import SystemUser
 from utils.tenant_model import tenant_fk
+from utils.tenant_scoped_model import TenantManager
 
 
 class Levels(models.Model):
+    TENANT_PATH = "tenant"
+    objects = TenantManager()
     name = models.CharField(max_length=50)
     level = models.IntegerField()
     tenant = tenant_fk("levels")
@@ -30,6 +33,8 @@ class Levels(models.Model):
 
 
 class Administration(models.Model):
+    TENANT_PATH = "tenant"
+    objects = TenantManager()
     parent = models.ForeignKey(
         "self",
         on_delete=models.PROTECT,
@@ -102,6 +107,9 @@ def set_administration_path(sender, instance: Administration, **_):
 
 
 class AdministrationAttribute(models.Model):
+    TENANT_PATH = "tenant"
+    objects = TenantManager()
+
     class Type(models.TextChoices):
         VALUE = "value", "Value"
         OPTION = "option", "Option"
@@ -122,6 +130,8 @@ class AdministrationAttribute(models.Model):
 
 
 class AdministrationAttributeValue(models.Model):
+    TENANT_PATH = "administration__tenant"
+    objects = TenantManager()
     administration = models.ForeignKey(
         to=Administration, on_delete=models.CASCADE, related_name="attributes"
     )
@@ -135,6 +145,8 @@ class AdministrationAttributeValue(models.Model):
 
 
 class Entity(models.Model):
+    TENANT_PATH = "tenant"
+    objects = TenantManager()
     name = models.TextField()
     tenant = tenant_fk("entities")
 
@@ -143,6 +155,8 @@ class Entity(models.Model):
 
 
 class EntityData(models.Model):
+    TENANT_PATH = "entity__tenant"
+    objects = TenantManager()
     name = models.TextField()
     code = models.CharField(max_length=255, null=True, default=None)
     entity = models.ForeignKey(
@@ -160,6 +174,8 @@ class EntityData(models.Model):
 
 
 class Role(models.Model):
+    TENANT_PATH = "administration_level__tenant"
+    objects = TenantManager()
     name = models.CharField(max_length=100, unique=True)
     description = models.TextField(null=True, blank=True)
     administration_level = models.ForeignKey(
@@ -218,6 +234,8 @@ class RoleFeatureAccess(models.Model):
 
 
 class UserRole(models.Model):
+    TENANT_PATH = "user__tenant"
+    objects = TenantManager()
     user = models.ForeignKey(
         to=SystemUser,
         on_delete=models.CASCADE,

--- a/backend/api/v1/v1_profile/tests/test_config_js.py
+++ b/backend/api/v1/v1_profile/tests/test_config_js.py
@@ -28,5 +28,17 @@ class ConfigJS(TestCase):
             content = f.read()
         os.remove(config_path)
         self.assertNotIn("var topojson", content)
-        for expected in ("var levels", "var appConfig", "var roleFeatures"):
+        # levels left the bake too once they became tenant-owned; what
+        # stays is per-deployment, not per-tenant.
+        for expected in ("var appConfig", "var roleFeatures"):
             self.assertIn(expected, content)
+
+    def test_config_has_no_levels_block(self):
+        administration_seeder.seed_administration_test()
+        if Path(config_path).exists():
+            os.remove(config_path)
+        self.client.get("/api/v1/config.js", follow=True)
+        with open(config_path) as f:
+            content = f.read()
+        os.remove(config_path)
+        self.assertNotIn("var levels", content)

--- a/backend/api/v1/v1_profile/tests/test_for_user_mechanism.py
+++ b/backend/api/v1/v1_profile/tests/test_for_user_mechanism.py
@@ -1,0 +1,57 @@
+from django.test import TestCase
+from django.test.utils import override_settings
+
+from api.v1.v1_profile.models import Administration, Levels
+from api.v1.v1_forms.models import Forms
+from api.v1.v1_users.models import Organisation, SystemUser, Tenant
+
+
+@override_settings(USE_TZ=False)
+class ForUserMechanismTestCase(TestCase):
+    def setUp(self):
+        self.acme = Tenant.objects.create(subdomain="acme")
+        self.beta = Tenant.objects.create(subdomain="beta")
+        self.acme_user = SystemUser.objects.create_superuser(
+            email="a@acme.org", password="Secret#Pass123",
+            first_name="A", last_name="A", tenant=self.acme,
+        )
+        self.acme_level = Levels.objects.create(
+            name="", level=0, tenant=self.acme
+        )
+        self.beta_level = Levels.objects.create(
+            name="", level=0, tenant=self.beta
+        )
+        self.acme_root = Administration.objects.create(
+            parent=None, level=self.acme_level, name="acme", tenant=self.acme
+        )
+        Administration.objects.create(
+            parent=None, level=self.beta_level, name="beta", tenant=self.beta
+        )
+        self.acme_form = Forms.objects.create(name="F", tenant=self.acme)
+        Forms.objects.create(name="G", tenant=self.beta)
+        Organisation.objects.create(name="Org", tenant=self.acme)
+        Organisation.objects.create(name="Org2", tenant=self.beta)
+
+    def test_direct_fk_model_scopes_to_tenant(self):
+        levels = Levels.objects.for_user(self.acme_user)
+        self.assertEqual(list(levels), [self.acme_level])
+
+    def test_forms_scope_to_tenant(self):
+        self.assertEqual(
+            list(Forms.objects.for_user(self.acme_user)), [self.acme_form]
+        )
+
+    def test_organisation_scopes_to_tenant(self):
+        self.assertEqual(
+            Organisation.objects.for_user(self.acme_user).count(), 1
+        )
+
+    def test_tenantless_user_matches_tenantless_rows(self):
+        Levels.objects.create(name="legacy", level=0)  # tenant is NULL
+        legacy = SystemUser.objects.create_superuser(
+            email="legacy@x.org", password="Secret#Pass123",
+            first_name="L", last_name="L",
+        )
+        scoped = Levels.objects.for_user(legacy)
+        self.assertEqual(scoped.count(), 1)
+        self.assertTrue(all(lv.tenant_id is None for lv in scoped))

--- a/backend/api/v1/v1_profile/urls.py
+++ b/backend/api/v1/v1_profile/urls.py
@@ -5,7 +5,6 @@ from api.v1.v1_profile.views import (
     AdministrationViewSet,
     EntityDataViewSet,
     EntityViewSet,
-    PublicAdministrationViewSet,
     RoleViewSet,
     export_administrations_template,
     export_prefilled_administrations_template,
@@ -73,24 +72,6 @@ urlpatterns = [
             }
         ),
         name="administration-attribute-list",
-    ),
-    re_path(
-        r"^(?P<version>(v1))/public/administrations/(?P<pk>[0-9]+)",
-        PublicAdministrationViewSet.as_view(
-            {
-                "get": "retrieve",
-            }
-        ),
-        name="public-administrations-detail",
-    ),
-    re_path(
-        r"^(?P<version>(v1))/public/administrations",
-        PublicAdministrationViewSet.as_view(
-            {
-                "get": "list",
-            }
-        ),
-        name="public-administrations-list",
     ),
     re_path(
         r"^(?P<version>(v1))/administrations/(?P<pk>[0-9]+)",

--- a/backend/api/v1/v1_profile/views.py
+++ b/backend/api/v1/v1_profile/views.py
@@ -14,7 +14,7 @@ from drf_spectacular.utils import (
     inline_serializer,
 )
 from rest_framework.request import Request
-from rest_framework.viewsets import ModelViewSet, ReadOnlyModelViewSet
+from rest_framework.viewsets import ModelViewSet
 from api.v1.v1_profile.models import (
     Administration,
     AdministrationAttribute,
@@ -47,7 +47,7 @@ from utils.custom_pagination import Pagination
 from rest_framework.decorators import api_view, permission_classes
 from rest_framework import serializers, status
 from rest_framework.response import Response
-from rest_framework.permissions import IsAuthenticated, AllowAny
+from rest_framework.permissions import IsAuthenticated
 from utils.email_helper import send_email, EmailTypes
 from utils.custom_serializer_fields import validate_serializers_message
 from utils.custom_generator import administration_csv_delete
@@ -95,7 +95,7 @@ def send_feedback(request, version):
 )
 @api_view(["GET"])
 def list_entity_data(request, version, entity_id, administration_id):
-    instance = EntityData.objects.filter(
+    instance = EntityData.objects.for_user(request.user).filter(
         entity__id=entity_id, administration__id=administration_id
     ).all()
     return Response(
@@ -111,7 +111,9 @@ class AdministrationViewSet(ModelViewSet):
     pagination_class = Pagination
 
     def get_queryset(self):
-        queryset = Administration.objects.select_related(
+        queryset = Administration.objects.for_user(
+            self.request.user
+        ).select_related(
             'level'
         ).prefetch_related(
             'parent_administration',
@@ -187,37 +189,16 @@ class AdministrationViewSet(ModelViewSet):
         return Response(status=status.HTTP_204_NO_CONTENT)
 
 
-@extend_schema(tags=["Public"])
-class PublicAdministrationViewSet(ReadOnlyModelViewSet):
-    serializer_class = AdministrationSerializer
-    permission_classes = [AllowAny]
-    pagination_class = None
-
-    def get_queryset(self):
-        queryset = Administration.objects.select_related(
-            'level'
-        ).prefetch_related(
-            'parent_administration',
-        ).all()
-
-        parent_id = self.request.query_params.get("parent")
-        if parent_id:
-            queryset = queryset.filter(parent_id=parent_id)
-
-        return queryset.order_by("id")
-
-    def get_serializer(self, *args, **kwargs):
-        if self.action == "list":
-            kwargs.update({"compact": True})
-        return super().get_serializer(*args, **kwargs)
-
-
 @extend_schema(tags=["Administration"])
 class AdministrationAttributeViewSet(ModelViewSet):
-    queryset = AdministrationAttribute.objects.order_by("id").all()
     serializer_class = AdministrationAttributeSerializer
     permission_classes = [IsAuthenticated]
     pagination_class = None
+
+    def get_queryset(self):
+        return AdministrationAttribute.objects.for_user(
+            self.request.user
+        ).order_by("id")
 
 
 @extend_schema(tags=["Entities"])
@@ -227,7 +208,7 @@ class EntityViewSet(ModelViewSet):
     pagination_class = Pagination
 
     def get_queryset(self):
-        queryset = Entity.objects.all()
+        queryset = Entity.objects.for_user(self.request.user)
         search = self.request.query_params.get("search")
         if search:
             queryset = queryset.filter(name__icontains=search)
@@ -241,7 +222,9 @@ class EntityDataViewSet(ModelViewSet):
     pagination_class = Pagination
 
     def get_queryset(self):
-        queryset = EntityData.objects.select_related(
+        queryset = EntityData.objects.for_user(
+            self.request.user
+        ).select_related(
             "administration", "entity"
         ).all()
         search = self.request.query_params.get("search")
@@ -524,7 +507,9 @@ class RoleViewSet(ModelViewSet):
     pagination_class = Pagination
 
     def get_queryset(self):
-        queryset = Role.objects.order_by("administration_level__level")
+        queryset = Role.objects.for_user(self.request.user).order_by(
+            "administration_level__level"
+        )
         search = self.request.query_params.get("search")
         if search:
             queryset = queryset.filter(name__icontains=search)

--- a/backend/api/v1/v1_users/models.py
+++ b/backend/api/v1/v1_users/models.py
@@ -5,6 +5,7 @@ from django.core import signing
 from django.db import models
 from django.utils import timezone
 from utils.soft_deletes_model import SoftDeletes
+from utils.tenant_scoped_model import TenantManager
 from utils.tenant_model import tenant_fk
 
 # Create your models here.
@@ -12,6 +13,8 @@ from utils.custom_manager import UserManager
 
 
 class Organisation(models.Model):
+    TENANT_PATH = "tenant"
+    objects = TenantManager()
     name = models.CharField(max_length=255)
     tenant = tenant_fk("organisations")
 
@@ -59,6 +62,7 @@ class Tenant(models.Model):
 
 
 class SystemUser(AbstractBaseUser, PermissionsMixin, SoftDeletes):
+    TENANT_PATH = "tenant"
     email = models.EmailField(max_length=254, unique=True)
     date_joined = models.DateTimeField(auto_now_add=True)
     first_name = models.CharField(max_length=50)

--- a/backend/api/v1/v1_users/tests/tests_tenant_isolation.py
+++ b/backend/api/v1/v1_users/tests/tests_tenant_isolation.py
@@ -1,42 +1,21 @@
-from django.test import TestCase
 from django.test.utils import override_settings
 from django.urls import NoReverseMatch, reverse
-from rest_framework_simplejwt.tokens import RefreshToken
 
-from api.v1.v1_profile.models import Administration, Levels
-from api.v1.v1_users.models import Organisation, SystemUser, Tenant
+from api.v1.v1_users.models import Organisation
+from utils.tenant_test_case import TenantIsolationTestCase
 
 
 @override_settings(USE_TZ=False)
-class UsersTenantIsolationTestCase(TestCase):
-    def _tenant(self, sub):
-        tenant = Tenant.objects.create(subdomain=sub)
-        level = Levels.objects.create(name="", level=0, tenant=tenant)
-        root = Administration.objects.create(
-            parent=None, level=level, name=sub, tenant=tenant
+class UsersTenantIsolationTestCase(TenantIsolationTestCase):
+    def make_tenant(self, sub):
+        tenant = super().make_tenant(sub)
+        tenant["org"] = Organisation.objects.create(
+            name=f"{sub}-org", tenant=tenant["tenant"]
         )
-        user = SystemUser.objects.create_superuser(
-            email=f"admin@{sub}.org", password="Secret#Pass123",
-            first_name="A", last_name="A", tenant=tenant,
-        )
-        org = Organisation.objects.create(name=f"{sub}-org", tenant=tenant)
-        return {
-            "tenant": tenant, "user": user, "root": root,
-            "level": level, "org": org,
-        }
-
-    def _auth(self, user):
-        return {
-            "HTTP_AUTHORIZATION":
-                f"Bearer {RefreshToken.for_user(user).access_token}"
-        }
-
-    def setUp(self):
-        self.a = self._tenant("acme")
-        self.b = self._tenant("beta")
+        return tenant
 
     def test_user_list_excludes_other_tenant(self):
-        res = self.client.get("/api/v1/users", **self._auth(self.a["user"]))
+        res = self.client.get("/api/v1/users", **self.auth(self.a["user"]))
         self.assertEqual(res.status_code, 200)
         emails = [u["email"] for u in res.json()["data"]]
         self.assertIn(self.a["user"].email, emails)
@@ -44,24 +23,23 @@ class UsersTenantIsolationTestCase(TestCase):
 
     def test_user_detail_404_on_foreign_user(self):
         res = self.client.get(
-            f"/api/v1/user/{self.b['user'].id}", **self._auth(self.a["user"])
+            f"/api/v1/user/{self.b['user'].id}", **self.auth(self.a["user"])
         )
         self.assertEqual(res.status_code, 404)
 
     def test_organisation_list_excludes_other_tenant(self):
         res = self.client.get(
-            "/api/v1/organisations", **self._auth(self.a["user"])
+            "/api/v1/organisations", **self.auth(self.a["user"])
         )
         self.assertEqual(res.status_code, 200)
         body = res.json()
-        names = [o["name"] for o in (body.get("data", body) if isinstance(
-            body, dict
-        ) else body)]
+        rows = body.get("data", body) if isinstance(body, dict) else body
+        names = [o["name"] for o in rows]
         self.assertIn(self.a["org"].name, names)
         self.assertNotIn(self.b["org"].name, names)
 
     def test_levels_list_excludes_other_tenant(self):
-        res = self.client.get("/api/v1/levels", **self._auth(self.a["user"]))
+        res = self.client.get("/api/v1/levels", **self.auth(self.a["user"]))
         self.assertEqual(res.status_code, 200)
         ids = [lv["id"] for lv in res.json()]
         self.assertIn(self.a["level"].id, ids)
@@ -70,7 +48,7 @@ class UsersTenantIsolationTestCase(TestCase):
     def test_administration_detail_404_on_foreign_root(self):
         res = self.client.get(
             f"/api/v1/administration/{self.b['root'].id}",
-            **self._auth(self.a["user"]),
+            **self.auth(self.a["user"]),
         )
         self.assertEqual(res.status_code, 404)
 

--- a/backend/api/v1/v1_users/tests/tests_tenant_isolation.py
+++ b/backend/api/v1/v1_users/tests/tests_tenant_isolation.py
@@ -1,0 +1,83 @@
+from django.test import TestCase
+from django.test.utils import override_settings
+from django.urls import NoReverseMatch, reverse
+from rest_framework_simplejwt.tokens import RefreshToken
+
+from api.v1.v1_profile.models import Administration, Levels
+from api.v1.v1_users.models import Organisation, SystemUser, Tenant
+
+
+@override_settings(USE_TZ=False)
+class UsersTenantIsolationTestCase(TestCase):
+    def _tenant(self, sub):
+        tenant = Tenant.objects.create(subdomain=sub)
+        level = Levels.objects.create(name="", level=0, tenant=tenant)
+        root = Administration.objects.create(
+            parent=None, level=level, name=sub, tenant=tenant
+        )
+        user = SystemUser.objects.create_superuser(
+            email=f"admin@{sub}.org", password="Secret#Pass123",
+            first_name="A", last_name="A", tenant=tenant,
+        )
+        org = Organisation.objects.create(name=f"{sub}-org", tenant=tenant)
+        return {
+            "tenant": tenant, "user": user, "root": root,
+            "level": level, "org": org,
+        }
+
+    def _auth(self, user):
+        return {
+            "HTTP_AUTHORIZATION":
+                f"Bearer {RefreshToken.for_user(user).access_token}"
+        }
+
+    def setUp(self):
+        self.a = self._tenant("acme")
+        self.b = self._tenant("beta")
+
+    def test_user_list_excludes_other_tenant(self):
+        res = self.client.get("/api/v1/users", **self._auth(self.a["user"]))
+        self.assertEqual(res.status_code, 200)
+        emails = [u["email"] for u in res.json()["data"]]
+        self.assertIn(self.a["user"].email, emails)
+        self.assertNotIn(self.b["user"].email, emails)
+
+    def test_user_detail_404_on_foreign_user(self):
+        res = self.client.get(
+            f"/api/v1/user/{self.b['user'].id}", **self._auth(self.a["user"])
+        )
+        self.assertEqual(res.status_code, 404)
+
+    def test_organisation_list_excludes_other_tenant(self):
+        res = self.client.get(
+            "/api/v1/organisations", **self._auth(self.a["user"])
+        )
+        self.assertEqual(res.status_code, 200)
+        body = res.json()
+        names = [o["name"] for o in (body.get("data", body) if isinstance(
+            body, dict
+        ) else body)]
+        self.assertIn(self.a["org"].name, names)
+        self.assertNotIn(self.b["org"].name, names)
+
+    def test_levels_list_excludes_other_tenant(self):
+        res = self.client.get("/api/v1/levels", **self._auth(self.a["user"]))
+        self.assertEqual(res.status_code, 200)
+        ids = [lv["id"] for lv in res.json()]
+        self.assertIn(self.a["level"].id, ids)
+        self.assertNotIn(self.b["level"].id, ids)
+
+    def test_administration_detail_404_on_foreign_root(self):
+        res = self.client.get(
+            f"/api/v1/administration/{self.b['root'].id}",
+            **self._auth(self.a["user"]),
+        )
+        self.assertEqual(res.status_code, 404)
+
+    def test_public_administration_endpoint_is_gone(self):
+        # Deleted rather than scoped: it returned every tenant's units to
+        # anyone, and its only consumer was the authenticated form-builder.
+        with self.assertRaises(NoReverseMatch):
+            reverse("public-administrations-list")
+        res = self.client.get("/api/v1/public/administrations")
+        self.assertEqual(res.status_code, 404)

--- a/backend/api/v1/v1_users/views.py
+++ b/backend/api/v1/v1_users/views.py
@@ -421,12 +421,16 @@ def list_administration(request, version, administration_id):
 )
 @api_view(["GET"])
 def list_levels(request, version):
-    return Response(
+    response = Response(
         ListLevelSerializer(
             instance=Levels.objects.for_user(request.user), many=True
         ).data,
         status=status.HTTP_200_OK,
     )
+    # Levels are per-tenant and fetched at runtime now, so a cached copy
+    # would follow one tenant's tiers into another's session.
+    response["Cache-Control"] = "no-cache"
+    return response
 
 
 @extend_schema(

--- a/backend/api/v1/v1_users/views.py
+++ b/backend/api/v1/v1_users/views.py
@@ -395,7 +395,9 @@ def set_user_password(request, version):
 )
 @api_view(["GET"])
 def list_administration(request, version, administration_id):
-    instance = get_object_or_404(Administration, pk=administration_id)
+    instance = get_object_or_404(
+        Administration.objects.for_user(request.user), pk=administration_id
+    )
     filter = request.GET.get("filter")
     max_level = request.GET.get("max_level")
     filter_children = request.GET.getlist("filter_children")
@@ -420,7 +422,9 @@ def list_administration(request, version, administration_id):
 @api_view(["GET"])
 def list_levels(request, version):
     return Response(
-        ListLevelSerializer(instance=Levels.objects.all(), many=True).data,
+        ListLevelSerializer(
+            instance=Levels.objects.for_user(request.user), many=True
+        ).data,
         status=status.HTTP_200_OK,
     )
 
@@ -625,7 +629,9 @@ def list_users(request, version):
     page_size = REST_FRAMEWORK.get("PAGE_SIZE")
     the_past = timezone.now() - datetime.timedelta(days=10 * 365)
     # also filter soft deletes
-    queryset = SystemUser.objects.filter(deleted_at=None, **filter_data)
+    queryset = SystemUser.objects.for_user(request.user).filter(
+        deleted_at=None, **filter_data
+    )
     # filter by email or fullname
     if serializer.validated_data.get("search"):
         search = serializer.validated_data.get("search")
@@ -683,7 +689,11 @@ class UserEditDeleteView(APIView):
         summary="To get user details",
     )
     def get(self, request, user_id, version):
-        instance = get_object_or_404(SystemUser, pk=user_id, deleted_at=None)
+        instance = get_object_or_404(
+            SystemUser.objects.for_user(request.user),
+            pk=user_id,
+            deleted_at=None,
+        )
         return Response(
             UserDetailSerializer(
                 instance=instance,
@@ -701,7 +711,9 @@ class UserEditDeleteView(APIView):
     )
     def delete(self, request, user_id, version):
         login_user = SystemUser.objects.get(email=request.user)
-        instance = get_object_or_404(SystemUser, pk=user_id)
+        instance = get_object_or_404(
+            SystemUser.objects.for_user(request.user), pk=user_id
+        )
         # prevent self deletion
         if login_user.id == instance.id:
             return Response(
@@ -719,7 +731,11 @@ class UserEditDeleteView(APIView):
         summary="To update user",
     )
     def put(self, request, user_id, version):
-        instance = get_object_or_404(SystemUser, pk=user_id, deleted_at=None)
+        instance = get_object_or_404(
+            SystemUser.objects.for_user(request.user),
+            pk=user_id,
+            deleted_at=None,
+        )
         serializer = AddEditUserSerializer(
             data=request.data,
             context={"user": request.user},
@@ -798,7 +814,7 @@ def list_organisations(request, version):
     attributes = request.GET.get("attributes")
     search = request.GET.get("search")
 
-    instance = Organisation.objects.prefetch_related(
+    instance = Organisation.objects.for_user(request.user).prefetch_related(
         'organisation_organisation_attribute'
     ).annotate(user_count=Count('user_organisation')).all()
 
@@ -856,7 +872,7 @@ class OrganisationEditDeleteView(APIView):
     )
     def get(self, request, organisation_id, version):
         instance = get_object_or_404(
-            Organisation.objects.annotate(
+            Organisation.objects.for_user(request.user).annotate(
                 user_count=Count('user_organisation')
             ),
             pk=organisation_id
@@ -874,7 +890,9 @@ class OrganisationEditDeleteView(APIView):
         summary="To delete organisation",
     )
     def delete(self, request, organisation_id, version):
-        instance = get_object_or_404(Organisation, pk=organisation_id)
+        instance = get_object_or_404(
+            Organisation.objects.for_user(request.user), pk=organisation_id
+        )
         instance.delete()
         return Response(status=status.HTTP_204_NO_CONTENT)
 
@@ -889,7 +907,9 @@ class OrganisationEditDeleteView(APIView):
         summary="To update organisation",
     )
     def put(self, request, organisation_id, version):
-        instance = get_object_or_404(Organisation, pk=organisation_id)
+        instance = get_object_or_404(
+            Organisation.objects.for_user(request.user), pk=organisation_id
+        )
         serializer = AddEditOrganisationSerializer(
             data=request.data,
             context={"attributes": request.data.get("attributes")},

--- a/backend/api/v1/v1_visualization/views.py
+++ b/backend/api/v1/v1_visualization/views.py
@@ -52,7 +52,9 @@ from utils.custom_serializer_fields import validate_serializers_message
 )
 @api_view(["GET"])
 def formdata_stats(request, form_id, version):
-    form = get_object_or_404(Forms, pk=form_id)
+    form = get_object_or_404(
+        Forms.objects.for_user(request.user), pk=form_id
+    )
     serializer = FormDataStatsFilterSerializer(
         data=request.GET,
         context={"form": form}
@@ -323,7 +325,9 @@ class GeolocationListView(APIView):
                 data=[],
                 status=status.HTTP_200_OK,
             )
-        form = get_object_or_404(Forms, pk=form_id)
+        form = get_object_or_404(
+            Forms.objects.for_user(request.user), pk=form_id
+        )
         queryset = form.form_form_data.filter(
             is_pending=False,
             is_draft=False,
@@ -418,7 +422,7 @@ class DatapointDetailView(APIView):
     )
     def get(self, request, data_id, version):
         point = get_object_or_404(
-            FormData, pk=data_id,
+            FormData.objects.for_user(request.user), pk=data_id,
             is_pending=False, is_draft=False, parent__isnull=True
         )
         return Response(
@@ -506,7 +510,9 @@ def visualization_values_formula(request, version):
         )
 
     validated = serializer.validated_data
-    form = get_object_or_404(Forms, pk=validated["form_id"])
+    form = get_object_or_404(
+        Forms.objects.for_user(request.user), pk=validated["form_id"]
+    )
     formula = validated["formula"]
     criteria = validated.get("criteria")
     from_date = validated.get("from_date")

--- a/backend/utils/draft_model.py
+++ b/backend/utils/draft_model.py
@@ -1,8 +1,9 @@
 from django.db import models
 from .soft_deletes_model import SoftDeletesQuerySet, SoftDeletesManager
+from .tenant_scoped_model import TenantScopedQuerySetMixin
 
 
-class DraftQuerySet(models.QuerySet):
+class DraftQuerySet(TenantScopedQuerySetMixin, models.QuerySet):
     def only_draft(self):
         return self.filter(is_draft=True)
 
@@ -39,6 +40,9 @@ class DraftManager(models.Manager):
 
     def draft(self):
         return DraftQuerySet(self.model).only_draft()
+
+    def for_user(self, user):
+        return self.get_queryset().for_user(user)
 
 
 class DraftSoftDeletesManager(SoftDeletesManager):

--- a/backend/utils/soft_deletes_model.py
+++ b/backend/utils/soft_deletes_model.py
@@ -1,8 +1,10 @@
 from django.db import models
 from django.utils import timezone
 
+from utils.tenant_scoped_model import TenantScopedQuerySetMixin
 
-class SoftDeletesQuerySet(models.QuerySet):
+
+class SoftDeletesQuerySet(TenantScopedQuerySetMixin, models.QuerySet):
     def only_deleted(self):
         return self.filter(deleted_at__isnull=False)
 
@@ -52,6 +54,9 @@ class SoftDeletesManager(models.Manager):
 
     def restore(self):
         return self.get_queryset().restore()
+
+    def for_user(self, user):
+        return self.get_queryset().for_user(user)
 
 
 class SoftDeletes(models.Model):

--- a/backend/utils/tenant_scoped_model.py
+++ b/backend/utils/tenant_scoped_model.py
@@ -1,0 +1,30 @@
+from django.db import models
+
+
+# =========================================================
+# Tenant scoping
+# =========================================================
+# Every tenant-owned model declares TENANT_PATH — the ORM lookup from the
+# model to its owning tenant. Direct-FK models use "tenant"; derived models
+# use a join, e.g. "form__tenant". for_user() applies it uniformly.
+#
+# A tenant-less user (user.tenant is None) filters on tenant IS NULL, which
+# matches tenant-less rows — the transitional state the test suite runs in.
+# The production invariant is that every user has a tenant.
+
+
+class TenantScopedQuerySetMixin:
+    def for_user(self, user):
+        return self.filter(**{self.model.TENANT_PATH: user.tenant})
+
+
+class TenantQuerySet(TenantScopedQuerySetMixin, models.QuerySet):
+    pass
+
+
+class TenantManager(models.Manager):
+    def get_queryset(self):
+        return TenantQuerySet(self.model, using=self._db)
+
+    def for_user(self, user):
+        return self.get_queryset().for_user(user)

--- a/backend/utils/tenant_scoped_model.py
+++ b/backend/utils/tenant_scoped_model.py
@@ -28,9 +28,9 @@ class TenantQuerySet(TenantScopedQuerySetMixin, models.QuerySet):
     pass
 
 
-class TenantManager(models.Manager):
-    def get_queryset(self):
-        return TenantQuerySet(self.model, using=self._db)
-
-    def for_user(self, user):
-        return self.get_queryset().for_user(user)
+# from_queryset copies for_user onto the manager, so plain-manager models
+# get Model.objects.for_user(...) without hand-written delegation. The
+# soft-deletes and draft managers cannot use this — their get_queryset
+# carries with_deleted/only_draft state a generated manager would drop —
+# so they delegate explicitly instead.
+TenantManager = models.Manager.from_queryset(TenantQuerySet)

--- a/backend/utils/tenant_scoped_model.py
+++ b/backend/utils/tenant_scoped_model.py
@@ -15,7 +15,13 @@ from django.db import models
 
 class TenantScopedQuerySetMixin:
     def for_user(self, user):
-        return self.filter(**{self.model.TENANT_PATH: user.tenant})
+        # AnonymousUser has no tenant attribute at all. Treat it as another
+        # tenant-less actor rather than letting it raise: on a real
+        # deployment every row is tenant-owned, so an anonymous caller
+        # matches nothing, which is the safe outcome for the handful of
+        # endpoints reachable without a token.
+        tenant = getattr(user, "tenant", None)
+        return self.filter(**{self.model.TENANT_PATH: tenant})
 
 
 class TenantQuerySet(TenantScopedQuerySetMixin, models.QuerySet):

--- a/backend/utils/tenant_test_case.py
+++ b/backend/utils/tenant_test_case.py
@@ -1,0 +1,53 @@
+from django.test import TestCase
+from rest_framework_simplejwt.tokens import RefreshToken
+
+from api.v1.v1_forms.constants import FormStatus
+from api.v1.v1_forms.models import Forms
+from api.v1.v1_profile.models import Administration, Levels
+from api.v1.v1_users.models import SystemUser, Tenant
+
+
+class TenantIsolationTestCase(TestCase):
+    """Two tenants, each with its own hierarchy, superadmin and form.
+
+    Every isolation test asks the same question — can tenant A reach
+    tenant B's rows — so the fixture lives here and each app extends
+    make_tenant with whatever it needs to answer that for its endpoints.
+    """
+
+    def make_tenant(self, sub):
+        tenant = Tenant.objects.create(subdomain=sub)
+        level = Levels.objects.create(name="", level=0, tenant=tenant)
+        child_level = Levels.objects.create(
+            name="district", level=1, tenant=tenant
+        )
+        root = Administration.objects.create(
+            parent=None, level=level, name=sub, tenant=tenant
+        )
+        # Datapoints hang off a child unit, not the root: list endpoints
+        # filter on administration__path__startswith, and a root's path
+        # is NULL, so data parked on the root is invisible to its owner.
+        child = Administration.objects.create(
+            parent=root, level=child_level, name=f"{sub}-d", tenant=tenant
+        )
+        user = SystemUser.objects.create_superuser(
+            email=f"admin@{sub}.org", password="Secret#Pass123",
+            first_name="A", last_name="A", tenant=tenant,
+        )
+        form = Forms.objects.create(
+            name=f"{sub}-form", tenant=tenant, status=FormStatus.published
+        )
+        return {
+            "tenant": tenant, "user": user, "form": form,
+            "root": root, "child": child, "level": level,
+        }
+
+    def auth(self, user):
+        return {
+            "HTTP_AUTHORIZATION":
+                f"Bearer {RefreshToken.for_user(user).access_token}"
+        }
+
+    def setUp(self):
+        self.a = self.make_tenant("acme")
+        self.b = self.make_tenant("beta")

--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -63,6 +63,7 @@ import { Layout, PageLoader } from "./components";
 import { useNotification } from "./util/hooks";
 import { eraseCookieFromAllPaths } from "./util/date";
 import { reloadData, fetchPublishedForms } from "./util/form";
+import { fetchLevels } from "./util/level";
 import { ability, AbilityContext } from "./components/can";
 
 const Private = ({ element: Element, alias }) => {
@@ -366,6 +367,7 @@ const App = () => {
   // bootstrap call made before sign-in returns nothing and the list has to
   // be rebuilt for the tenant once we know who is asking.
   useEffect(() => {
+    fetchLevels();
     fetchPublishedForms()
       .catch((err) => {
         console.error(err);

--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -367,6 +367,10 @@ const App = () => {
   // bootstrap call made before sign-in returns nothing and the list has to
   // be rebuilt for the tenant once we know who is asking.
   useEffect(() => {
+    // Re-gate on every refetch, not just the bootstrap one: without this the
+    // post-login pass leaves the old (empty, pre-tenant) list on screen while
+    // the tenant-scoped request is in flight.
+    setFormsLoading(true);
     fetchLevels();
     fetchPublishedForms()
       .catch((err) => {

--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -358,9 +358,13 @@ const App = () => {
     });
   }, [pageLocation]);
 
-  // Fetch published forms once at bootstrap (replaces the window.forms global
+  // Fetch published forms at bootstrap (replaces the window.forms global
   // baked into config.js). Gates render so dropdowns/dashboards never show an
   // empty list before the forms resolve.
+  //
+  // Refetched when auth changes: the endpoint is now tenant-scoped, so the
+  // bootstrap call made before sign-in returns nothing and the list has to
+  // be rebuilt for the tenant once we know who is asking.
   useEffect(() => {
     fetchPublishedForms()
       .catch((err) => {
@@ -369,7 +373,7 @@ const App = () => {
       .finally(() => {
         setFormsLoading(false);
       });
-  }, []);
+  }, [isLoggedIn]);
 
   useEffect(() => {
     if (!location.pathname.includes("/login")) {

--- a/frontend/src/components/visualisation/AdministrationChart.jsx
+++ b/frontend/src/components/visualisation/AdministrationChart.jsx
@@ -8,6 +8,7 @@ import { Chart } from "../../components";
 import PropTypes from "prop-types";
 import { Color } from "../../components/chart/options/common";
 import { generateAdvanceFilterURL } from "../../util/filter";
+import { getLevels } from "../../util/level";
 
 const getOptionColor = (name, index) => {
   return (
@@ -66,7 +67,7 @@ const AdministrationChart = ({ current, index }) => {
 
   const { next, wait } = queue.useState((q) => q);
   const runCall = index === next && !wait;
-  const loading = next <= index && administration.length < window.levels.length;
+  const loading = next <= index && administration.length < getLevels().length;
 
   const { id, title, stack, options, type, horizontal = true } = current;
   const selectedAdministration = takeRight(administration, 1)[0] || null;
@@ -82,7 +83,7 @@ const AdministrationChart = ({ current, index }) => {
       s.next = null;
     });
     const adminRes = (
-      selectedAdministration?.levelName === takeRight(window.levels, 1)[0]?.name
+      selectedAdministration?.levelName === takeRight(getLevels(), 1)[0]?.name
         ? takeRight(administration, 2)[0]
         : takeRight(administration, 1)[0]
     ).children?.find((c) => c.name.toLowerCase() === e.toLowerCase());
@@ -90,7 +91,7 @@ const AdministrationChart = ({ current, index }) => {
       store.update((s) => {
         if (
           selectedAdministration?.levelName ===
-          takeRight(window.levels, 1)[0]?.name
+          takeRight(getLevels(), 1)[0]?.name
         ) {
           s.administration.length = s.administration.length - 1;
         }
@@ -107,7 +108,7 @@ const AdministrationChart = ({ current, index }) => {
     if (
       administration.length === 1 ||
       (takeRight(administration, 1)[0]?.levelName !==
-        takeRight(window.levels, 1)[0]?.name &&
+        takeRight(getLevels(), 1)[0]?.name &&
         (parent === null ||
           (!!parent && !!takeRight(administration, 1)[0]?.parent)))
     ) {
@@ -194,7 +195,7 @@ const AdministrationChart = ({ current, index }) => {
 
   const highlighted = useMemo(() => {
     return selectedAdministration?.levelName ===
-      takeRight(window.levels, 1)[0]?.name
+      takeRight(getLevels(), 1)[0]?.name
       ? selectedAdministration.name
       : null;
   }, [selectedAdministration]);

--- a/frontend/src/lib/__test__/__snapshots__/store.test.js.snap
+++ b/frontend/src/lib/__test__/__snapshots__/store.test.js.snap
@@ -55,7 +55,28 @@ Object {
       "en": "English",
     },
   },
-  "levels": undefined,
+  "levels": Array [
+    Object {
+      "id": 1,
+      "level": 0,
+      "name": "National",
+    },
+    Object {
+      "id": 2,
+      "level": 1,
+      "name": "County",
+    },
+    Object {
+      "id": 3,
+      "level": 2,
+      "name": "Sub-County",
+    },
+    Object {
+      "id": 4,
+      "level": 3,
+      "name": "Ward",
+    },
+  ],
   "loadingForm": false,
   "loadingMap": false,
   "masterData": Object {

--- a/frontend/src/lib/__test__/administration-cascade.test.js
+++ b/frontend/src/lib/__test__/administration-cascade.test.js
@@ -1,0 +1,14 @@
+import { buildAdministrationCascade } from "../constants";
+
+describe("buildAdministrationCascade", () => {
+  test("targets the authenticated endpoint with a bearer header", () => {
+    const [cascade] = buildAdministrationCascade("tok3n", 7);
+    expect(cascade.endpoint).toBe("/api/v1/administration");
+    expect(cascade.headers).toEqual({ Authorization: "Bearer tok3n" });
+  });
+
+  test("starts at the caller's own root, not a hardcoded 1", () => {
+    const [cascade] = buildAdministrationCascade("tok3n", 7);
+    expect(cascade.initial).toBe(7);
+  });
+});

--- a/frontend/src/lib/__test__/store.test.js
+++ b/frontend/src/lib/__test__/store.test.js
@@ -23,7 +23,7 @@ describe("Store", () => {
       loadingMap: false,
       allForms: [],
       forms: [],
-      levels: window.levels,
+      levels: [],
       selectedForm: null,
       loadingForm: false,
       questionGroups: [],

--- a/frontend/src/lib/constants.js
+++ b/frontend/src/lib/constants.js
@@ -52,12 +52,20 @@ export const APPROVAL_STATUS_PENDING = 1;
 export const APPROVAL_STATUS_APPROVED = 2;
 export const APPROVAL_STATUS_REJECTED = 3;
 
-export const ARF_CASCASE_URLS = [
+// The administration cascade for the form builder. It used to point at a
+// token-less /public/administrations, which handed every tenant's units to
+// anyone; that endpoint is gone. akvo-react-form threads `headers` into its
+// axios.get, so the cascade can use the authenticated, tenant-scoped
+// endpoint instead. It has to be built per render rather than kept as a
+// module constant: it needs the live token, and `initial` must be the
+// caller's own root, not a hardcoded 1.
+export const buildAdministrationCascade = (token, rootId) => [
   {
     name: "Administration",
-    endpoint: "/api/v1/public/administrations",
-    initial: 1,
+    endpoint: "/api/v1/administration",
+    initial: rootId,
     list: "children",
+    headers: { Authorization: `Bearer ${token}` },
   },
 ];
 

--- a/frontend/src/lib/store.js
+++ b/frontend/src/lib/store.js
@@ -23,7 +23,8 @@ const defaultUIState = {
   // forms: assignment-filtered, sorted subset rendered by the UI.
   allForms: [],
   forms: [],
-  levels: window.levels,
+  // Populated at runtime from GET /api/v1/levels (tenant-owned).
+  levels: [],
   selectedForm: null,
   selectedFormData: null,
   loadingForm: false,

--- a/frontend/src/pages/approvers-tree/ApproversTree.jsx
+++ b/frontend/src/pages/approvers-tree/ApproversTree.jsx
@@ -8,6 +8,7 @@ import { SteppedLineTo } from "react-lineto";
 import { takeRight } from "lodash";
 import { useNotification } from "../../util/hooks";
 import { InfoCircleOutlined } from "@ant-design/icons";
+import { getLevels } from "../../util/level";
 
 const ApproversTree = () => {
   const {
@@ -43,7 +44,7 @@ const ApproversTree = () => {
     },
   ];
 
-  const startingLevel = window.levels.find(
+  const startingLevel = getLevels().find(
     (l) => l.level === authUser?.administration?.level + 1
   );
 
@@ -273,7 +274,7 @@ const ApproversTree = () => {
                       onClick={() => {
                         if (
                           adminItem.levelName !==
-                            takeRight(window.levels, 2)[0]?.name &&
+                            takeRight(getLevels(), 2)[0]?.name &&
                           administration[k + 1]?.children[0]?.parent !==
                             childItem.id
                         ) {

--- a/frontend/src/pages/form-builder/FormBuilderCreate.jsx
+++ b/frontend/src/pages/form-builder/FormBuilderCreate.jsx
@@ -7,7 +7,7 @@ import {
   api,
   store,
   uiText,
-  ARF_CASCASE_URLS,
+  buildAdministrationCascade,
   QUESTION_TYPES,
   REGISTRATION_FORM,
   MONITORING_FORM,
@@ -25,7 +25,13 @@ const FormBuilderCreate = () => {
   const [parentForm, setParentForm] = useState(null);
   const [parentError, setParentError] = useState(false);
 
-  const { language } = store.useState((s) => s);
+  const { language, user: authUser } = store.useState((s) => s);
+  // The cascade is authenticated now and starts at this tenant's own
+  // root administration, which the profile resolves.
+  const cascadeURL = useMemo(
+    () => buildAdministrationCascade(api.token, authUser?.administration?.id),
+    [authUser]
+  );
   const { active: activeLang } = language;
   const text = useMemo(() => uiText[activeLang], [activeLang]);
 
@@ -102,7 +108,7 @@ const FormBuilderCreate = () => {
               initialValue={{}}
               onSave={saving || parentError ? null : onSave}
               limitQuestionType={Object.keys(QUESTION_TYPES)}
-              settingCascadeURL={ARF_CASCASE_URLS}
+              settingCascadeURL={cascadeURL}
             />
           </div>
         </div>

--- a/frontend/src/pages/form-builder/FormBuilderEdit.jsx
+++ b/frontend/src/pages/form-builder/FormBuilderEdit.jsx
@@ -10,7 +10,7 @@ import {
   store,
   uiText,
   QUESTION_TYPES,
-  ARF_CASCASE_URLS,
+  buildAdministrationCascade,
 } from "../../lib";
 import { useNotification } from "../../util/hooks";
 import { fetchPublishedForms } from "../../util/form";
@@ -41,7 +41,13 @@ const FormBuilderEdit = () => {
   const [previewingVersion, setPreviewingVersion] = useState(null);
   const [loading, setLoading] = useState(true);
 
-  const { language } = store.useState((s) => s);
+  const { language, user: authUser } = store.useState((s) => s);
+  // The cascade is authenticated now and starts at this tenant's own
+  // root administration, which the profile resolves.
+  const cascadeURL = useMemo(
+    () => buildAdministrationCascade(api.token, authUser?.administration?.id),
+    [authUser]
+  );
   const { active: activeLang } = language;
   const text = useMemo(() => uiText[activeLang], [activeLang]);
 
@@ -341,7 +347,7 @@ const FormBuilderEdit = () => {
               initialValue={loading ? {} : initialValue}
               onSave={saving ? null : onSave}
               limitQuestionType={Object.keys(QUESTION_TYPES)}
-              settingCascadeURL={ARF_CASCASE_URLS}
+              settingCascadeURL={cascadeURL}
             />
           </div>
         </div>

--- a/frontend/src/setupTests.js
+++ b/frontend/src/setupTests.js
@@ -6,12 +6,6 @@ import "@testing-library/jest-dom";
 import "jest-canvas-mock";
 import store from "./lib/store";
 
-window.levels = [
-  { id: 1, name: "National", level: 0 },
-  { id: 2, name: "County", level: 1 },
-  { id: 3, name: "Sub-County", level: 2 },
-  { id: 4, name: "Ward", level: 3 },
-];
 const formsFixture = [
   { id: 1, name: "Example 1", type: 1, version: 1, type_text: "County" },
   { id: 2, name: "Example 2", type: 2, version: 1, type_text: "National" },
@@ -22,6 +16,13 @@ const formsFixture = [
 store.update((s) => {
   s.allForms = formsFixture;
   s.forms = formsFixture;
+  // Levels are fetched at runtime now; seed the store, not a global.
+  s.levels = [
+    { id: 1, name: "National", level: 0 },
+    { id: 2, name: "County", level: 1 },
+    { id: 3, name: "Sub-County", level: 2 },
+    { id: 4, name: "Ward", level: 3 },
+  ];
 });
 
 window.visualisation = [];

--- a/frontend/src/util/__test__/level.test.js
+++ b/frontend/src/util/__test__/level.test.js
@@ -1,0 +1,19 @@
+import { getLevels } from "../level";
+import store from "../../lib/store";
+
+describe("level util", () => {
+  test("getLevels returns [] when the store has no levels", () => {
+    store.update((s) => {
+      s.levels = [];
+    });
+    expect(getLevels()).toEqual([]);
+  });
+
+  test("getLevels returns the store levels", () => {
+    const fixture = [{ id: 1, name: "National", level: 0 }];
+    store.update((s) => {
+      s.levels = fixture;
+    });
+    expect(getLevels()).toEqual(fixture);
+  });
+});

--- a/frontend/src/util/level.js
+++ b/frontend/src/util/level.js
@@ -4,19 +4,18 @@ import { api, store } from "../lib";
 // baked into config.js as window.levels). Mirrors util/form.js.
 export const getLevels = () => store.getRawState().levels || [];
 
+// The rejection path matters on a refetch: it clears the previous
+// tenant's levels rather than leaving them for the next session.
 export const fetchLevels = () =>
   api
     .get("levels")
-    .then((res) => {
-      const levels = Array.isArray(res.data) ? res.data : [];
+    .then(
+      (res) => (Array.isArray(res.data) ? res.data : []),
+      () => []
+    )
+    .then((levels) => {
       store.update((s) => {
         s.levels = levels;
       });
       return levels;
-    })
-    .catch(() => {
-      store.update((s) => {
-        s.levels = [];
-      });
-      return [];
     });

--- a/frontend/src/util/level.js
+++ b/frontend/src/util/level.js
@@ -1,0 +1,22 @@
+import { api, store } from "../lib";
+
+// Levels are tenant-owned and served at runtime (they were previously
+// baked into config.js as window.levels). Mirrors util/form.js.
+export const getLevels = () => store.getRawState().levels || [];
+
+export const fetchLevels = () =>
+  api
+    .get("levels")
+    .then((res) => {
+      const levels = Array.isArray(res.data) ? res.data : [];
+      store.update((s) => {
+        s.levels = levels;
+      });
+      return levels;
+    })
+    .catch(() => {
+      store.update((s) => {
+        s.levels = [];
+      });
+      return [];
+    });


### PR DESCRIPTION
Closes #270

Iteration 3 of the multi-tenant SaaS roadmap: every list and detail read
observes tenant ownership. Stacked on `feature/269-tenant-scoping-db`
(#279), which is still open — that is the base branch.

---

## ⚠️ Do not deploy the epic branch until iteration 4 lands

Merging this into `epic/multi-tenant-saas` is fine. **Deploying the epic
branch is not**, until write-path enforcement (iteration 4) merges.

This iteration filters every read by tenant. Stamping new rows with the
creator's tenant is iteration 4's job. In between, a create succeeds and
the row lands with `tenant = NULL`, which no longer matches anyone — so
it is invisible to its own creator. Verified against a running stack:

```
POST /api/v1/entities      → 201 {"id":1,"name":"Water Point"}
GET  /api/v1/entities      → {"data":[]}
DB                         → 'Water Point' tenant=None

POST /api/v1/manage/forms  → 201 {"id":1,"name":"Household Survey"}
GET  /api/v1/manage/forms  → visible forms: []
DB                         → 'Household Survey' tenant=None
```

The form builder is the worst case: a form saves and vanishes. This hits
every tenant, including fresh registrations, not just the existing
deployments.

The roadmap's promotion gate already says nothing ships to real users
until iterations 1–4 all land, but framed that as a security boundary.
It is also a functionality one: iteration 3 is not independently
deployable. The spec explicitly puts write stamping out of scope, so
this branch matches its spec — the gap is in the sequencing, not the
implementation.

For what it is worth, existing deployments (mohhs-mis, unicef-fsm) need
**no** manual default-tenant setup: iteration 2's
`0004_backfill_default_tenant` creates it and stamps every pre-existing
row on migrate. Only post-upgrade writes are affected.

---

## The mechanism

Each tenant-owned model declares `TENANT_PATH` — the ORM lookup to its
owning tenant, `"tenant"` for direct-FK tables and a join like
`"form__tenant"` for derived ones — and gains
`Model.objects.for_user(user)`, which filters uniformly by that path.
The method lives on the querysets via a shared mixin and is delegated by
each manager family, so callers write the same `for_user` everywhere
regardless of a model's manager.

`TENANT_PATH` is a deliberate opt-in: a model without it raises rather
than silently returning unscoped rows, so a forgotten declaration fails
loudly instead of leaking.

A tenant-less user filters on NULL and matches tenant-less rows, which
is what keeps the existing suite (seeded tenant-less) green with no
fixture migration.

## Coverage

Scoped per app, one commit each: **v1_data**, **v1_forms**,
**v1_users/v1_profile**, **v1_mobile/v1_visualization**. Every
`if is_superuser: <all rows>` branch now returns the tenant's rows;
detail lookups run against the scoped queryset so a foreign id returns
404 rather than confirming the row exists.

`PublicAdministrationViewSet` is **deleted** rather than scoped. It
returned every tenant's administration units to anyone with the URL, and
its only consumer was the authenticated form-builder, which pointed the
akvo-react-form cascade at a token-less endpoint. The library threads
headers into its fetch, so the builder now loads administrations through
the scoped `list_administration` with an `Authorization` header,
starting at the tenant's own root instead of a hardcoded id 1.

Levels move out of `config.js` to a per-tenant runtime fetch, mirroring
the earlier forms migration, so isolation is observable in the control
center.

## Four things the plan did not anticipate

1. **`AnonymousUser` has no `.tenant`** — `for_user` raised a 500 on the
   endpoints reachable without a token. It now reads the tenant with
   `getattr`, so an anonymous caller behaves as a tenant-less actor and
   matches nothing on a deployment where every row is owned.

2. **`/forms/published` was globally cached.** Scoping it without
   splitting the cache key would have served whichever tenant warmed the
   cache to all the others — a worse leak than the one being fixed. The
   key now carries the tenant id, with a test for exactly that.

3. **That endpoint is fetched once at mount, before sign-in.** Scoping
   it alone would have left every signed-in user with zero forms, so the
   bootstrap effect refetches when auth state changes.

4. **Mobile auth carries the user on `request.auth.assignment`**, not
   `request.user`. Two form lookups ran before that resolved and had to
   be reordered — scoping them on `request.user` would have silently
   matched nothing, since a device token carries no `SystemUser`.

## The grep audit earned its place

After all five per-app passes were done and green, the coverage audit
over every `is_superuser` branch found the same unscoped
`Administration.objects.filter(parent__isnull=True).first()` twice more,
in **v1_forms** and **v1_jobs** — apps the per-app tasks never walked.
That lookup picks whichever root sorts first in the whole table, which
stopped meaning "my root" the moment a second tenant existed. In
v1_forms it decided which administration a webform prefilled for a
superadmin; in v1_jobs it stamped the administration onto a bulk-upload
validation job.

## Verification

- 1416 backend tests, `flake8` clean
- 30 frontend suites / 248 tests, eslint clean
- `frontend/release.sh` passes end to end, including the strict
  `.eslintrc.prod.json` that `ci/build.sh` generates by promoting every
  `warn` to `error`
- `backend/run-qc.sh`: lint and all 1416 tests pass. It exits 1 at
  `coverage report` when run in the dev container — `.coveragerc` maps
  `[paths] source = /app/backend` and `docker-compose.test.yml` sets
  that working dir, but the dev container has the code at `/app`, so
  combine rewrites paths to a location that does not exist there. No
  file in this branch touches `.coveragerc`, `run-qc.sh` or any
  Dockerfile
- Live two-tenant walkthrough from a fresh database: each tenant sees
  only its own levels and users; `acme` gets 404 on beta's
  administration and 200 on its own; `/public/administrations` is gone;
  `config.js` is 381 bytes with zero `var levels`

## Note for the reviewer

The last commit is a complexity-only pass with no behaviour change:
`TenantManager` collapses to `models.Manager.from_queryset`, the
two-tenant fixture duplicated across four isolation modules moves to a
shared `TenantIsolationTestCase`, and `fetchLevels` loses a redundant
store write. The soft-deletes and draft managers deliberately keep their
explicit `for_user` delegators — their `get_queryset` carries
`with_deleted`/`only_draft` state that a generated manager would drop.

Not verified: the browser walkthrough. Everything under it is checked —
API flow end to end, both suites, production build — but nobody has
clicked through the control center.


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1216901353714064