### PR TITLE
[#271] Enforce tenant ownership on every write

### DIFF
--- a/backend/api/v1/v1_data/tests/tests_write_fk_scoping.py
+++ b/backend/api/v1/v1_data/tests/tests_write_fk_scoping.py
@@ -1,0 +1,84 @@
+from django.test.utils import override_settings
+
+from api.v1.v1_profile.models import Administration, Role
+from utils.tenant_test_case import TenantIsolationTestCase
+
+
+@override_settings(USE_TZ=False)
+class WriteFkScopingTestCase(TenantIsolationTestCase):
+    """A payload may not reference another tenant's object.
+
+    These are 400s rather than 404s: the object addressed by the URL is
+    the caller's own, it is a value inside the payload that is invalid.
+    """
+
+    def make_tenant(self, sub):
+        tenant = super().make_tenant(sub)
+        tenant["role"] = Role.objects.create(
+            name=f"{sub}-role", administration_level=tenant["level"]
+        )
+        return tenant
+
+    def test_add_user_rejects_foreign_role(self):
+        res = self.client.post(
+            "/api/v1/user",
+            {
+                "first_name": "X", "last_name": "Y",
+                "email": "x@acme.org",
+                "roles": [{
+                    "role": self.b["role"].id,
+                    "administration": self.a["root"].id,
+                }],
+                "forms": [], "trained": False,
+            },
+            content_type="application/json",
+            **self.auth(self.a["user"]),
+        )
+        self.assertEqual(res.status_code, 400)
+
+    def test_add_user_rejects_foreign_administration(self):
+        res = self.client.post(
+            "/api/v1/user",
+            {
+                "first_name": "X", "last_name": "Y",
+                "email": "x2@acme.org",
+                "roles": [{
+                    "role": self.a["role"].id,
+                    "administration": self.b["root"].id,
+                }],
+                "forms": [], "trained": False,
+            },
+            content_type="application/json",
+            **self.auth(self.a["user"]),
+        )
+        self.assertEqual(res.status_code, 400)
+
+    def test_administration_create_rejects_foreign_parent(self):
+        res = self.client.post(
+            "/api/v1/administrations",
+            {
+                "name": "Sneaky",
+                "parent": self.b["root"].id,
+                "level": self.b["child_level"].id,
+                "code": "SN1",
+            },
+            content_type="application/json",
+            **self.auth(self.a["user"]),
+        )
+        self.assertEqual(res.status_code, 400)
+        self.assertFalse(
+            Administration.objects.filter(name="Sneaky").exists()
+        )
+
+    def test_form_data_submission_rejects_foreign_administration(self):
+        res = self.client.post(
+            f"/api/v1/form-data/{self.a['form'].id}",
+            {
+                "administration": self.b["child"].id,
+                "name": "dp",
+                "answers": {},
+            },
+            content_type="application/json",
+            **self.auth(self.a["user"]),
+        )
+        self.assertEqual(res.status_code, 400)

--- a/backend/api/v1/v1_data/tests/tests_write_guard.py
+++ b/backend/api/v1/v1_data/tests/tests_write_guard.py
@@ -1,0 +1,104 @@
+from django.test.utils import override_settings
+
+from api.v1.v1_data.models import FormData
+from api.v1.v1_forms.models import Forms
+from api.v1.v1_profile.models import Entity
+from api.v1.v1_users.models import Organisation, SystemUser
+from utils.tenant_test_case import TenantIsolationTestCase
+
+
+@override_settings(USE_TZ=False)
+class WriteGuardTestCase(TenantIsolationTestCase):
+    """A PUT/PATCH/DELETE aimed at another tenant's object must 404.
+
+    404 rather than 403: the object's existence is not revealed, matching
+    the read detail endpoints.
+    """
+
+    def make_tenant(self, sub):
+        tenant = super().make_tenant(sub)
+        tenant["data"] = FormData.objects.create(
+            name=f"{sub}-dp",
+            form=tenant["form"],
+            administration=tenant["child"],
+            created_by=tenant["user"],
+        )
+        tenant["org"] = Organisation.objects.create(
+            name=f"{sub}-org", tenant=tenant["tenant"]
+        )
+        tenant["entity"] = Entity.objects.create(
+            name=f"{sub}-entity", tenant=tenant["tenant"]
+        )
+        return tenant
+
+    def test_delete_foreign_datapoint_404s(self):
+        res = self.client.delete(
+            f"/api/v1/data/{self.b['data'].id}",
+            **self.auth(self.a["user"]),
+        )
+        self.assertEqual(res.status_code, 404)
+        self.assertTrue(FormData.objects.filter(id=self.b["data"].id).exists())
+
+    def test_delete_foreign_form_404s(self):
+        res = self.client.delete(
+            f"/api/v1/manage/forms/{self.b['form'].id}",
+            **self.auth(self.a["user"]),
+        )
+        self.assertEqual(res.status_code, 404)
+        self.assertTrue(
+            Forms.objects_with_deleted.filter(
+                id=self.b["form"].id, deleted_at__isnull=True
+            ).exists()
+        )
+
+    def test_delete_foreign_user_404s(self):
+        res = self.client.delete(
+            f"/api/v1/user/{self.b['user'].id}",
+            **self.auth(self.a["user"]),
+        )
+        self.assertEqual(res.status_code, 404)
+        self.assertTrue(
+            SystemUser.objects.filter(id=self.b["user"].id).exists()
+        )
+
+    def test_edit_foreign_organisation_404s(self):
+        res = self.client.put(
+            f"/api/v1/organisation/{self.b['org'].id}",
+            {"name": "Hijacked", "attributes": [1]},
+            content_type="application/json",
+            **self.auth(self.a["user"]),
+        )
+        self.assertEqual(res.status_code, 404)
+        self.b["org"].refresh_from_db()
+        self.assertEqual(self.b["org"].name, "beta-org")
+
+    def test_edit_foreign_entity_404s(self):
+        res = self.client.put(
+            f"/api/v1/entities/{self.b['entity'].id}",
+            {"name": "Hijacked"},
+            content_type="application/json",
+            **self.auth(self.a["user"]),
+        )
+        self.assertEqual(res.status_code, 404)
+        self.b["entity"].refresh_from_db()
+        self.assertEqual(self.b["entity"].name, "beta-entity")
+
+    def test_monitoring_form_cannot_parent_to_foreign_form(self):
+        # A cross-tenant write that no lookup guarded: the parent id was
+        # resolved against every form in the table.
+        self.b["form"].status = 1
+        self.b["form"].save()
+        res = self.client.post(
+            "/api/v1/manage/forms",
+            {
+                "name": "Sneaky Monitoring",
+                "type": "monitoring",
+                "parent": self.b["form"].id,
+            },
+            content_type="application/json",
+            **self.auth(self.a["user"]),
+        )
+        self.assertEqual(res.status_code, 400)
+        self.assertFalse(
+            Forms.objects.filter(name="Sneaky Monitoring").exists()
+        )

--- a/backend/api/v1/v1_forms/functions.py
+++ b/backend/api/v1/v1_forms/functions.py
@@ -390,6 +390,7 @@ def duplicate_form(original_form, user=None):
         languages=original_form.languages,
         default_language=original_form.default_language,
         translations=original_form.translations,
+        tenant=getattr(user, "tenant", None) or original_form.tenant,
         created_by=user,
     )
     for group in original_form.form_question_group.all().order_by("order"):
@@ -1406,6 +1407,7 @@ def _apply_import_create_path(norm, user, parent_form, force_new_id):
         approval_instructions=norm.get("approval_instructions"),
         created_by=user,
         updated_by=user,
+        tenant=getattr(user, "tenant", None),
     )
     if use_file_form_id:
         create_kwargs["id"] = file_form_id

--- a/backend/api/v1/v1_forms/functions.py
+++ b/backend/api/v1/v1_forms/functions.py
@@ -242,6 +242,7 @@ def save_form(data, instance=None, user=None):
             default_language=data.get("default_language"),
             translations=data.get("translations"),
             created_by=user,
+            tenant=getattr(user, "tenant", None),
         )
         form_id = data.get("id")
         if form_id:

--- a/backend/api/v1/v1_forms/tests/tests_form_import_tenant.py
+++ b/backend/api/v1/v1_forms/tests/tests_form_import_tenant.py
@@ -1,0 +1,50 @@
+import io
+import json
+
+from django.test.utils import override_settings
+
+from api.v1.v1_forms.functions import (
+    import_form_definition,
+    normalize_form_definition,
+)
+from api.v1.v1_forms.tests.tests_form_import_preflight import (
+    _make_export_payload,
+)
+from utils.tenant_test_case import TenantIsolationTestCase
+
+
+@override_settings(USE_TZ=False)
+class FormImportTenantTestCase(TenantIsolationTestCase):
+    """Form import is a write path keyed on an id inside the file.
+
+    The id is supplied by whoever uploads the file, so an unscoped match
+    would let an import address another tenant's form, and an unstamped
+    create would produce a form its own importer cannot see.
+    """
+
+    def _upload(self, payload, user, path="/api/v1/manage/forms/import"):
+        f = io.BytesIO(json.dumps(payload).encode())
+        f.name = "form.json"
+        return self.client.post(path, {"file": f}, **self.auth(user))
+
+    def test_preflight_does_not_match_another_tenants_form(self):
+        # The file claims beta's form id. For acme that id must look like
+        # a form that does not exist, not like an update target.
+        res = self._upload(
+            _make_export_payload(name="X", form_id=self.b["form"].id),
+            self.a["user"],
+            path="/api/v1/manage/forms/import/preflight",
+        )
+        self.assertEqual(res.status_code, 200)
+        self.assertFalse(res.json()["match"]["exists"])
+
+    def test_imported_form_is_stamped_with_the_importer_tenant(self):
+        # The HTTP endpoint enqueues a task, so the create itself is
+        # exercised through the function the worker calls.
+        norm = normalize_form_definition(
+            _make_export_payload(name="Imported Form", form_id=978001)
+        )
+        form, _ = import_form_definition(
+            norm, user=self.a["user"], mode="create"
+        )
+        self.assertEqual(form.tenant, self.a["tenant"])

--- a/backend/api/v1/v1_forms/views.py
+++ b/backend/api/v1/v1_forms/views.py
@@ -655,7 +655,9 @@ class FormBuilderViewSet(viewsets.ModelViewSet):
         is_monitoring = req_type in (FormTypes.monitoring, "monitoring")
         if is_monitoring and parent_id:
             try:
-                parent = Forms.objects.get(id=parent_id)
+                parent = Forms.objects.for_user(request.user).get(
+                    id=parent_id
+                )
             except Forms.DoesNotExist:
                 return Response(
                     {"parent": "Parent form not found"},
@@ -1005,7 +1007,9 @@ class FormBuilderViewSet(viewsets.ModelViewSet):
         file_form_id = norm.get("form_id")
         match_info = {"exists": False, "form": None, "name_mismatch": False}
         if file_form_id is not None:
-            existing = Forms.objects.filter(id=file_form_id).first()
+            existing = Forms.objects.for_user(request.user).filter(
+                id=file_form_id
+            ).first()
             if existing:
                 submission_count = existing.form_data.count() if hasattr(
                     existing, "form_data"
@@ -1032,7 +1036,9 @@ class FormBuilderViewSet(viewsets.ModelViewSet):
         parent_hint = norm.get("parent_hint")
         resolved_parent = None
         if is_monitoring and parent_hint and parent_hint.get("id"):
-            p = Forms.objects.filter(id=parent_hint["id"]).first()
+            p = Forms.objects.for_user(request.user).filter(
+                id=parent_hint["id"]
+            ).first()
             if p:
                 resolved_parent = {"id": p.id, "name": p.name}
 
@@ -1131,7 +1137,8 @@ class FormBuilderViewSet(viewsets.ModelViewSet):
         if (
             mode == "create_or_update"
             and file_form_id is not None
-            and Forms.objects.filter(id=file_form_id).exists()
+            and Forms.objects.for_user(request.user)
+            .filter(id=file_form_id).exists()
         ):
             edit_perm = FormBuilderAccess(FeatureAccessTypes.form_edit)()
             if not edit_perm.has_permission(request, self):

--- a/backend/api/v1/v1_jobs/administrations_bulk_upload.py
+++ b/backend/api/v1/v1_jobs/administrations_bulk_upload.py
@@ -19,15 +19,19 @@ logger = logging.getLogger(__name__)
 # [[ SEEDER ]]
 
 @transaction.atomic
-def seed_administration_data(io_file):
+def seed_administration_data(io_file, tenant=None):
     df = pd.read_excel(io_file, sheet_name='data')
     columns = list(df)
     columns = [col for col in columns if 'Code' not in col]
-    level_count = Levels.objects.count()
-    level_map = map_column_model(columns[:level_count], Levels)
+    # Scope the tier count and the column-to-model maps by tenant:
+    # level numbers repeat across tenants, so an unscoped count splits
+    # the spreadsheet columns at the wrong place.
+    level_count = Levels.objects.filter(tenant=tenant).count()
+    level_map = map_column_model(columns[:level_count], Levels, tenant)
     attribute_map = map_column_model(
         columns[level_count:],
-        AdministrationAttribute
+        AdministrationAttribute,
+        tenant,
     )
     records = df.to_dict('records')
     for row in records:
@@ -46,7 +50,9 @@ def seed_administration_data(io_file):
                 row[col],
                 administration_code
             ))
-        target_administration = seed_administrations(administration_data)
+        target_administration = seed_administrations(
+            administration_data, tenant=tenant
+        )
         if not target_administration:
             break
         attribute_data = []
@@ -58,7 +64,8 @@ def seed_administration_data(io_file):
 
 
 def seed_administrations(
-        data: List[Tuple[Levels, str, str]]
+        data: List[Tuple[Levels, str, str]],
+        tenant=None,
         ) -> Union[Administration, None]:
     last_obj = None
     for item in data:
@@ -67,13 +74,15 @@ def seed_administrations(
             Q(name__iexact=name),
             level=level,
             parent=last_obj,
+            tenant=tenant,
         ).first()
         if not obj:
             obj = Administration.objects.create(
                 name=name.title(),
                 code=code,
                 level=level,
-                parent=last_obj
+                parent=last_obj,
+                tenant=tenant,
             )
         last_obj = obj
     return last_obj
@@ -111,11 +120,11 @@ def group_attributes(
     return grouped
 
 
-def map_column_model(columns, model: Type[Model]):
+def map_column_model(columns, model: Type[Model], tenant=None):
     map = {}
     for column in columns:
         id = column.split('|')[0]
-        obj = model.objects.get(id=id)
+        obj = model.objects.get(id=id, tenant=tenant)
         map[column] = obj
     return map
 

--- a/backend/api/v1/v1_jobs/job.py
+++ b/backend/api/v1/v1_jobs/job.py
@@ -1224,7 +1224,7 @@ def handle_administrations_bulk_upload(filename, user_id, upload_time):
             content_type="text/csv",
         )
         return
-    seed_administration_data(file_path)
+    seed_administration_data(file_path, tenant=user.tenant)
     generate_sqlite(Administration)
     send_email(context=email_context, type=EmailTypes.administration_upload)
 
@@ -1271,7 +1271,7 @@ def handle_entities_bulk_upload(filename, user_id, upload_time):
     user = SystemUser.objects.get(id=user_id)
     storage.download(f"upload/{filename}")
     file_path = f"./tmp/{filename}"
-    errors = validate_entity_file(file_path)
+    errors = validate_entity_file(file_path, tenant=user.tenant)
     email_context = {
         "send_to": [user.email],
         "listing": [
@@ -1288,7 +1288,7 @@ def handle_entities_bulk_upload(filename, user_id, upload_time):
     if len(errors):
         handle_entities_error_upload(errors, email_context, user, upload_time)
         return
-    errors = validate_entity_data(file_path)
+    errors = validate_entity_data(file_path, tenant=user.tenant)
     if len(errors):
         handle_entities_error_upload(errors, email_context, user, upload_time)
         return

--- a/backend/api/v1/v1_jobs/tests/tests_bulk_upload_tenant.py
+++ b/backend/api/v1/v1_jobs/tests/tests_bulk_upload_tenant.py
@@ -1,0 +1,54 @@
+from django.test.utils import override_settings
+
+from api.v1.v1_jobs.administrations_bulk_upload import seed_administrations
+from api.v1.v1_profile.models import Administration, Levels
+from utils.tenant_test_case import TenantIsolationTestCase
+
+
+@override_settings(USE_TZ=False)
+class BulkUploadTenantTestCase(TenantIsolationTestCase):
+    """Spreadsheet onboarding is the largest data-entry path.
+
+    Rows created there must belong to the uploader's tenant, or the whole
+    onboarding flow produces data nobody can see.
+    """
+
+    def test_bulk_created_administrations_carry_the_tenant(self):
+        # A real upload names the tenant's existing root in its first
+        # column; the seeder matches it and builds the subtree beneath.
+        created = seed_administrations(
+            [
+                (self.a["level"], self.a["root"].name, None),
+                (self.a["child_level"], "District One", "D1"),
+            ],
+            tenant=self.a["tenant"],
+        )
+        self.assertEqual(created.name, "District One")
+        self.assertEqual(created.parent, self.a["root"])
+        self.assertEqual(created.tenant, self.a["tenant"])
+
+    def test_bulk_upload_does_not_reuse_another_tenants_unit(self):
+        # The existing-row lookup matches on name within the tenant. An
+        # unscoped match would silently attach B's subtree to A's upload.
+        for t in (self.a, self.b):
+            seed_administrations(
+                [
+                    (t["level"], t["root"].name, None),
+                    (t["child_level"], "Shared Name", "S1"),
+                ],
+                tenant=t["tenant"],
+            )
+        rows = Administration.objects.filter(name="Shared Name")
+        self.assertEqual(rows.count(), 2)
+        self.assertEqual(
+            set(rows.values_list("tenant__subdomain", flat=True)),
+            {"acme", "beta"},
+        )
+
+    def test_tenantless_upload_still_produces_tenantless_rows(self):
+        # The seeders call this with no tenant; that path must not change.
+        level = Levels.objects.create(name="legacy", level=0)
+        seed_administrations([(level, "Legacy Unit", "L1")])
+        self.assertIsNone(
+            Administration.objects.get(name="Legacy Unit").tenant
+        )

--- a/backend/api/v1/v1_profile/serializers.py
+++ b/backend/api/v1/v1_profile/serializers.py
@@ -7,6 +7,7 @@ from utils.custom_serializer_fields import (
     CustomListField,
 )
 from utils.custom_generator import update_sqlite
+from utils.tenant_scoped_model import TenantStampedSerializerMixin
 from utils.custom_generator import (
     administration_csv_add,
     administration_csv_update,
@@ -50,7 +51,8 @@ class AdministrationLevelsSerializer(serializers.ModelSerializer):
         fields = ["id", "name"]
 
 
-class AdministrationAttributeSerializer(serializers.ModelSerializer):
+class AdministrationAttributeSerializer(TenantStampedSerializerMixin,
+                                        serializers.ModelSerializer):
     class Meta:
         model = AdministrationAttribute
         fields = ["id", "name", "type", "options"]
@@ -156,14 +158,19 @@ class AdministrationAttributeValueSerializer(serializers.ModelSerializer):
 
 
 def validate_parent(obj: Administration):
+    # Scope by the parent's own tenant: level numbers are unique per
+    # tenant, not globally, so an unscoped get() matches one row per
+    # tenant and raises MultipleObjectsReturned as soon as a second
+    # tenant exists.
     sub_level = obj.level.level + 1
-    try:
-        Levels.objects.get(level=sub_level)
-    except Levels.DoesNotExist:
+    if not Levels.objects.filter(
+        level=sub_level, tenant=obj.tenant
+    ).exists():
         raise serializers.ValidationError("Invalid parent level")
 
 
-class AdministrationSerializer(serializers.ModelSerializer):
+class AdministrationSerializer(TenantStampedSerializerMixin,
+                               serializers.ModelSerializer):
     parent = RelatedAdministrationField(
         queryset=Administration.objects.all(), validators=[validate_parent]
     )  # type: ignore
@@ -282,15 +289,20 @@ class AdministrationSerializer(serializers.ModelSerializer):
         validated_data.update({"code": code})
 
     def _assign_level(self, validated_data):
-        parent_level = validated_data.get("parent").level.level
-        try:
-            sublevel = Levels.objects.get(level=parent_level + 1)
-        except Levels.DoesNotExist as e:
-            raise ValueError() from e
+        # Resolve the child tier within the parent's tenant: level numbers
+        # repeat across tenants, so an unscoped get() raises
+        # MultipleObjectsReturned once a second tenant exists.
+        parent = validated_data.get("parent")
+        sublevel = Levels.objects.filter(
+            level=parent.level.level + 1, tenant=parent.tenant
+        ).first()
+        if sublevel is None:
+            raise ValueError()
         validated_data.update({"level": sublevel})
 
 
-class EntitySerializer(serializers.ModelSerializer):
+class EntitySerializer(TenantStampedSerializerMixin,
+                       serializers.ModelSerializer):
     class Meta:
         model = Entity
         fields = ["id", "name"]

--- a/backend/api/v1/v1_profile/serializers.py
+++ b/backend/api/v1/v1_profile/serializers.py
@@ -3,6 +3,7 @@ import string
 from typing import Any, Dict, cast
 from rest_framework import serializers
 from utils.custom_serializer_fields import (
+    TenantScopedPrimaryKeyRelatedField,
     CustomPrimaryKeyRelatedField,
     CustomListField,
 )
@@ -32,7 +33,7 @@ from api.v1.v1_profile.constants import (
 )
 
 
-class RelatedAdministrationField(serializers.PrimaryKeyRelatedField):
+class RelatedAdministrationField(TenantScopedPrimaryKeyRelatedField):
     def use_pk_only_optimization(self):
         return False
 

--- a/backend/api/v1/v1_profile/tests/test_write_mechanisms.py
+++ b/backend/api/v1/v1_profile/tests/test_write_mechanisms.py
@@ -1,0 +1,73 @@
+from rest_framework import serializers
+from django.test import TestCase
+from django.test.utils import override_settings
+
+from api.v1.v1_forms.models import Forms
+from api.v1.v1_users.models import SystemUser, Tenant
+from utils.tenant_scoped_model import TenantStampedSerializerMixin
+from utils.custom_serializer_fields import TenantScopedPrimaryKeyRelatedField
+
+
+class _StampSerializer(TenantStampedSerializerMixin,
+                       serializers.ModelSerializer):
+    class Meta:
+        model = Forms
+        fields = ["name"]
+
+
+class _RefSerializer(serializers.Serializer):
+    form = TenantScopedPrimaryKeyRelatedField(queryset=Forms.objects.all())
+
+
+@override_settings(USE_TZ=False)
+class WriteMechanismsTestCase(TestCase):
+    def setUp(self):
+        self.acme = Tenant.objects.create(subdomain="acme")
+        self.beta = Tenant.objects.create(subdomain="beta")
+        self.acme_user = SystemUser.objects.create_superuser(
+            email="a@acme.org", password="Secret#Pass123",
+            first_name="A", last_name="A", tenant=self.acme,
+        )
+        self.beta_form = Forms.objects.create(name="beta", tenant=self.beta)
+        self.acme_form = Forms.objects.create(name="acme", tenant=self.acme)
+
+    def test_stamp_sets_tenant_from_context_user(self):
+        s = _StampSerializer(
+            data={"name": "new"}, context={"user": self.acme_user}
+        )
+        s.is_valid(raise_exception=True)
+        instance = s.save()
+        self.assertEqual(instance.tenant, self.acme)
+
+    def test_stamp_ignores_a_client_supplied_tenant(self):
+        # Tenant is derived from the authenticated user, never bound from
+        # the payload: a caller cannot plant a row in another tenant.
+        s = _StampSerializer(
+            data={"name": "new", "tenant": self.beta.id},
+            context={"user": self.acme_user},
+        )
+        s.is_valid(raise_exception=True)
+        self.assertEqual(s.save().tenant, self.acme)
+
+    def test_stamp_resolves_user_from_request_context(self):
+        class _Req:
+            user = self.acme_user
+
+        s = _StampSerializer(data={"name": "n"}, context={"request": _Req()})
+        s.is_valid(raise_exception=True)
+        self.assertEqual(s.save().tenant, self.acme)
+
+    def test_scoped_field_accepts_own_tenant_object(self):
+        s = _RefSerializer(
+            data={"form": self.acme_form.id},
+            context={"user": self.acme_user},
+        )
+        self.assertTrue(s.is_valid())
+
+    def test_scoped_field_rejects_foreign_tenant_object(self):
+        s = _RefSerializer(
+            data={"form": self.beta_form.id},
+            context={"user": self.acme_user},
+        )
+        self.assertFalse(s.is_valid())
+        self.assertIn("form", s.errors)

--- a/backend/api/v1/v1_profile/views.py
+++ b/backend/api/v1/v1_profile/views.py
@@ -478,7 +478,9 @@ def export_pre_entities_data_template(request: Request, version):
     adm_id = request.query_params.get("adm_id")
     administration = None
     if adm_id:
-        administration = Administration.objects.get(pk=adm_id)
+        administration = Administration.objects.for_user(
+            request.user
+        ).filter(pk=adm_id).first()
     TESTING = settings.TEST_ENV
     filepath = generate_entities_data_excel(
         cast(SystemUser, request.user),

--- a/backend/api/v1/v1_users/serializers.py
+++ b/backend/api/v1/v1_users/serializers.py
@@ -30,6 +30,7 @@ from api.v1.v1_users.models import (
 from api.v1.v1_mobile.models import MobileAssignment
 from api.v1.v1_approval.models import DataBatch
 from utils.custom_serializer_fields import (
+    TenantScopedPrimaryKeyRelatedField,
     CustomEmailField,
     CustomCharField,
     CustomPrimaryKeyRelatedField,
@@ -263,12 +264,12 @@ class ListAdministrationSerializer(serializers.ModelSerializer):
 
 
 class AddRolesSerializer(serializers.Serializer):
-    role = CustomPrimaryKeyRelatedField(
+    role = TenantScopedPrimaryKeyRelatedField(
         queryset=Role.objects.none(),
         required=True,
         help_text='Role to assign to user'
     )
-    administration = CustomPrimaryKeyRelatedField(
+    administration = TenantScopedPrimaryKeyRelatedField(
         queryset=Administration.objects.none(),
         required=True,
         help_text='Administration to assign role to user'
@@ -366,7 +367,7 @@ class AddRolesSerializer(serializers.Serializer):
 
 class AddEditUserSerializer(TenantStampedSerializerMixin,
                             serializers.ModelSerializer):
-    organisation = CustomPrimaryKeyRelatedField(
+    organisation = TenantScopedPrimaryKeyRelatedField(
         queryset=Organisation.objects.none(), required=False)
     trained = CustomBooleanField(default=False)
     roles = AddRolesSerializer(many=True, required=False)

--- a/backend/api/v1/v1_users/serializers.py
+++ b/backend/api/v1/v1_users/serializers.py
@@ -39,6 +39,7 @@ from utils.custom_serializer_fields import (
 from api.v1.v1_profile.constants import FeatureAccessTypes
 from utils.custom_helper import CustomPasscode
 from utils.custom_generator import update_sqlite
+from utils.tenant_scoped_model import TenantStampedSerializerMixin
 
 
 class OrganisationSerializer(serializers.ModelSerializer):
@@ -96,7 +97,8 @@ class OrganisationListSerializer(serializers.ModelSerializer):
         fields = ['id', 'name', 'attributes', 'users']
 
 
-class AddEditOrganisationSerializer(serializers.ModelSerializer):
+class AddEditOrganisationSerializer(TenantStampedSerializerMixin,
+                                    serializers.ModelSerializer):
     attributes = CustomMultipleChoiceField(choices=list(
         OrganisationTypes.FieldStr.keys()),
                                            required=True)
@@ -362,7 +364,8 @@ class AddRolesSerializer(serializers.Serializer):
         fields = ['role', 'administration']
 
 
-class AddEditUserSerializer(serializers.ModelSerializer):
+class AddEditUserSerializer(TenantStampedSerializerMixin,
+                            serializers.ModelSerializer):
     organisation = CustomPrimaryKeyRelatedField(
         queryset=Organisation.objects.none(), required=False)
     trained = CustomBooleanField(default=False)

--- a/backend/api/v1/v1_users/tests/tests_write_stamping.py
+++ b/backend/api/v1/v1_users/tests/tests_write_stamping.py
@@ -93,19 +93,6 @@ class WriteStampingTestCase(TenantIsolationTestCase):
             self.a["tenant"],
         )
 
-    def test_created_rows_are_visible_to_their_creator(self):
-        # The regression that made iteration 3 undeployable: a create
-        # succeeded, landed tenant-less, and vanished from every list.
-        self.client.post(
-            "/api/v1/entities",
-            {"name": "Borehole"},
-            content_type="application/json",
-            **self.auth(self.a["user"]),
-        )
-        res = self.client.get("/api/v1/entities", **self.auth(self.a["user"]))
-        names = [e["name"] for e in res.json()["data"]]
-        self.assertIn("Borehole", names)
-
     def test_user_create_is_stamped(self):
         res = self.client.post(
             "/api/v1/user",

--- a/backend/api/v1/v1_users/tests/tests_write_stamping.py
+++ b/backend/api/v1/v1_users/tests/tests_write_stamping.py
@@ -126,3 +126,13 @@ class WriteStampingTestCase(TenantIsolationTestCase):
             SystemUser.objects.get(email="member@acme.org").tenant,
             self.a["tenant"],
         )
+
+    def test_duplicated_form_keeps_the_tenant(self):
+        res = self.client.post(
+            f"/api/v1/manage/forms/{self.a['form'].id}/duplicate",
+            content_type="application/json",
+            **self.auth(self.a["user"]),
+        )
+        self.assertIn(res.status_code, (200, 201))
+        copy = Forms.objects.get(name=f"{self.a['form'].name} (Copy)")
+        self.assertEqual(copy.tenant, self.a["tenant"])

--- a/backend/api/v1/v1_users/tests/tests_write_stamping.py
+++ b/backend/api/v1/v1_users/tests/tests_write_stamping.py
@@ -1,0 +1,128 @@
+from django.test.utils import override_settings
+
+from api.v1.v1_forms.models import Forms
+from api.v1.v1_profile.models import (
+    Administration,
+    AdministrationAttribute,
+    Entity,
+    Role,
+)
+from api.v1.v1_users.models import Organisation, SystemUser
+from utils.tenant_test_case import TenantIsolationTestCase
+
+
+@override_settings(USE_TZ=False)
+class WriteStampingTestCase(TenantIsolationTestCase):
+    """Everything tenant A creates must come out owned by A.
+
+    Before this iteration these all landed with tenant = NULL, which the
+    read filtering then hid from their own creator.
+    """
+
+    def make_tenant(self, sub):
+        tenant = super().make_tenant(sub)
+        tenant["role"] = Role.objects.create(
+            name=f"{sub}-role", administration_level=tenant["level"]
+        )
+        return tenant
+
+    def test_form_create_is_stamped(self):
+        res = self.client.post(
+            "/api/v1/manage/forms",
+            {"name": "Household Survey", "type": 1},
+            content_type="application/json",
+            **self.auth(self.a["user"]),
+        )
+        self.assertEqual(res.status_code, 201)
+        form = Forms.objects.get(name="Household Survey")
+        self.assertEqual(form.tenant, self.a["tenant"])
+
+    def test_entity_create_is_stamped(self):
+        res = self.client.post(
+            "/api/v1/entities",
+            {"name": "Water Point"},
+            content_type="application/json",
+            **self.auth(self.a["user"]),
+        )
+        self.assertEqual(res.status_code, 201)
+        self.assertEqual(
+            Entity.objects.get(name="Water Point").tenant, self.a["tenant"]
+        )
+
+    def test_attribute_create_is_stamped(self):
+        res = self.client.post(
+            "/api/v1/administration-attributes",
+            {"name": "Population", "type": "value", "options": []},
+            content_type="application/json",
+            **self.auth(self.a["user"]),
+        )
+        self.assertEqual(res.status_code, 201)
+        self.assertEqual(
+            AdministrationAttribute.objects.get(name="Population").tenant,
+            self.a["tenant"],
+        )
+
+    def test_organisation_create_is_stamped(self):
+        res = self.client.post(
+            "/api/v1/organisation",
+            {"name": "Ministry of Water", "attributes": [1]},
+            content_type="application/json",
+            **self.auth(self.a["user"]),
+        )
+        self.assertEqual(res.status_code, 200)
+        self.assertEqual(
+            Organisation.objects.get(name="Ministry of Water").tenant,
+            self.a["tenant"],
+        )
+
+    def test_administration_create_is_stamped(self):
+        res = self.client.post(
+            "/api/v1/administrations",
+            {
+                "name": "New District",
+                "parent": self.a["root"].id,
+                "level": self.a["child_level"].id,
+                "code": "ND1",
+            },
+            content_type="application/json",
+            **self.auth(self.a["user"]),
+        )
+        self.assertEqual(res.status_code, 201)
+        self.assertEqual(
+            Administration.objects.get(name="New District").tenant,
+            self.a["tenant"],
+        )
+
+    def test_created_rows_are_visible_to_their_creator(self):
+        # The regression that made iteration 3 undeployable: a create
+        # succeeded, landed tenant-less, and vanished from every list.
+        self.client.post(
+            "/api/v1/entities",
+            {"name": "Borehole"},
+            content_type="application/json",
+            **self.auth(self.a["user"]),
+        )
+        res = self.client.get("/api/v1/entities", **self.auth(self.a["user"]))
+        names = [e["name"] for e in res.json()["data"]]
+        self.assertIn("Borehole", names)
+
+    def test_user_create_is_stamped(self):
+        res = self.client.post(
+            "/api/v1/user",
+            {
+                "first_name": "New",
+                "last_name": "Member",
+                "email": "member@acme.org",
+                "administration": self.a["root"].id,
+                "role": self.a["role"].id,
+                "forms": [],
+                "trained": False,
+            },
+            content_type="application/json",
+            **self.auth(self.a["user"]),
+        )
+        self.assertIn(res.status_code, (200, 201))
+        self.assertEqual(
+            SystemUser.objects.get(email="member@acme.org").tenant,
+            self.a["tenant"],
+        )

--- a/backend/api/v1/v1_users/views.py
+++ b/backend/api/v1/v1_users/views.py
@@ -852,7 +852,10 @@ def list_organisations(request, version):
 def add_organisation(request, version):
     serializer = AddEditOrganisationSerializer(
         data=request.data,
-        context={"attributes": request.data.get("attributes")},
+        context={
+            "attributes": request.data.get("attributes"),
+            "user": request.user,
+        },
     )
     if not serializer.is_valid():
         return Response(
@@ -916,7 +919,10 @@ class OrganisationEditDeleteView(APIView):
         )
         serializer = AddEditOrganisationSerializer(
             data=request.data,
-            context={"attributes": request.data.get("attributes")},
+            context={
+                "attributes": request.data.get("attributes"),
+                "user": request.user,
+            },
             instance=instance,
         )
         if not serializer.is_valid():

--- a/backend/utils/custom_serializer_fields.py
+++ b/backend/utils/custom_serializer_fields.py
@@ -1,4 +1,6 @@
 from django.core.validators import EmailValidator
+
+from utils.tenant_scoped_model import acting_user
 from django.utils.translation import gettext_lazy as _
 from rest_framework.fields import (
     IntegerField,
@@ -274,3 +276,15 @@ def validate_serializers_message(errors):
 
     msg = extract_messages(errors)
     return "|".join(msg)
+
+
+class TenantScopedPrimaryKeyRelatedField(CustomPrimaryKeyRelatedField):
+    # Narrows the candidate queryset to the acting user's tenant, so a pk
+    # referencing another tenant's object fails validation as
+    # does_not_exist (a 400) rather than silently binding a foreign row.
+    def get_queryset(self):
+        queryset = super().get_queryset()
+        user = acting_user(self.context)
+        if user is None:
+            return queryset.none()
+        return queryset.for_user(user)

--- a/backend/utils/custom_serializer_fields.py
+++ b/backend/utils/custom_serializer_fields.py
@@ -283,8 +283,7 @@ class TenantScopedPrimaryKeyRelatedField(CustomPrimaryKeyRelatedField):
     # referencing another tenant's object fails validation as
     # does_not_exist (a 400) rather than silently binding a foreign row.
     def get_queryset(self):
+        # No acting user means no context was passed: fail closed.
         queryset = super().get_queryset()
         user = acting_user(self.context)
-        if user is None:
-            return queryset.none()
-        return queryset.for_user(user)
+        return queryset.for_user(user) if user else queryset.none()

--- a/backend/utils/tenant_scoped_model.py
+++ b/backend/utils/tenant_scoped_model.py
@@ -34,3 +34,24 @@ class TenantQuerySet(TenantScopedQuerySetMixin, models.QuerySet):
 # carries with_deleted/only_draft state a generated manager would drop —
 # so they delegate explicitly instead.
 TenantManager = models.Manager.from_queryset(TenantQuerySet)
+
+
+def acting_user(context):
+    # Serializers here are called with either context={"user": ...} or the
+    # DRF default context={"request": ...}. Support both so callers do not
+    # have to be normalised first.
+    user = context.get("user")
+    if user is None:
+        request = context.get("request")
+        user = getattr(request, "user", None)
+    return user
+
+
+class TenantStampedSerializerMixin:
+    # create() stamps the new row with the acting user's tenant. Tenant is
+    # never read from the payload — only from the authenticated user — so a
+    # caller cannot plant a row in someone else's tenant.
+    def create(self, validated_data):
+        user = acting_user(self.context)
+        validated_data["tenant"] = getattr(user, "tenant", None)
+        return super().create(validated_data)

--- a/backend/utils/tenant_scoped_model.py
+++ b/backend/utils/tenant_scoped_model.py
@@ -40,11 +40,9 @@ def acting_user(context):
     # Serializers here are called with either context={"user": ...} or the
     # DRF default context={"request": ...}. Support both so callers do not
     # have to be normalised first.
-    user = context.get("user")
-    if user is None:
-        request = context.get("request")
-        user = getattr(request, "user", None)
-    return user
+    return context.get("user") or getattr(
+        context.get("request"), "user", None
+    )
 
 
 class TenantStampedSerializerMixin:

--- a/backend/utils/tenant_test_case.py
+++ b/backend/utils/tenant_test_case.py
@@ -39,7 +39,8 @@ class TenantIsolationTestCase(TestCase):
         )
         return {
             "tenant": tenant, "user": user, "form": form,
-            "root": root, "child": child, "level": level,
+            "root": root, "child": child,
+            "level": level, "child_level": child_level,
         }
 
     def auth(self, user):

--- a/backend/utils/upload_entities.py
+++ b/backend/utils/upload_entities.py
@@ -71,7 +71,7 @@ def normalize_string(s):
     return s.strip().replace('"', '')
 
 
-def validate_entity_data(filename: str):
+def validate_entity_data(filename: str, tenant=None):
     errors = []
     last_level = Levels.objects.all().order_by("level").last()
     xl = pd.ExcelFile(filename)
@@ -82,7 +82,9 @@ def validate_entity_data(filename: str):
         if all(cell.value is None for row
                in check_sheet.iter_rows() for cell in row):
             continue
-        entity = Entity.objects.filter(name=sheet).first()
+        entity = Entity.objects.filter(
+            name=sheet, tenant=tenant
+        ).first()
         if not entity:
             continue
         df = pd.read_excel(filename, sheet_name=entity.name)
@@ -154,7 +156,7 @@ def validate_entity_data(filename: str):
     return errors
 
 
-def validate_entity_file(filename: str):
+def validate_entity_file(filename: str, tenant=None):
     xl = pd.ExcelFile(filename)
     wb = openpyxl.load_workbook(filename)
     sheet_names = xl.sheet_names
@@ -166,7 +168,9 @@ def validate_entity_file(filename: str):
         if all(cell.value is None for row
                in check_sheet.iter_rows() for cell in row):
             continue
-        entity = Entity.objects.filter(name=sheet).first()
+        entity = Entity.objects.filter(
+            name=sheet, tenant=tenant
+        ).first()
         if not entity:
             errors.append({
                 "sheet": sheet,

--- a/backend/utils/upload_entities.py
+++ b/backend/utils/upload_entities.py
@@ -82,9 +82,7 @@ def validate_entity_data(filename: str, tenant=None):
         if all(cell.value is None for row
                in check_sheet.iter_rows() for cell in row):
             continue
-        entity = Entity.objects.filter(
-            name=sheet, tenant=tenant
-        ).first()
+        entity = Entity.objects.filter(name=sheet, tenant=tenant).first()
         if not entity:
             continue
         df = pd.read_excel(filename, sheet_name=entity.name)
@@ -168,9 +166,7 @@ def validate_entity_file(filename: str, tenant=None):
         if all(cell.value is None for row
                in check_sheet.iter_rows() for cell in row):
             continue
-        entity = Entity.objects.filter(
-            name=sheet, tenant=tenant
-        ).first()
+        entity = Entity.objects.filter(name=sheet, tenant=tenant).first()
         if not entity:
             errors.append({
                 "sheet": sheet,


### PR DESCRIPTION
Closes #271

Iteration 4 of the multi-tenant SaaS roadmap: every write observes tenant
ownership. Stacked on `feature/270-tenant-isolation-read-filtering` (#281),
which is still open — that is the base branch.

---

## This unblocks the epic branch

#281 filtered reads but left writes unstamped, so a create landed with
`tenant = NULL` and vanished from its own creator's lists. That made
iteration 3 undeployable and is why #281 carries a "do not deploy the epic"
warning. **This PR closes that gap.** Verified live on a fresh two-tenant
database:

```
create entity → 201    acme sees: ['Water Point']
create form   → 201    acme forms: ['Household Survey']   beta forms: []
```

Reads and writes now both observe ownership, which was the condition on the
gate. Suggested sequence: merge #281, then this, then re-run the two-tenant
walkthrough on the merged epic before treating the gate as lifted.

## The three threats

Write enforcement is not one change. Each threat gets its own mechanism:

**(a) Stamping.** `TenantStampedSerializerMixin.create()` sets the new row's
tenant from the authenticated user — never from the payload. A test asserts a
create carrying `"tenant": <other id>` is stamped to the caller regardless.

The plan expected two variants: the mixin where `create()` is default, and
explicit assignment where it is overridden. Only the mixin was needed — all
three custom `create()` methods call `super().create()`, so the mixin sits
behind them in the MRO and stamps on the way through.

**(b) Guarding.** Write detail lookups run through `for_user`, so a PUT or
DELETE aimed at another tenant's object returns **404**. Most of this was
already true: #270 scoped `get_object_or_404` and those same lookups serve the
write verbs. The tests here pin it down so a refactor cannot quietly reopen it.

**(c) Input-FK validation.** `TenantScopedPrimaryKeyRelatedField` narrows a
foreign-key input's candidates via `for_user`, so a pk pointing at another
tenant fails validation with a **400** before any write. It composes with the
`queryset`-assigned-in-`__init__` pattern already used here rather than
replacing it.

The 404/400 split is deliberate: one is "the thing you addressed isn't yours"
(indistinguishable from "doesn't exist"), the other is "a value you submitted
is invalid".

## Five holes the plan's checklist did not cover

1. **`validate_parent` and `_assign_level`** resolved the child tier with
   `Levels.objects.get(level=n)`. Level numbers are unique per tenant, not
   globally, so with a second tenant present these matched two rows and raised
   `MultipleObjectsReturned` — creating *any* child administration was a
   **500**, not a leak. Read filtering missed them because they live in a
   serializer validator, not a view queryset.
2. **Monitoring forms could be parented to another tenant's form** — the
   parent id was resolved against every form in the table.
3. **Form import matched the id inside the uploaded file unscoped**, so an
   import could target a form the importer does not own.
4. **Bulk upload split spreadsheet columns using a global `Levels.count()`**,
   cutting at the wrong column, and its existing-row match compared names
   without a tenant, so one tenant's upload could attach its subtree to
   another tenant's unit.
5. **Form duplication and form import created tenant-less forms.** Neither
   goes through a create serializer, so the per-threat tasks never reached
   them; the write-endpoint audit did.

## Async path

The bulk-upload handlers already load the uploading user; they now pass
`user.tenant` through the seeding functions, so spreadsheet onboarding — the
largest data-entry path there is — produces rows the uploader can see. The
`tenant` argument defaults to `None` throughout, so the test seeders keep
producing tenant-less rows unchanged.

Entity data has no tenant column — it derives ownership from its entity — so
the fix there is scoping the entity lookup the uploaded sheet name resolves
to.

## Verification

- 1443 backend tests, `flake8` clean
- Live two-tenant walkthrough: `DELETE`/`PUT` on beta's form → **404** with
  the form intact; a monitoring form parented to beta's form → **400**; a
  payload carrying `"tenant": <beta>` → row stamped **acme**

## Notes for the reviewer

- **Iteration 7 supersedes the bulk-upload fixes here.** Its spec already
  covers "match within the tenant" and "resolve level 0 to the existing root",
  plus template scoping. The changes in this PR are the minimum to stop
  iteration 4's own goal from breaking; expect to redo them properly there.
- **Form import is not covered by any later iteration.** I grepped every spec:
  iteration 10 is export/download jobs, iteration 7 is administration bulk
  upload. Nothing revisits form import, which is why holes 3 and 5b carry the
  only two dedicated tests in `tests_form_import_tenant.py` — each confirmed
  to fail with its fix reverted.
- **One hole is patched but untested:** the bulk-upload column split (4b). The
  surrounding path is covered, and testing the split itself means building
  per-tenant `generate_template` output for a one-line filter. Iteration 7
  will replace it.
- **Still unscoped, out of scope here:** `upload_entities.py:73`,
  `last_level = Levels.objects.all().order_by("level").last()` — same class as
  the two level lookups fixed in `v1_profile/serializers.py`. Flagging rather
  than widening this PR.
- The last commit is a complexity-only pass: no behaviour change.


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1216901353714073