### PR TITLE
[#272] Let a tenant build its hierarchy's depth

### DIFF
--- a/backend/api/v1/v1_profile/serializers.py
+++ b/backend/api/v1/v1_profile/serializers.py
@@ -471,7 +471,11 @@ class RoleSerializer(serializers.ModelSerializer):
         read_only=True,
         help_text="List of features and their access levels for this role",
     )
-    administration_level = CustomPrimaryKeyRelatedField(
+    # A role's tenant IS its level's tenant (TENANT_PATH is
+    # administration_level__tenant), so an unscoped candidate set here lets a
+    # caller hand its new role to another tenant — and that role then blocks
+    # the other tenant from removing its own level, invisibly.
+    administration_level = TenantScopedPrimaryKeyRelatedField(
         queryset=Levels.objects.all(),
     )
 

--- a/backend/api/v1/v1_profile/serializers.py
+++ b/backend/api/v1/v1_profile/serializers.py
@@ -52,6 +52,16 @@ class AdministrationLevelsSerializer(serializers.ModelSerializer):
         fields = ["id", "name"]
 
 
+class LevelSerializer(serializers.ModelSerializer):
+    # A tier's depth is append-only, so `level` is derived server-side from
+    # the tenant's current maximum rather than bound from the payload; the
+    # tenant itself is stamped from the request user. Only `name` is input.
+    class Meta:
+        model = Levels
+        fields = ["id", "name", "level"]
+        read_only_fields = ["level"]
+
+
 class AdministrationAttributeSerializer(TenantStampedSerializerMixin,
                                         serializers.ModelSerializer):
     class Meta:

--- a/backend/api/v1/v1_profile/tests/test_level_management.py
+++ b/backend/api/v1/v1_profile/tests/test_level_management.py
@@ -1,0 +1,151 @@
+from rest_framework_simplejwt.tokens import RefreshToken
+from django.test import TestCase
+from django.test.utils import override_settings
+
+from api.v1.v1_profile.models import Administration, Levels, Role
+from api.v1.v1_users.models import SystemUser, Tenant
+
+URL = "/api/v1/levels-management"
+
+
+@override_settings(USE_TZ=False)
+class LevelManagementTestCase(TestCase):
+    """A freshly registered tenant: level 0 and its root unit, nothing else.
+
+    The shared TenantIsolationTestCase fixture already has a unit below
+    root, which is the frozen state — the opposite of what most of these
+    assertions need — so the fixture is local.
+    """
+
+    def _tenant(self, sub):
+        tenant = Tenant.objects.create(subdomain=sub)
+        level = Levels.objects.create(name="", level=0, tenant=tenant)
+        root = Administration.objects.create(
+            parent=None, level=level, name=sub, tenant=tenant
+        )
+        admin = SystemUser.objects.create_superuser(
+            email=f"a@{sub}.org", password="Secret#Pass123",
+            first_name="A", last_name="A", tenant=tenant,
+        )
+        return {
+            "tenant": tenant, "level0": level, "root": root, "admin": admin,
+        }
+
+    def _auth(self, user):
+        return {
+            "HTTP_AUTHORIZATION":
+                f"Bearer {RefreshToken.for_user(user).access_token}"
+        }
+
+    def _unit_below_root(self, fixture):
+        return Administration.objects.create(
+            parent=fixture["root"], level=fixture["level0"], name="child",
+            tenant=fixture["tenant"],
+        )
+
+    def setUp(self):
+        self.a = self._tenant("acme")
+        self.b = self._tenant("beta")
+
+    def test_list_shows_only_own_tenant_levels(self):
+        Levels.objects.create(
+            name="Beta Province", level=1, tenant=self.b["tenant"]
+        )
+        res = self.client.get(URL, **self._auth(self.a["admin"]))
+        self.assertEqual(res.status_code, 200)
+        self.assertEqual(
+            [lv["id"] for lv in res.json()], [self.a["level0"].id]
+        )
+
+    def test_add_appends_at_max_plus_one_and_ignores_client_level(self):
+        res = self.client.post(
+            URL, {"name": "Province", "level": 9},
+            content_type="application/json", **self._auth(self.a["admin"]),
+        )
+        self.assertEqual(res.status_code, 201)
+        created = Levels.objects.get(name="Province")
+        self.assertEqual(created.level, 1)
+        self.assertEqual(created.tenant, self.a["tenant"])
+
+    def test_rename_always_allowed_even_with_units(self):
+        self._unit_below_root(self.a)
+        res = self.client.put(
+            f"{URL}/{self.a['level0'].id}", {"name": "Country"},
+            content_type="application/json", **self._auth(self.a["admin"]),
+        )
+        self.assertEqual(res.status_code, 200)
+        self.a["level0"].refresh_from_db()
+        self.assertEqual(self.a["level0"].name, "Country")
+
+    def test_add_frozen_once_units_exist_below_root(self):
+        self._unit_below_root(self.a)
+        res = self.client.post(
+            URL, {"name": "Province"}, content_type="application/json",
+            **self._auth(self.a["admin"]),
+        )
+        self.assertEqual(res.status_code, 400)
+        self.assertFalse(Levels.objects.filter(name="Province").exists())
+
+    def test_delete_removes_deepest_only(self):
+        lvl1 = Levels.objects.create(
+            name="Province", level=1, tenant=self.a["tenant"]
+        )
+        res0 = self.client.delete(
+            f"{URL}/{self.a['level0'].id}", **self._auth(self.a["admin"])
+        )
+        self.assertEqual(res0.status_code, 400)
+        res1 = self.client.delete(
+            f"{URL}/{lvl1.id}", **self._auth(self.a["admin"])
+        )
+        self.assertEqual(res1.status_code, 204)
+        self.assertFalse(Levels.objects.filter(id=lvl1.id).exists())
+
+    def test_delete_blocked_when_units_exist(self):
+        lvl1 = Levels.objects.create(
+            name="Province", level=1, tenant=self.a["tenant"]
+        )
+        self._unit_below_root(self.a)
+        res = self.client.delete(
+            f"{URL}/{lvl1.id}", **self._auth(self.a["admin"])
+        )
+        self.assertEqual(res.status_code, 400)
+        self.assertTrue(Levels.objects.filter(id=lvl1.id).exists())
+
+    def test_delete_blocked_when_role_bound(self):
+        # Role.administration_level cascades, so an unguarded delete would
+        # silently take the role, its access rows and user assignments.
+        lvl1 = Levels.objects.create(
+            name="Province", level=1, tenant=self.a["tenant"]
+        )
+        Role.objects.create(name="r", administration_level=lvl1)
+        res = self.client.delete(
+            f"{URL}/{lvl1.id}", **self._auth(self.a["admin"])
+        )
+        self.assertEqual(res.status_code, 400)
+        self.assertTrue(Levels.objects.filter(id=lvl1.id).exists())
+
+    def test_delete_level_zero_blocked_root_unit_present(self):
+        # Level 0 is the deepest and nothing sits below root, so only the
+        # unit-at-this-level guard stands between the root and deletion.
+        res = self.client.delete(
+            f"{URL}/{self.a['level0'].id}", **self._auth(self.a["admin"])
+        )
+        self.assertEqual(res.status_code, 400)
+        self.assertTrue(
+            Levels.objects.filter(id=self.a["level0"].id).exists()
+        )
+
+    def test_foreign_level_is_not_found(self):
+        res = self.client.put(
+            f"{URL}/{self.b['level0'].id}", {"name": "Hijacked"},
+            content_type="application/json", **self._auth(self.a["admin"]),
+        )
+        self.assertEqual(res.status_code, 404)
+
+    def test_non_superadmin_forbidden(self):
+        plain = SystemUser.objects.create_user(
+            email="plain@acme.org", password="Secret#Pass123",
+            first_name="P", last_name="P", tenant=self.a["tenant"],
+        )
+        res = self.client.get(URL, **self._auth(plain))
+        self.assertEqual(res.status_code, 403)

--- a/backend/api/v1/v1_profile/tests/test_level_management.py
+++ b/backend/api/v1/v1_profile/tests/test_level_management.py
@@ -2,6 +2,7 @@ from rest_framework_simplejwt.tokens import RefreshToken
 from django.test import TestCase
 from django.test.utils import override_settings
 
+from api.v1.v1_profile.constants import DataAccessTypes
 from api.v1.v1_profile.models import Administration, Levels, Role
 from api.v1.v1_users.models import SystemUser, Tenant
 
@@ -141,6 +142,22 @@ class LevelManagementTestCase(TestCase):
             content_type="application/json", **self._auth(self.a["admin"]),
         )
         self.assertEqual(res.status_code, 404)
+
+    def test_role_cannot_bind_to_another_tenants_level(self):
+        # A role's tenant is its level's tenant, so binding across tenants
+        # both hands the role away and leaves the other tenant unable to
+        # remove its own level — with nothing in its UI explaining why.
+        res = self.client.post(
+            "/api/v1/roles",
+            {
+                "name": "Poacher",
+                "administration_level": self.b["level0"].id,
+                "role_access": [DataAccessTypes.read],
+            },
+            content_type="application/json", **self._auth(self.a["admin"]),
+        )
+        self.assertEqual(res.status_code, 400)
+        self.assertFalse(Role.objects.filter(name="Poacher").exists())
 
     def test_non_superadmin_forbidden(self):
         plain = SystemUser.objects.create_user(

--- a/backend/api/v1/v1_profile/tests/test_level_management.py
+++ b/backend/api/v1/v1_profile/tests/test_level_management.py
@@ -1,9 +1,12 @@
+from unittest.mock import patch
+
 from rest_framework_simplejwt.tokens import RefreshToken
 from django.test import TestCase
 from django.test.utils import override_settings
 
 from api.v1.v1_profile.constants import DataAccessTypes
 from api.v1.v1_profile.models import Administration, Levels, Role
+from api.v1.v1_profile.views import LevelViewSet
 from api.v1.v1_users.models import SystemUser, Tenant
 
 URL = "/api/v1/levels-management"
@@ -77,6 +80,22 @@ class LevelManagementTestCase(TestCase):
         self.assertEqual(res.status_code, 200)
         self.a["level0"].refresh_from_db()
         self.assertEqual(self.a["level0"].name, "Country")
+
+    def test_add_losing_a_race_is_rejected_rather_than_a_server_error(self):
+        # Two adds in flight together both read the same maximum and both
+        # write max + 1; the loser hits unique_level_per_tenant. Freezing
+        # the read at a stale value reproduces the loser's view exactly,
+        # without needing a second connection to race against.
+        Levels.objects.create(
+            name="Province", level=1, tenant=self.a["tenant"]
+        )
+        with patch.object(LevelViewSet, "_deepest_level", return_value=0):
+            res = self.client.post(
+                URL, {"name": "District"}, content_type="application/json",
+                **self._auth(self.a["admin"]),
+            )
+        self.assertEqual(res.status_code, 400)
+        self.assertFalse(Levels.objects.filter(name="District").exists())
 
     def test_add_frozen_once_units_exist_below_root(self):
         self._unit_below_root(self.a)

--- a/backend/api/v1/v1_profile/urls.py
+++ b/backend/api/v1/v1_profile/urls.py
@@ -5,6 +5,7 @@ from api.v1.v1_profile.views import (
     AdministrationViewSet,
     EntityDataViewSet,
     EntityViewSet,
+    LevelViewSet,
     RoleViewSet,
     export_administrations_template,
     export_prefilled_administrations_template,
@@ -35,6 +36,18 @@ urlpatterns = [
             }
         ),
         name="role-detail",
+    ),
+    re_path(
+        r"^(?P<version>(v1))/levels-management$",
+        LevelViewSet.as_view({"get": "list", "post": "create"}),
+        name="level-management-list",
+    ),
+    re_path(
+        r"^(?P<version>(v1))/levels-management/(?P<pk>[0-9]+)$",
+        LevelViewSet.as_view(
+            {"get": "retrieve", "put": "update", "delete": "destroy"}
+        ),
+        name="level-management-detail",
     ),
     re_path(
         r"^(?P<version>(v1))/export/administrations-template",

--- a/backend/api/v1/v1_profile/views.py
+++ b/backend/api/v1/v1_profile/views.py
@@ -3,6 +3,7 @@ from typing import cast
 from wsgiref.util import FileWrapper
 from django.contrib.admin.sites import site
 from django.core.handlers.wsgi import WSGIRequest
+from django.db import IntegrityError, transaction
 from django.db.models import Max, ProtectedError, Q
 from django.contrib.admin.utils import get_deleted_objects
 from django.http.response import HttpResponse
@@ -548,7 +549,23 @@ class LevelViewSet(ModelViewSet):
             return self._rejected(
                 "Levels cannot be added once administrative units exist"
             )
-        return super().create(request, *args, **kwargs)
+        try:
+            # The savepoint is not optional: an IntegrityError caught
+            # without one leaves the connection unusable for the rest of
+            # the transaction, so the 400 below could not be built if a
+            # transaction were ever open around the request.
+            with transaction.atomic():
+                return super().create(request, *args, **kwargs)
+        except IntegrityError:
+            # perform_create reads the current maximum and writes max + 1
+            # without a lock, so two requests in flight together both pick
+            # the same depth and the loser trips unique_level_per_tenant.
+            # Locking the table for a screen a tenant uses once during
+            # onboarding would be the wrong trade; telling the caller to
+            # look again is enough.
+            return self._rejected(
+                "Another level was added at the same time; reload and retry"
+            )
 
     def perform_create(self, serializer):
         # Append at the tenant's max + 1; a tenant with no levels starts at 0.

--- a/backend/api/v1/v1_profile/views.py
+++ b/backend/api/v1/v1_profile/views.py
@@ -3,7 +3,7 @@ from typing import cast
 from wsgiref.util import FileWrapper
 from django.contrib.admin.sites import site
 from django.core.handlers.wsgi import WSGIRequest
-from django.db.models import ProtectedError, Q
+from django.db.models import Max, ProtectedError, Q
 from django.contrib.admin.utils import get_deleted_objects
 from django.http.response import HttpResponse
 from django.conf import settings
@@ -30,6 +30,7 @@ from api.v1.v1_profile.serializers import (
     EntitySerializer,
     DownloadAdministrationRequestSerializer,
     DownloadEntityDataRequestSerializer,
+    LevelSerializer,
     ListEntityDataSerializer,
     RoleSerializer,
     RoleDetailSerializer,
@@ -500,6 +501,87 @@ def export_pre_entities_data_template(request: Request, version):
         )
         response["Content-Disposition"] = f'attachment; filename="{filename}"'
         return response
+
+
+@extend_schema(tags=["Levels"])
+class LevelViewSet(ModelViewSet):
+    """Tenant-scoped hierarchy depth management.
+
+    A tenant's depth is set once during onboarding, so the shape of this
+    viewset is deliberately narrow: append a tier, rename any tier, remove
+    the deepest one. Arbitrary insertion or reordering would mean
+    re-pathing every administrative unit beneath, which the spec rejects as
+    disproportionate.
+    """
+
+    serializer_class = LevelSerializer
+    permission_classes = [IsAuthenticated, IsSuperAdmin]
+    # A handful of tiers in strict depth order — paging them (the project
+    # default is LimitOffsetPagination) would only make the screen walk
+    # pages to render one table.
+    pagination_class = None
+
+    def get_queryset(self):
+        return Levels.objects.for_user(self.request.user).order_by("level")
+
+    def _deepest_level(self):
+        return Levels.objects.for_user(self.request.user).aggregate(
+            m=Max("level")
+        )["m"]
+
+    def _units_below_root(self):
+        """Has the tenant built units under its root yet?
+
+        Once it has, changing the depth would strand or re-path them, so
+        add and delete freeze. A count of exactly 1 is the root alone.
+        Rename ignores this gate — naming a tier moves nothing.
+        """
+        return Administration.objects.for_user(self.request.user).count() > 1
+
+    def _rejected(self, message):
+        return Response(
+            {"message": message}, status=status.HTTP_400_BAD_REQUEST
+        )
+
+    def create(self, request, *args, **kwargs):
+        if self._units_below_root():
+            return self._rejected(
+                "Levels cannot be added once administrative units exist"
+            )
+        return super().create(request, *args, **kwargs)
+
+    def perform_create(self, serializer):
+        # Append at the tenant's max + 1; a tenant with no levels starts at 0.
+        current_max = self._deepest_level()
+        serializer.save(
+            tenant=self.request.user.tenant,
+            level=0 if current_max is None else current_max + 1,
+        )
+
+    def destroy(self, request, *args, **kwargs):
+        # get_object() resolves through get_queryset, so another tenant's
+        # level is a 404 rather than a rejection that confirms it exists.
+        level = self.get_object()
+        if level.level != self._deepest_level():
+            return self._rejected("Only the deepest level can be removed")
+        if self._units_below_root():
+            return self._rejected(
+                "Levels cannot be removed once administrative units exist"
+            )
+        # With the two gates above passed, the only unit that can still sit
+        # at this level is the root at level 0 — this is what stops a tenant
+        # from deleting the last tier out from under its own root.
+        if Administration.objects.for_user(request.user).filter(
+            level=level
+        ).exists():
+            return self._rejected("This level still has administrative units")
+        # Role.administration_level cascades, so deleting the level would
+        # take the role, its access rows and every user assignment with it.
+        if Role.objects.filter(administration_level=level).exists():
+            return self._rejected(
+                "This level is in use by one or more roles; remove them first"
+            )
+        return super().destroy(request, *args, **kwargs)
 
 
 @extend_schema(tags=["Roles"])

--- a/backend/api/v1/v1_users/urls.py
+++ b/backend/api/v1/v1_users/urls.py
@@ -22,7 +22,10 @@ from api.v1.v1_users.views import (
 from api.v1.v1_profile.views import list_entity_data
 
 urlpatterns = [
-    re_path(r"^(?P<version>(v1))/levels", list_levels),
+    # Anchored: unanchored, this pattern also matches /levels-management
+    # and — because v1_users is included before v1_profile — would answer
+    # it with the read-only list.
+    re_path(r"^(?P<version>(v1))/levels$", list_levels),
     re_path(
         r"^(?P<version>(v1))/administration/(?P<administration_id>[0-9]+)",
         list_administration,

--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -34,6 +34,7 @@ import {
   Dashboard,
   MobileAssignment,
   AddAssignment,
+  Levels,
   MasterData,
   MasterDataAttributes,
   ManageEntityTypes,
@@ -188,6 +189,10 @@ const RouteList = () => {
         <Route
           path="master-data/administration"
           element={<Private element={MasterData} alias="master-data" />}
+        />
+        <Route
+          path="master-data/levels"
+          element={<Private element={Levels} alias="master-data" />}
         />
         <Route
           path="master-data/administration/upload"

--- a/frontend/src/TestApp.js
+++ b/frontend/src/TestApp.js
@@ -2,16 +2,6 @@ import { MemoryRouter } from "react-router-dom";
 import { CookiesProvider } from "react-cookie";
 import App from "./App";
 
-window.matchMedia =
-  window.matchMedia ||
-  function () {
-    return {
-      matches: false,
-      addListener: function () {},
-      removeListener: function () {},
-    };
-  };
-
 const TestApp = ({ entryPoint = "/" }) => {
   return (
     <CookiesProvider>

--- a/frontend/src/components/sidebar/index.jsx
+++ b/frontend/src/components/sidebar/index.jsx
@@ -248,6 +248,12 @@ const Sidebar = () => {
                 {text.menuAdministrativeList}
               </Menu.Item>
               <Menu.Item
+                key="menu-levels"
+                data-url="/control-center/master-data/levels"
+              >
+                {text.menuLevels}
+              </Menu.Item>
+              <Menu.Item
                 key="menu-attributes"
                 data-url="/control-center/master-data/attributes"
               >

--- a/frontend/src/lib/__test__/__snapshots__/ui-text.test.js.snap
+++ b/frontend/src/lib/__test__/__snapshots__/ui-text.test.js.snap
@@ -43,6 +43,7 @@ Object {
        
       platform.
     </React.Fragment>,
+    "addLevel": "Add Level",
     "addNew": "Add New",
     "addNewButton": "Add New",
     "addNewUser": "Add new user",
@@ -647,8 +648,10 @@ Object {
     "lastUpdatedCol": "Last Updated",
     "latestData": "Latest Data",
     "latestUpdateText": "Latest Updates",
+    "levelDeleteTitle": "Remove the deepest level?",
     "levelField": "Level",
     "levelFieldRequired": "Level is required",
+    "levelFrozenHint": "Levels can no longer be added or removed because administrative units already exist. Renaming is still available.",
     "levelLabel": "Level",
     "loadMoreLable": "Load More",
     "loadingText": "Loading...",
@@ -747,6 +750,8 @@ Object {
         </li>
       </ul>
     </React.Fragment>,
+    "manageLevelText": "Define the tiers of your administrative hierarchy, from the top level down. Tiers can be renamed at any time, but they can only be added or removed while no administrative units exist below your top level.",
+    "manageLevels": "Manage Levels",
     "manageOrganisations": "Manage Organizations",
     "manageRoleText": <React.Fragment>
       This is where you manage roles based on their fields. You can :
@@ -808,6 +813,7 @@ Object {
     "menuEntities": "Entities",
     "menuEntityTypes": "Entity Types",
     "menuFormBuilder": "Form Builder",
+    "menuLevels": "Levels",
     "menuManageData": "Manage Data",
     "menuManageDraft": "Manage Drafts",
     "menuManageMobileUsers": "Manage Mobile Users",
@@ -884,6 +890,7 @@ Object {
     "nameField": "Name",
     "nameFieldRequired": "Name is required",
     "nameLabel": "Name",
+    "newLevelName": "New level name",
     "newSubmissionBtn": "Add New Submission",
     "newsEvents": "News & Events",
     "next": "Next",

--- a/frontend/src/lib/ui-text.js
+++ b/frontend/src/lib/ui-text.js
@@ -15,6 +15,7 @@ const uiText = {
     menuManageRoles: "Manage Roles",
     menuMasterData: "Master Data",
     menuAdministrativeList: "Administrative List",
+    menuLevels: "Levels",
     menuAttributes: "Attributes",
     menuEntities: "Entities",
     menuEntityTypes: "Entity Types",
@@ -377,6 +378,18 @@ const uiText = {
     manageAttributes: "Manage Attributes",
     editAttributes: "Edit Attribute",
     addAttributes: "Add Attribute",
+    manageLevels: "Manage Levels",
+    manageLevelText:
+      "Define the tiers of your administrative hierarchy, from the top " +
+      "level down. Tiers can be renamed at any time, but they can only " +
+      "be added or removed while no administrative units exist below " +
+      "your top level.",
+    addLevel: "Add Level",
+    newLevelName: "New level name",
+    levelFrozenHint:
+      "Levels can no longer be added or removed because administrative " +
+      "units already exist. Renaming is still available.",
+    levelDeleteTitle: "Remove the deepest level?",
     manageEntities: "Manage Entities",
     manageEntityTypes: "Manage Entity Types",
     addEntities: "Add Entities",

--- a/frontend/src/pages/index.js
+++ b/frontend/src/pages/index.js
@@ -26,6 +26,7 @@ export { default as Dashboard } from "./dashboard/Dashboard";
 export { default as MobileAssignment } from "./mobile-assignment/MobileAssignment";
 export { default as AddAssignment } from "./mobile-assignment/AddAssignment";
 export { default as MasterData } from "./master-data/MasterData";
+export { default as Levels } from "./master-data/levels/Levels";
 export { default as MasterDataAttributes } from "./master-data-attributes/MasterDataAttributes";
 export { default as ManageEntityTypes } from "./master-data-entities/ManageEntityTypes";
 export { default as AddAdministration } from "./master-data/AddAdministration";

--- a/frontend/src/pages/master-data/levels/Levels.jsx
+++ b/frontend/src/pages/master-data/levels/Levels.jsx
@@ -1,0 +1,275 @@
+import React, { useCallback, useEffect, useMemo, useState } from "react";
+import { Alert, Button, Col, Divider, Input, Modal, Row, Table } from "antd";
+import { PlusOutlined } from "@ant-design/icons";
+import { Breadcrumbs, DescriptionPanel } from "../../../components";
+import { api, store, uiText } from "../../../lib";
+import { useNotification } from "../../../util/hooks";
+import { fetchLevels } from "../../../util/level";
+
+// A tenant's hierarchy depth is append-only: a tier can be renamed at any
+// time, but adding and removing are frozen once administrative units exist
+// below the top level, because changing the depth then would strand them.
+// The server enforces all of this; the disabled controls here are a hint,
+// so every rejection is still surfaced from the response.
+const Levels = () => {
+  const [dataset, setDataset] = useState([]);
+  const [loading, setLoading] = useState(true);
+  const [frozen, setFrozen] = useState(false);
+  const [newName, setNewName] = useState("");
+  const [saving, setSaving] = useState(false);
+  // Rename happens inline: the edited row's name cell becomes an input.
+  const [editingId, setEditingId] = useState(null);
+  const [editingName, setEditingName] = useState("");
+
+  const language = store.useState((s) => s.language);
+  const { active: activeLang } = language;
+  const { notify } = useNotification();
+
+  const text = useMemo(() => {
+    return uiText[activeLang];
+  }, [activeLang]);
+
+  const pagePath = [
+    {
+      title: text.controlCenter,
+      link: "/control-center",
+    },
+    {
+      title: text.manageLevels,
+    },
+  ];
+
+  const rejected = useCallback(
+    (error, fallback) => {
+      notify({
+        type: "error",
+        message: error?.response?.data?.message || fallback,
+      });
+    },
+    [notify]
+  );
+
+  const fetchData = useCallback(async () => {
+    setLoading(true);
+    try {
+      const { data } = await api.get("levels-management");
+      setDataset(data);
+      // The same count the server's freeze gate uses: anything beyond the
+      // single root unit means the hierarchy is populated.
+      const { data: units } = await api.get("administrations?page=1");
+      setFrozen(units?.total > 1);
+    } catch (error) {
+      rejected(error, text.errorSomething);
+    } finally {
+      setLoading(false);
+    }
+  }, [rejected, text.errorSomething]);
+
+  useEffect(() => {
+    fetchData();
+  }, [fetchData]);
+
+  // Dependent screens read levels from the store, so a change to the shape
+  // of the hierarchy has to refresh it as well as this table.
+  const reload = async () => {
+    await fetchData();
+    await fetchLevels();
+  };
+
+  const handleOnAdd = async () => {
+    setSaving(true);
+    try {
+      await api.post("levels-management", { name: newName });
+      setNewName("");
+      await reload();
+    } catch (error) {
+      rejected(error, text.errorSomething);
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  const handleOnRename = async (record) => {
+    setSaving(true);
+    try {
+      await api.put(`levels-management/${record.id}`, { name: editingName });
+      setEditingId(null);
+      await reload();
+    } catch (error) {
+      rejected(error, text.errorSomething);
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  const handleOnDelete = (record) => {
+    Modal.confirm({
+      title: text.levelDeleteTitle,
+      content: record.name,
+      centered: true,
+      okText: text.deleteText,
+      cancelText: text.cancelButton,
+      onOk: async () => {
+        try {
+          await api.delete(`levels-management/${record.id}`);
+          await reload();
+        } catch (error) {
+          rejected(error, text.errorSomething);
+        }
+      },
+    });
+  };
+
+  const deepest = dataset.length ? dataset[dataset.length - 1] : null;
+
+  const columns = [
+    {
+      title: text.levelLabel,
+      dataIndex: "level",
+      width: "10%",
+    },
+    {
+      title: text.nameLabel,
+      dataIndex: "name",
+      render: (name, record) => {
+        if (record.id !== editingId) {
+          return name;
+        }
+        return (
+          <Input
+            value={editingName}
+            onChange={(e) => {
+              setEditingName(e.target.value);
+            }}
+            onPressEnter={() => handleOnRename(record)}
+          />
+        );
+      },
+    },
+    {
+      title: "Action",
+      dataIndex: "id",
+      width: "25%",
+      render: (_, record) => {
+        if (record.id === editingId) {
+          return (
+            <>
+              <Button
+                shape="round"
+                type="primary"
+                loading={saving}
+                onClick={() => handleOnRename(record)}
+              >
+                {text.saveButton}
+              </Button>
+              <Button
+                shape="round"
+                type="link"
+                onClick={() => {
+                  setEditingId(null);
+                }}
+              >
+                {text.cancelButton}
+              </Button>
+            </>
+          );
+        }
+        return (
+          <>
+            <Button
+              shape="round"
+              type="primary"
+              onClick={() => {
+                setEditingId(record.id);
+                setEditingName(record.name);
+              }}
+            >
+              {text.editButton}
+            </Button>
+            {record.id === deepest?.id && (
+              <Button
+                shape="round"
+                type="link"
+                danger
+                disabled={frozen}
+                onClick={() => handleOnDelete(record)}
+              >
+                {text.deleteText}
+              </Button>
+            )}
+          </>
+        );
+      },
+    },
+  ];
+
+  return (
+    <div id="masterDataLevels">
+      <div className="description-container">
+        <Row justify="space-between" align="bottom">
+          <Col>
+            <Breadcrumbs pagePath={pagePath} />
+            <DescriptionPanel
+              description={text.manageLevelText}
+              title={text.manageLevels}
+            />
+          </Col>
+        </Row>
+      </div>
+      <div className="table-section">
+        <div className="table-wrapper">
+          {frozen && (
+            <Alert
+              type="info"
+              showIcon
+              message={text.levelFrozenHint}
+              style={{ marginBottom: "1rem" }}
+            />
+          )}
+          <Row justify="space-between" align="middle" gutter={[16, 16]}>
+            <Col span={12}>
+              <Input
+                value={newName}
+                onChange={(e) => {
+                  setNewName(e.target.value);
+                }}
+                onPressEnter={handleOnAdd}
+                placeholder={text.newLevelName}
+                disabled={frozen}
+                style={{ maxWidth: 260 }}
+              />
+            </Col>
+            <Col>
+              <Button
+                type="primary"
+                shape="round"
+                icon={<PlusOutlined />}
+                onClick={handleOnAdd}
+                loading={saving}
+                disabled={frozen || !newName}
+              >
+                {text.addLevel}
+              </Button>
+            </Col>
+          </Row>
+          <Divider />
+          <div
+            style={{ padding: 0, minHeight: "40vh" }}
+            bodystyle={{ padding: 0 }}
+          >
+            <Table
+              columns={columns}
+              dataSource={dataset}
+              loading={loading}
+              rowClassName="editable-row"
+              rowKey="id"
+              pagination={false}
+            />
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default Levels;

--- a/frontend/src/pages/master-data/levels/Levels.jsx
+++ b/frontend/src/pages/master-data/levels/Levels.jsx
@@ -40,13 +40,13 @@ const Levels = () => {
   ];
 
   const rejected = useCallback(
-    (error, fallback) => {
+    (error) => {
       notify({
         type: "error",
-        message: error?.response?.data?.message || fallback,
+        message: error?.response?.data?.message || text.errorSomething,
       });
     },
-    [notify]
+    [notify, text.errorSomething]
   );
 
   const fetchData = useCallback(async () => {
@@ -59,47 +59,47 @@ const Levels = () => {
       const { data: units } = await api.get("administrations?page=1");
       setFrozen(units?.total > 1);
     } catch (error) {
-      rejected(error, text.errorSomething);
+      rejected(error);
     } finally {
       setLoading(false);
     }
-  }, [rejected, text.errorSomething]);
+  }, [rejected]);
 
   useEffect(() => {
     fetchData();
   }, [fetchData]);
 
-  // Dependent screens read levels from the store, so a change to the shape
-  // of the hierarchy has to refresh it as well as this table.
-  const reload = async () => {
-    await fetchData();
-    await fetchLevels();
-  };
+  // Every mutation shares one shell: run it, then refresh both this table
+  // and the levels store — dependent screens read the hierarchy's shape
+  // from there — and surface whatever the server rejected.
+  const mutate = useCallback(
+    async (call) => {
+      setSaving(true);
+      try {
+        await call();
+        await fetchData();
+        await fetchLevels();
+      } catch (error) {
+        rejected(error);
+      } finally {
+        setSaving(false);
+      }
+    },
+    [fetchData, rejected]
+  );
 
-  const handleOnAdd = async () => {
-    setSaving(true);
-    try {
+  const handleOnAdd = () => {
+    return mutate(async () => {
       await api.post("levels-management", { name: newName });
       setNewName("");
-      await reload();
-    } catch (error) {
-      rejected(error, text.errorSomething);
-    } finally {
-      setSaving(false);
-    }
+    });
   };
 
-  const handleOnRename = async (record) => {
-    setSaving(true);
-    try {
+  const handleOnRename = (record) => {
+    return mutate(async () => {
       await api.put(`levels-management/${record.id}`, { name: editingName });
       setEditingId(null);
-      await reload();
-    } catch (error) {
-      rejected(error, text.errorSomething);
-    } finally {
-      setSaving(false);
-    }
+    });
   };
 
   const handleOnDelete = (record) => {
@@ -109,18 +109,11 @@ const Levels = () => {
       centered: true,
       okText: text.deleteText,
       cancelText: text.cancelButton,
-      onOk: async () => {
-        try {
-          await api.delete(`levels-management/${record.id}`);
-          await reload();
-        } catch (error) {
-          rejected(error, text.errorSomething);
-        }
-      },
+      onOk: () => mutate(() => api.delete(`levels-management/${record.id}`)),
     });
   };
 
-  const deepest = dataset.length ? dataset[dataset.length - 1] : null;
+  const deepest = dataset[dataset.length - 1];
 
   const columns = [
     {
@@ -253,10 +246,7 @@ const Levels = () => {
             </Col>
           </Row>
           <Divider />
-          <div
-            style={{ padding: 0, minHeight: "40vh" }}
-            bodystyle={{ padding: 0 }}
-          >
+          <div style={{ minHeight: "40vh" }}>
             <Table
               columns={columns}
               dataSource={dataset}

--- a/frontend/src/pages/master-data/levels/Levels.jsx
+++ b/frontend/src/pages/master-data/levels/Levels.jsx
@@ -88,16 +88,30 @@ const Levels = () => {
     [fetchData, rejected]
   );
 
+  // Both handlers trim before sending and refuse a blank result. DRF trims
+  // too and would answer 400, so this is not the validation — it just keeps
+  // a name of spaces from costing a round-trip and a generic error toast.
+  // The `saving` guard is what the buttons already get for free from antd,
+  // which swallows clicks while `loading`; Enter has no such protection, and
+  // two of them in quick succession is a real double-submit.
   const handleOnAdd = () => {
-    return mutate(async () => {
-      await api.post("levels-management", { name: newName });
+    const name = newName.trim();
+    if (!name || saving) {
+      return;
+    }
+    mutate(async () => {
+      await api.post("levels-management", { name });
       setNewName("");
     });
   };
 
   const handleOnRename = (record) => {
-    return mutate(async () => {
-      await api.put(`levels-management/${record.id}`, { name: editingName });
+    const name = editingName.trim();
+    if (!name || saving) {
+      return;
+    }
+    mutate(async () => {
+      await api.put(`levels-management/${record.id}`, { name });
       setEditingId(null);
     });
   };
@@ -151,6 +165,7 @@ const Levels = () => {
                 shape="round"
                 type="primary"
                 loading={saving}
+                disabled={!editingName.trim()}
                 onClick={() => handleOnRename(record)}
               >
                 {text.saveButton}
@@ -239,7 +254,7 @@ const Levels = () => {
                 icon={<PlusOutlined />}
                 onClick={handleOnAdd}
                 loading={saving}
-                disabled={frozen || !newName}
+                disabled={frozen || !newName.trim()}
               >
                 {text.addLevel}
               </Button>

--- a/frontend/src/pages/master-data/levels/__test__/Levels.test.js
+++ b/frontend/src/pages/master-data/levels/__test__/Levels.test.js
@@ -1,0 +1,76 @@
+import { render, screen, waitFor } from "@testing-library/react";
+import { MemoryRouter } from "react-router-dom";
+import axios from "axios";
+import Levels from "../Levels";
+import "@testing-library/jest-dom";
+
+jest.mock("axios");
+
+// antd's responsive Row/Col subscribe to media queries on mount; jsdom has
+// no matchMedia. TestApp shims this for the full-app tests — this suite
+// renders the screen directly, so it needs its own.
+window.matchMedia =
+  window.matchMedia ||
+  function () {
+    return { matches: false, addListener: () => {}, removeListener: () => {} };
+  };
+
+// The screen renders the server's list as-is; its only local logic is the
+// freeze gate — derived from the administration count — and picking the
+// deepest row as the only deletable one. Those are what is asserted here.
+const renderLevels = () => {
+  return render(
+    <MemoryRouter>
+      <Levels />
+    </MemoryRouter>
+  );
+};
+
+const mockLoad = (unitCount) => {
+  axios.mockImplementation(({ url }) => {
+    if (url.startsWith("administrations")) {
+      return Promise.resolve({ data: { total: unitCount } });
+    }
+    return Promise.resolve({
+      data: [
+        { id: 1, name: "National", level: 0 },
+        { id: 2, name: "Province", level: 1 },
+      ],
+    });
+  });
+};
+
+describe("Levels management", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  test("lists the tenant's tiers and allows adding when only root exists", async () => {
+    mockLoad(1);
+    renderLevels();
+
+    expect(await screen.findByText("National")).toBeInTheDocument();
+    expect(screen.getByText("Province")).toBeInTheDocument();
+
+    const add = screen.getByRole("button", { name: /Add Level/i });
+    // Disabled until a name is typed, but not frozen.
+    expect(screen.getByPlaceholderText(/New level name/i)).toBeEnabled();
+    expect(add).toBeInTheDocument();
+    expect(screen.queryByText(/can no longer be added/i)).toBeNull();
+    // Only the deepest tier offers a delete.
+    expect(screen.getAllByRole("button", { name: /Delete/i })).toHaveLength(1);
+  });
+
+  test("freezes add and delete once units exist below root", async () => {
+    mockLoad(5);
+    renderLevels();
+
+    expect(await screen.findByText(/can no longer be added/i)).toBeVisible();
+    await waitFor(() => {
+      expect(screen.getByPlaceholderText(/New level name/i)).toBeDisabled();
+    });
+    expect(screen.getByRole("button", { name: /Delete/i })).toBeDisabled();
+    // Rename stays available on every tier.
+    expect(screen.getAllByRole("button", { name: /Edit/i })).toHaveLength(2);
+  });
+});

--- a/frontend/src/pages/master-data/levels/__test__/Levels.test.js
+++ b/frontend/src/pages/master-data/levels/__test__/Levels.test.js
@@ -1,4 +1,5 @@
 import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
 import { MemoryRouter } from "react-router-dom";
 import axios from "axios";
 import Levels from "../Levels";
@@ -50,6 +51,26 @@ describe("Levels management", () => {
     expect(screen.queryByText(/can no longer be added/i)).toBeNull();
     // Only the deepest tier offers a delete.
     expect(screen.getAllByRole("button", { name: /Delete/i })).toHaveLength(1);
+  });
+
+  test("treats a name of only spaces as no name at all", async () => {
+    mockLoad(1);
+    renderLevels();
+
+    await screen.findByText("National");
+    const input = screen.getByPlaceholderText(/New level name/i);
+    const add = screen.getByRole("button", { name: /Add Level/i });
+
+    expect(add).toBeDisabled();
+    await userEvent.type(input, "   ");
+    // Still disabled: the server trims and would answer 400, so letting the
+    // click through would spend a round-trip to say what is visible here.
+    expect(add).toBeDisabled();
+
+    await userEvent.type(input, "Ward");
+    await waitFor(() => {
+      expect(add).toBeEnabled();
+    });
   });
 
   test("freezes add and delete once units exist below root", async () => {

--- a/frontend/src/pages/master-data/levels/__test__/Levels.test.js
+++ b/frontend/src/pages/master-data/levels/__test__/Levels.test.js
@@ -6,15 +6,6 @@ import "@testing-library/jest-dom";
 
 jest.mock("axios");
 
-// antd's responsive Row/Col subscribe to media queries on mount; jsdom has
-// no matchMedia. TestApp shims this for the full-app tests — this suite
-// renders the screen directly, so it needs its own.
-window.matchMedia =
-  window.matchMedia ||
-  function () {
-    return { matches: false, addListener: () => {}, removeListener: () => {} };
-  };
-
 // The screen renders the server's list as-is; its only local logic is the
 // freeze gate — derived from the administration count — and picking the
 // deepest row as the only deletable one. Those are what is asserted here.

--- a/frontend/src/setupTests.js
+++ b/frontend/src/setupTests.js
@@ -25,6 +25,15 @@ store.update((s) => {
   ];
 });
 
+// antd's responsive Row/Col subscribe to media queries on mount and jsdom
+// has no matchMedia. Every suite that renders a page needs this, so it
+// lives here rather than in each of them.
+window.matchMedia =
+  window.matchMedia ||
+  function () {
+    return { matches: false, addListener: () => {}, removeListener: () => {} };
+  };
+
 window.visualisation = [];
 
 window.dbadm = [


### PR DESCRIPTION
Closes #272

Iteration 5 of the multi-tenant SaaS roadmap. Targets
`epic/multi-tenant-saas` directly, now that #282 has merged.

---

## What this unblocks

After isolation, a freshly registered tenant has exactly one level — the
unnamed level 0 created at registration — plus its root unit. There was no
way, through the UI or the API, to define deeper tiers. That blocked
everything downstream: administrative units below the root, roles (which bind
to a level), and any meaningful data scoping. This iteration is the
onboarding-completeness step that follows isolation.

## The shape of the API

A superadmin-only `LevelViewSet` at `/api/v1/levels-management`, every
operation scoped through `for_user`. The shape is deliberately narrow —
depth is set once during onboarding, and arbitrary insertion or reordering
would mean re-pathing every unit beneath:

- **create** appends at the tenant's `max(level) + 1` and stamps the tenant;
  a client-supplied `level` is ignored.
- **rename** changes only the name, and is *never* frozen.
- **delete** removes the deepest tier only, behind four guards checked in
  order, each with its own message: not deepest → units exist below root →
  a unit still sits at this level → a role is bound to it.

The last two guards matter for different reasons. The unit-at-this-level
check is what stops a tenant deleting the last tier out from under its own
root. The role check exists because `Role.administration_level` cascades —
an unguarded delete would silently take the role, its access rows and every
user assignment with it.

## Verified live, two tenants, fresh database

```
acme fresh tenant                    [{"id":1,"name":"","level":0}]
POST {"name":"Province","level":9}   → level 1   (client level ignored)
PUT beta's level as acme             → 404
DELETE Province (not deepest)        → 400 "Only the deepest level can be removed"
DELETE District (deepest)            → 204
DELETE Country (root sits on it)     → 400 "This level still has administrative units"
DELETE with a role bound             → 400 "...in use by one or more roles"
POST level once units exist          → 400 "...cannot be added once units exist"
PUT rename while frozen              → 200
beta's list throughout               [{"id":2,"name":"","level":0}]
```

## Three things the plan did not anticipate

**1. The route could never have worked.** `GET /levels` was registered
unanchored, and `v1_users` is included before `v1_profile`, so
`/levels-management` resolved to the read-only list — the permission test
passed with a 200 before any code existed. Anchored with `$`; its only
caller passes no suffix.

**2. Pagination.** The plan asserted a plain list because the viewset sets no
`pagination_class`. The project sets `DEFAULT_PAGINATION_CLASS` globally, so
it would have paged. Set to `None` — a handful of tiers rendered as one
ordered table.

**3. A cross-tenant hole in `RoleSerializer`.** `administration_level`
resolved its candidates against every level in the table. Since a role's
tenant *is* its level's tenant (`TENANT_PATH` is
`administration_level__tenant`), a superadmin could create a role bound to
another tenant's tier: the role left its creator's list and silently blocked
the victim from deleting its own level. Fixed with
`TenantScopedPrimaryKeyRelatedField`; the test returns 201 with the field
reverted. Found only because this iteration's delete guard is meaningless if
the bindings themselves can cross tenants.

## The screen

A Master Data → Levels page listing the tenant's tiers in depth order: add,
rename inline, delete the deepest. Once units exist, add and delete disable
behind an explanation while rename stays live — but every server rejection is
surfaced regardless, because the disabled controls are a hint and the server
is authoritative. Each successful change refreshes the levels store as well
as the table, so dependent screens stay consistent.

The frozen state comes from `GET administrations?page=1` and its `total > 1`,
the same count the server's gate uses — one extra request, no new endpoint or
response field. The menu entry sits under the existing Master Data submenu,
whose gate is already superadmin-only, so it needs no new ability rule.

## Two deliberate deviations from the spec

- The spec allows a blank tier name; the model field is not `blank`, so DRF
  requires one. Naming tiers is the screen's whole purpose, so this is left
  strict rather than widening the field.
- No transaction around create/delete. Each is a single statement, so there
  is nothing partial to roll back. The real concurrency edge is two tabs
  racing a POST, which `unique_level_per_tenant` turns into a 500 rather than
  a 400; the Add button's loading state covers double-clicks. Adding a lock
  looked disproportionate — say if you disagree.

## Verification

- `backend/run-qc.sh` → exit 0 (**1454 tests OK**, 1 skipped, `flake8` clean,
  coverage 88.0%), run the way CI does — under `docker-compose.test.yml`,
  whose `working_dir: /app/backend` is what `.coveragerc` expects
- `frontend/release.sh` → exit 0 (prod eslint with warnings-as-errors,
  `prettier --check`, production build)
- **31 suites / 250 frontend tests**
- `makemigrations --check` → no changes detected
- All re-run after the rebase onto the epic, not just before

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1216901353714081
