### PR TITLE
[#275] Make the URL host say which workspace it is

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -44,9 +44,9 @@ To work on it locally you must add an `/etc/hosts` line **per workspace** —
 it. Full workflow and the four things that commonly break it:
 `doc/notes/subdomain-local-dev.md`.
 
-Tests reach a workspace with an `X-Tenant-Subdomain` header instead (the Django
-test client cannot vary hosts); it is honoured only when `ALLOW_TENANT_HEADER`
-or `DEBUG` is set.
+Tests need no hosts entries: pass `HTTP_HOST="acme.app.com"` to the test client.
+`BASE_DOMAIN` is forced empty under `manage.py test`, so a test that wants host
+routing opts in with `override_settings`.
 
 ## Architecture
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -32,6 +32,22 @@ python manage.py migrate  # Running directly on host
 cd frontend && npm run lint  # Running on host instead of container
 ```
 
+### Subdomain Routing in Local Development
+
+Each workspace (tenant) is served at its own host, `<subdomain>.<BASE_DOMAIN>`,
+and the backend resolves the tenant from the request's `Host` header. This is
+**off by default**: with `BASE_DOMAIN` empty, every host is the base domain,
+nothing resolves to a tenant, and the app behaves as a single-host install.
+
+To work on it locally you must add an `/etc/hosts` line **per workspace** —
+`/etc/hosts` has no wildcard, so registering a workspace is not enough to reach
+it. Full workflow and the four things that commonly break it:
+`doc/notes/subdomain-local-dev.md`.
+
+Tests reach a workspace with an `X-Tenant-Subdomain` header instead (the Django
+test client cannot vary hosts); it is honoured only when `ALLOW_TENANT_HEADER`
+or `DEBUG` is set.
+
 ## Architecture
 
 ### Multi-Tier Application Structure

--- a/backend/api/v1/v1_data/management/commands/generate_config.py
+++ b/backend/api/v1/v1_data/management/commands/generate_config.py
@@ -7,6 +7,7 @@ from mis.settings import (
     APP_NAME,
     APP_SHORT_NAME,
     APK_NAME,
+    BASE_DOMAIN,
     SHOW_LANDING_PAGE,
 )
 from api.v1.v1_profile.constants import FeatureTypes, FeatureAccessTypes
@@ -74,6 +75,12 @@ class Command(BaseCommand):
                         "shortName": APP_SHORT_NAME,
                         "apkName": APK_NAME,
                         "showLandingPage": SHOW_LANDING_PAGE,
+                        # Empty on a single-host deployment, which is how
+                        # the frontend knows not to split itself into
+                        # base-domain and workspace contexts at all.
+                        # tenant-info answers 204 in both cases, so the
+                        # app cannot tell them apart without this.
+                        "baseDomain": BASE_DOMAIN,
                     }),
                     ";",
                     "var roleFeatures=",

--- a/backend/api/v1/v1_users/serializers.py
+++ b/backend/api/v1/v1_users/serializers.py
@@ -726,6 +726,7 @@ def tenant_is_configured(tenant):
 class UserSerializer(serializers.ModelSerializer):
     name = serializers.SerializerMethodField()
     configured = serializers.SerializerMethodField()
+    subdomain = serializers.SerializerMethodField()
     administration = serializers.SerializerMethodField()
     roles = serializers.SerializerMethodField()
     organisation = serializers.SerializerMethodField()
@@ -811,13 +812,23 @@ class UserSerializer(serializers.ModelSerializer):
     def get_configured(self, instance: SystemUser):
         return tenant_is_configured(instance.tenant)
 
+    @extend_schema_field(OpenApiTypes.STR)
+    def get_subdomain(self, instance: SystemUser):
+        # The address this session belongs to. The frontend compares it
+        # against the host it is being served on, so that a user who
+        # lands on the wrong workspace — or on the tenant-less main
+        # site — is sent to their own rather than shown the 403.
+        # Empty for a tenant-less account, which has no address of its
+        # own and is therefore never redirected.
+        return instance.tenant.subdomain if instance.tenant_id else ""
+
     class Meta:
         model = SystemUser
         fields = [
             'email', 'name', 'roles', 'trained',
             'phone_number', 'forms', 'organisation',
             'last_login', 'passcode', 'is_superuser',
-            'administration', 'id', 'configured',
+            'administration', 'id', 'configured', 'subdomain',
         ]
 
 

--- a/backend/api/v1/v1_users/tests/tests_login.py
+++ b/backend/api/v1/v1_users/tests/tests_login.py
@@ -66,6 +66,9 @@ class LoginUserTestCase(TestCase):
                 # workspace goes to the configuration form, not the
                 # dashboard.
                 "configured",
+                # The address this session belongs to, so the app can
+                # send a user who landed on the wrong host to their own.
+                "subdomain",
                 "token",
                 "invite",
                 "expiration_time",

--- a/backend/api/v1/v1_users/tests/tests_login_host.py
+++ b/backend/api/v1/v1_users/tests/tests_login_host.py
@@ -10,7 +10,7 @@ LOGIN = "/api/v1/login"
 TENANT_INFO = "/api/v1/tenant-info"
 
 
-@override_settings(BASE_DOMAIN="app.com", ALLOW_TENANT_HEADER=True)
+@override_settings(BASE_DOMAIN="app.com")
 class LoginHostTestCase(TestCase, TenantTestHelperMixin):
     """Signing in happens at your own workspace's address.
 
@@ -32,13 +32,13 @@ class LoginHostTestCase(TestCase, TenantTestHelperMixin):
 
     def test_own_workspace_signs_in(self):
         response = self.client.post(
-            LOGIN, self.credentials, HTTP_X_TENANT_SUBDOMAIN="acme"
+            LOGIN, self.credentials, HTTP_HOST="acme.app.com"
         )
         self.assertEqual(response.status_code, 200)
 
     def test_other_workspace_is_refused(self):
         response = self.client.post(
-            LOGIN, self.credentials, HTTP_X_TENANT_SUBDOMAIN="beta"
+            LOGIN, self.credentials, HTTP_HOST="beta.app.com"
         )
         self.assertEqual(response.status_code, 401)
         self.assertIn("workspace", response.json()["message"])
@@ -61,7 +61,7 @@ class LoginHostTestCase(TestCase, TenantTestHelperMixin):
         response = self.client.post(
             LOGIN,
             {"email": operator.email, "password": TENANT_PASSWORD},
-            HTTP_X_TENANT_SUBDOMAIN="acme",
+            HTTP_HOST="acme.app.com",
         )
         self.assertEqual(response.status_code, 401)
 
@@ -77,7 +77,7 @@ class LoginHostTestCase(TestCase, TenantTestHelperMixin):
         response = self.client.post(
             LOGIN,
             {"email": user.email, "password": TENANT_PASSWORD},
-            HTTP_X_TENANT_SUBDOMAIN="acme",
+            HTTP_HOST="acme.app.com",
         )
         self.assertEqual(response.status_code, 401)
         self.assertTrue(response.json()["unverified"])
@@ -97,7 +97,7 @@ class LoginHostTestCase(TestCase, TenantTestHelperMixin):
         response = self.client.post(
             LOGIN,
             {"email": "new@acme.org", "password": TENANT_PASSWORD},
-            HTTP_X_TENANT_SUBDOMAIN="beta",
+            HTTP_HOST="beta.app.com",
         )
         self.assertEqual(response.status_code, 401)
         self.assertNotIn("unverified", response.json())
@@ -139,7 +139,7 @@ class ProfileSubdomainTestCase(TestCase, TenantTestHelperMixin):
         self.assertEqual(response.json()["subdomain"], "")
 
 
-@override_settings(BASE_DOMAIN="app.com", ALLOW_TENANT_HEADER=True)
+@override_settings(BASE_DOMAIN="app.com")
 class TenantInfoTestCase(TestCase, TenantTestHelperMixin):
     """What a visitor may know about a workspace before signing in."""
 
@@ -149,19 +149,18 @@ class TenantInfoTestCase(TestCase, TenantTestHelperMixin):
         )
 
     def test_workspace_host_returns_its_name(self):
-        response = self.client.get(TENANT_INFO, HTTP_X_TENANT_SUBDOMAIN="acme")
+        response = self.client.get(TENANT_INFO, HTTP_HOST="acme.app.com")
         self.assertEqual(response.status_code, 200)
         self.assertEqual(
-            response.json(),
-            {"subdomain": "acme", "name": "Kenya", "configured": True},
+            response.json(), {"subdomain": "acme", "name": "Kenya"}
         )
 
-    def test_nothing_beyond_those_three_fields_is_exposed(self):
+    def test_nothing_beyond_those_two_fields_is_exposed(self):
         # Anonymous and cacheable, so the field list is the whole of the
         # security review — assert it exhaustively rather than by sample.
-        response = self.client.get(TENANT_INFO, HTTP_X_TENANT_SUBDOMAIN="acme")
+        response = self.client.get(TENANT_INFO, HTTP_HOST="acme.app.com")
         self.assertEqual(
-            set(response.json().keys()), {"subdomain", "name", "configured"}
+            set(response.json().keys()), {"subdomain", "name"}
         )
 
     def test_base_domain_returns_nothing(self):
@@ -171,9 +170,6 @@ class TenantInfoTestCase(TestCase, TenantTestHelperMixin):
     def test_unconfigured_workspace_has_no_name_yet(self):
         Tenant.objects.create(subdomain="fresh")
         response = self.client.get(
-            TENANT_INFO, HTTP_X_TENANT_SUBDOMAIN="fresh"
+            TENANT_INFO, HTTP_HOST="fresh.app.com"
         )
-        self.assertEqual(
-            response.json(),
-            {"subdomain": "fresh", "name": "", "configured": False},
-        )
+        self.assertEqual(response.json(), {"subdomain": "fresh", "name": ""})

--- a/backend/api/v1/v1_users/tests/tests_login_host.py
+++ b/backend/api/v1/v1_users/tests/tests_login_host.py
@@ -1,0 +1,152 @@
+from django.test import TestCase, override_settings
+
+from api.v1.v1_profile.tests.mixins import (
+    TENANT_PASSWORD,
+    TenantTestHelperMixin,
+)
+from api.v1.v1_users.models import SystemUser, Tenant
+
+LOGIN = "/api/v1/login"
+TENANT_INFO = "/api/v1/tenant-info"
+
+
+@override_settings(BASE_DOMAIN="app.com", ALLOW_TENANT_HEADER=True)
+class LoginHostTestCase(TestCase, TenantTestHelperMixin):
+    """Signing in happens at your own workspace's address.
+
+    The middleware cannot do this one: a login request carries no token
+    yet, so there is no session for it to compare against the host.
+    """
+
+    def setUp(self):
+        self.acme = self.create_tenant(
+            "acme", ["Country", "Province"], "Kenya"
+        )
+        self.beta = self.create_tenant(
+            "beta", ["Country", "Region"], "Uganda"
+        )
+        self.credentials = {
+            "email": self.acme.admin.email,
+            "password": TENANT_PASSWORD,
+        }
+
+    def test_own_workspace_signs_in(self):
+        response = self.client.post(
+            LOGIN, self.credentials, HTTP_X_TENANT_SUBDOMAIN="acme"
+        )
+        self.assertEqual(response.status_code, 200)
+
+    def test_other_workspace_is_refused(self):
+        response = self.client.post(
+            LOGIN, self.credentials, HTTP_X_TENANT_SUBDOMAIN="beta"
+        )
+        self.assertEqual(response.status_code, 401)
+        self.assertIn("workspace", response.json()["message"])
+
+    def test_base_domain_does_not_sign_in(self):
+        # The main site signs people up; it has no workspace to sign in
+        # to. Refused before the password is even looked at.
+        response = self.client.post(
+            LOGIN, self.credentials, HTTP_HOST="app.com"
+        )
+        self.assertEqual(response.status_code, 400)
+
+    def test_tenant_less_account_is_refused_on_a_workspace(self):
+        operator = SystemUser.objects.create_superuser(
+            email="operator@akvo.org",
+            password=TENANT_PASSWORD,
+            first_name="Op",
+            last_name="Erator",
+        )
+        response = self.client.post(
+            LOGIN,
+            {"email": operator.email, "password": TENANT_PASSWORD},
+            HTTP_X_TENANT_SUBDOMAIN="acme",
+        )
+        self.assertEqual(response.status_code, 401)
+
+    def test_unverified_account_is_told_to_verify_on_its_own_workspace(self):
+        user = SystemUser.objects.create_superuser(
+            email="new@acme.org",
+            password=TENANT_PASSWORD,
+            first_name="",
+            last_name="",
+            tenant=self.acme.tenant,
+            is_active=False,
+        )
+        response = self.client.post(
+            LOGIN,
+            {"email": user.email, "password": TENANT_PASSWORD},
+            HTTP_X_TENANT_SUBDOMAIN="acme",
+        )
+        self.assertEqual(response.status_code, 401)
+        self.assertTrue(response.json()["unverified"])
+
+    def test_unverified_account_says_nothing_on_another_workspace(self):
+        # The "resend your activation email" branch is an account
+        # existence oracle by design, but only for the workspace the
+        # account belongs to. Elsewhere it must stay shut.
+        SystemUser.objects.create_superuser(
+            email="new@acme.org",
+            password=TENANT_PASSWORD,
+            first_name="",
+            last_name="",
+            tenant=self.acme.tenant,
+            is_active=False,
+        )
+        response = self.client.post(
+            LOGIN,
+            {"email": "new@acme.org", "password": TENANT_PASSWORD},
+            HTTP_X_TENANT_SUBDOMAIN="beta",
+        )
+        self.assertEqual(response.status_code, 401)
+        self.assertNotIn("unverified", response.json())
+
+
+class SingleHostLoginTestCase(TestCase, TenantTestHelperMixin):
+    def test_login_is_unchanged_without_a_base_domain(self):
+        acme = self.create_tenant("acme", ["Country", "Province"], "Kenya")
+        response = self.client.post(
+            LOGIN, {"email": acme.admin.email, "password": TENANT_PASSWORD}
+        )
+        self.assertEqual(response.status_code, 200)
+
+
+@override_settings(BASE_DOMAIN="app.com", ALLOW_TENANT_HEADER=True)
+class TenantInfoTestCase(TestCase, TenantTestHelperMixin):
+    """What a visitor may know about a workspace before signing in."""
+
+    def setUp(self):
+        self.acme = self.create_tenant(
+            "acme", ["Country", "Province"], "Kenya"
+        )
+
+    def test_workspace_host_returns_its_name(self):
+        response = self.client.get(TENANT_INFO, HTTP_X_TENANT_SUBDOMAIN="acme")
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(
+            response.json(),
+            {"subdomain": "acme", "name": "Kenya", "configured": True},
+        )
+
+    def test_nothing_beyond_those_three_fields_is_exposed(self):
+        # Anonymous and cacheable, so the field list is the whole of the
+        # security review — assert it exhaustively rather than by sample.
+        response = self.client.get(TENANT_INFO, HTTP_X_TENANT_SUBDOMAIN="acme")
+        self.assertEqual(
+            set(response.json().keys()), {"subdomain", "name", "configured"}
+        )
+
+    def test_base_domain_returns_nothing(self):
+        response = self.client.get(TENANT_INFO, HTTP_HOST="app.com")
+        self.assertEqual(response.status_code, 204)
+
+    def test_unconfigured_workspace_has_no_name_yet(self):
+        Tenant.objects.create(subdomain="fresh")
+        response = self.client.get(
+            TENANT_INFO, HTTP_X_TENANT_SUBDOMAIN="fresh"
+        )
+        self.assertEqual(
+            response.json(),
+            {"subdomain": "fresh", "name": "", "configured": False},
+        )

--- a/backend/api/v1/v1_users/tests/tests_login_host.py
+++ b/backend/api/v1/v1_users/tests/tests_login_host.py
@@ -112,6 +112,33 @@ class SingleHostLoginTestCase(TestCase, TenantTestHelperMixin):
         self.assertEqual(response.status_code, 200)
 
 
+class ProfileSubdomainTestCase(TestCase, TenantTestHelperMixin):
+    """The profile says which address the session belongs to.
+
+    The frontend compares it against the host it is served on; without
+    it, a user on the wrong workspace has nowhere to be redirected to.
+    """
+
+    def test_profile_carries_the_users_own_workspace(self):
+        acme = self.create_tenant("acme", ["Country", "Province"], "Kenya")
+        response = self.client.get(
+            "/api/v1/profile", **self.bearer(acme.admin)
+        )
+        self.assertEqual(response.json()["subdomain"], "acme")
+
+    def test_tenant_less_account_has_no_workspace(self):
+        operator = SystemUser.objects.create_superuser(
+            email="operator@akvo.org",
+            password=TENANT_PASSWORD,
+            first_name="Op",
+            last_name="Erator",
+        )
+        response = self.client.get(
+            "/api/v1/profile", **self.bearer(operator)
+        )
+        self.assertEqual(response.json()["subdomain"], "")
+
+
 @override_settings(BASE_DOMAIN="app.com", ALLOW_TENANT_HEADER=True)
 class TenantInfoTestCase(TestCase, TenantTestHelperMixin):
     """What a visitor may know about a workspace before signing in."""

--- a/backend/api/v1/v1_users/tests/tests_register.py
+++ b/backend/api/v1/v1_users/tests/tests_register.py
@@ -24,10 +24,15 @@ class RegisterEndpointTestCase(TestCase):
         "subdomain": "acme",
     }
 
-    def register(self, **overrides):
+    def register(self, host=None, **overrides):
         payload = {**self.payload, **overrides}
+        # Registration lives on the base domain. Only the tests that set
+        # BASE_DOMAIN need to say so — the rest run single-host, where
+        # every host is the base domain.
+        extra = {"HTTP_HOST": host} if host else {}
         return self.client.post(
-            "/api/v1/register", payload, content_type="application/json"
+            "/api/v1/register", payload,
+            content_type="application/json", **extra
         )
 
     def registered_tenants(self):
@@ -59,6 +64,16 @@ class RegisterEndpointTestCase(TestCase):
         context = send.call_args.kwargs["context"]
         self.assertEqual(context["send_to"], ["founder@acme.org"])
         self.assertIn("/activate/", context["button_url"])
+
+    @override_settings(BASE_DOMAIN="app.com", WEBDOMAIN="https://app.com")
+    def test_the_activation_link_lands_on_the_new_workspace(self):
+        # Registration happens on the main site, but activation hands
+        # back a session — and that session is only valid on the
+        # workspace's own host, so the link has to go there.
+        with mock.patch("api.v1.v1_users.views.send_email") as send:
+            self.register(host="app.com")
+        url = send.call_args.kwargs["context"]["button_url"]
+        self.assertTrue(url.startswith("https://acme.app.com/activate/"), url)
 
     def test_unverified_registrant_cannot_log_in(self):
         with mock.patch("api.v1.v1_users.views.send_email"):

--- a/backend/api/v1/v1_users/tests/tests_tenant_host.py
+++ b/backend/api/v1/v1_users/tests/tests_tenant_host.py
@@ -1,7 +1,11 @@
 from django.test import TestCase, override_settings
 
 from api.v1.v1_users.models import Tenant
-from utils.tenant_host import is_base_domain, resolve_tenant_from_host
+from utils.tenant_host import (
+    is_base_domain,
+    resolve_tenant_from_host,
+    tenant_web_url,
+)
 
 
 @override_settings(BASE_DOMAIN="app.com")
@@ -62,3 +66,34 @@ class IsBaseDomainTestCase(TestCase):
         # "testserver" — have exactly one context, and it is tenant-less.
         self.assertTrue(is_base_domain("testserver"))
         self.assertTrue(is_base_domain("anything.example.org"))
+
+
+class TenantWebUrlTestCase(TestCase):
+    """The address an emailed link should point at."""
+
+    def setUp(self):
+        self.acme = Tenant.objects.create(subdomain="acme")
+
+    @override_settings(BASE_DOMAIN="app.com", WEBDOMAIN="https://app.com")
+    def test_workspace_gets_its_own_host(self):
+        self.assertEqual(tenant_web_url(self.acme), "https://acme.app.com")
+
+    @override_settings(
+        BASE_DOMAIN="localapp.test", WEBDOMAIN="http://localhost:3000"
+    )
+    def test_scheme_and_port_come_from_webdomain(self):
+        # Local development runs on a port and on http; only the host
+        # part is the base domain's to decide.
+        self.assertEqual(
+            tenant_web_url(self.acme), "http://acme.localapp.test:3000"
+        )
+
+    @override_settings(BASE_DOMAIN="", WEBDOMAIN="https://mis.example.org")
+    def test_single_host_keeps_its_one_address(self):
+        self.assertEqual(
+            tenant_web_url(self.acme), "https://mis.example.org"
+        )
+
+    @override_settings(BASE_DOMAIN="app.com", WEBDOMAIN="https://app.com")
+    def test_no_tenant_falls_back_to_the_base_domain(self):
+        self.assertEqual(tenant_web_url(None), "https://app.com")

--- a/backend/api/v1/v1_users/tests/tests_tenant_host.py
+++ b/backend/api/v1/v1_users/tests/tests_tenant_host.py
@@ -1,0 +1,64 @@
+from django.test import TestCase, override_settings
+
+from api.v1.v1_users.models import Tenant
+from utils.tenant_host import is_base_domain, resolve_tenant_from_host
+
+
+@override_settings(BASE_DOMAIN="app.com")
+class ResolveTenantFromHostTestCase(TestCase):
+    def setUp(self):
+        self.acme = Tenant.objects.create(subdomain="acme")
+
+    def test_base_domain_resolves_to_none(self):
+        self.assertIsNone(resolve_tenant_from_host("app.com"))
+        self.assertIsNone(resolve_tenant_from_host("www.app.com"))
+
+    def test_subdomain_resolves_to_tenant(self):
+        self.assertEqual(resolve_tenant_from_host("acme.app.com"), self.acme)
+
+    def test_port_and_case_are_handled(self):
+        self.assertEqual(
+            resolve_tenant_from_host("ACME.app.com:3000"), self.acme
+        )
+
+    def test_unknown_subdomain_resolves_to_none(self):
+        self.assertIsNone(resolve_tenant_from_host("nope.app.com"))
+
+    def test_foreign_host_resolves_to_none(self):
+        self.assertIsNone(resolve_tenant_from_host("example.org"))
+
+    def test_nested_label_resolves_to_none(self):
+        # One label only. "acme.staging.app.com" is not acme's host, and
+        # accepting it would let any depth of prefix reach a tenant.
+        self.assertIsNone(resolve_tenant_from_host("acme.staging.app.com"))
+
+    @override_settings(BASE_DOMAIN="")
+    def test_no_base_domain_configured_resolves_to_none(self):
+        self.assertIsNone(resolve_tenant_from_host("acme.app.com"))
+
+
+@override_settings(BASE_DOMAIN="app.com")
+class IsBaseDomainTestCase(TestCase):
+    """The base domain is the tenant-less signup context.
+
+    Everything else that fails to resolve is an unknown workspace, which
+    is what lets the middleware tell "no tenant here by design" apart
+    from "no tenant by that name".
+    """
+
+    def test_base_and_www_are_the_base_domain(self):
+        self.assertTrue(is_base_domain("app.com"))
+        self.assertTrue(is_base_domain("WWW.app.com:3000"))
+
+    def test_subdomain_is_not_the_base_domain(self):
+        self.assertFalse(is_base_domain("acme.app.com"))
+
+    def test_foreign_host_is_not_the_base_domain(self):
+        self.assertFalse(is_base_domain("example.org"))
+
+    @override_settings(BASE_DOMAIN="")
+    def test_every_host_is_the_base_domain_when_unconfigured(self):
+        # Single-host deployments — including the test client's
+        # "testserver" — have exactly one context, and it is tenant-less.
+        self.assertTrue(is_base_domain("testserver"))
+        self.assertTrue(is_base_domain("anything.example.org"))

--- a/backend/api/v1/v1_users/tests/tests_tenant_middleware.py
+++ b/backend/api/v1/v1_users/tests/tests_tenant_middleware.py
@@ -5,7 +5,7 @@ from api.v1.v1_profile.tests.mixins import TenantTestHelperMixin
 PROFILE = "/api/v1/profile"
 
 
-@override_settings(BASE_DOMAIN="app.com", ALLOW_TENANT_HEADER=True)
+@override_settings(BASE_DOMAIN="app.com")
 class TenantMiddlewareTestCase(TestCase, TenantTestHelperMixin):
     """The host decides which workspace a request is for, and a session
     is only valid on its own workspace's host."""
@@ -76,26 +76,6 @@ class TenantMiddlewareTestCase(TestCase, TenantTestHelperMixin):
             HTTP_AUTHORIZATION="Bearer not-a-token",
         )
         self.assertEqual(response.status_code, 401)
-
-    def test_header_stands_in_for_the_host(self):
-        # The test client cannot vary /etc/hosts, so the override is the
-        # only way a test reaches a subdomain without one.
-        response = self.client.get(
-            PROFILE, HTTP_X_TENANT_SUBDOMAIN="acme"
-        )
-        self.assertEqual(response.wsgi_request.tenant, self.acme.tenant)
-
-    def test_unknown_header_subdomain_is_404(self):
-        response = self.client.get(PROFILE, HTTP_X_TENANT_SUBDOMAIN="nope")
-        self.assertEqual(response.status_code, 404)
-
-    @override_settings(ALLOW_TENANT_HEADER=False)
-    def test_header_is_ignored_when_not_allowed(self):
-        # Production must not let a request header choose its workspace.
-        response = self.client.get(
-            PROFILE, HTTP_HOST="app.com", HTTP_X_TENANT_SUBDOMAIN="acme"
-        )
-        self.assertIsNone(response.wsgi_request.tenant)
 
 
 class SingleHostTestCase(TestCase, TenantTestHelperMixin):

--- a/backend/api/v1/v1_users/tests/tests_tenant_middleware.py
+++ b/backend/api/v1/v1_users/tests/tests_tenant_middleware.py
@@ -1,0 +1,115 @@
+from django.test import TestCase, override_settings
+
+from api.v1.v1_profile.tests.mixins import TenantTestHelperMixin
+
+PROFILE = "/api/v1/profile"
+
+
+@override_settings(BASE_DOMAIN="app.com", ALLOW_TENANT_HEADER=True)
+class TenantMiddlewareTestCase(TestCase, TenantTestHelperMixin):
+    """The host decides which workspace a request is for, and a session
+    is only valid on its own workspace's host."""
+
+    def setUp(self):
+        self.acme = self.create_tenant(
+            "acme", ["Country", "Province"], "Kenya"
+        )
+        self.beta = self.create_tenant("beta", ["Country", "Region"], "Uganda")
+
+    def test_host_attaches_the_tenant_to_the_request(self):
+        response = self.client.get(PROFILE, HTTP_HOST="acme.app.com")
+        self.assertEqual(response.wsgi_request.tenant, self.acme.tenant)
+
+    def test_base_domain_has_no_tenant(self):
+        response = self.client.get(PROFILE, HTTP_HOST="app.com")
+        self.assertIsNone(response.wsgi_request.tenant)
+
+    def test_unknown_subdomain_is_404(self):
+        response = self.client.get(PROFILE, HTTP_HOST="nope.app.com")
+        self.assertEqual(response.status_code, 404)
+
+    def test_foreign_host_is_404(self):
+        # Not the base domain and not a workspace. Nothing here is for it.
+        response = self.client.get(PROFILE, HTTP_HOST="example.org")
+        self.assertEqual(response.status_code, 404)
+
+    def test_own_subdomain_passes(self):
+        response = self.client.get(
+            PROFILE, HTTP_HOST="acme.app.com", **self.bearer(self.acme.admin)
+        )
+        self.assertEqual(response.status_code, 200)
+
+    def test_other_tenants_subdomain_is_403(self):
+        response = self.client.get(
+            PROFILE, HTTP_HOST="beta.app.com", **self.bearer(self.acme.admin)
+        )
+        self.assertEqual(response.status_code, 403)
+
+    def test_base_domain_is_not_enforced(self):
+        # The signup context belongs to no tenant, so there is nothing to
+        # mismatch against — a session reaching it is not a violation.
+        response = self.client.get(
+            PROFILE, HTTP_HOST="app.com", **self.bearer(self.acme.admin)
+        )
+        self.assertEqual(response.status_code, 200)
+
+    def test_anonymous_request_on_a_tenant_host_is_not_403(self):
+        # Enforcement compares an account against a host; with no account
+        # there is nothing to compare, so the view answers as it always
+        # did. Every public endpoint stays reachable for free.
+        response = self.client.get(PROFILE, HTTP_HOST="acme.app.com")
+        self.assertEqual(response.status_code, 401)
+
+    def test_invalid_token_is_left_to_the_view(self):
+        response = self.client.get(
+            PROFILE,
+            HTTP_HOST="acme.app.com",
+            HTTP_AUTHORIZATION="Bearer not-a-token",
+        )
+        self.assertEqual(response.status_code, 401)
+
+    def test_header_stands_in_for_the_host(self):
+        # The test client cannot vary /etc/hosts, so the override is the
+        # only way a test reaches a subdomain without one.
+        response = self.client.get(
+            PROFILE, HTTP_X_TENANT_SUBDOMAIN="acme"
+        )
+        self.assertEqual(response.wsgi_request.tenant, self.acme.tenant)
+
+    def test_unknown_header_subdomain_is_404(self):
+        response = self.client.get(PROFILE, HTTP_X_TENANT_SUBDOMAIN="nope")
+        self.assertEqual(response.status_code, 404)
+
+    @override_settings(ALLOW_TENANT_HEADER=False)
+    def test_header_is_ignored_when_not_allowed(self):
+        # Production must not let a request header choose its workspace.
+        response = self.client.get(
+            PROFILE, HTTP_HOST="app.com", HTTP_X_TENANT_SUBDOMAIN="acme"
+        )
+        self.assertIsNone(response.wsgi_request.tenant)
+
+
+class SingleHostTestCase(TestCase, TenantTestHelperMixin):
+    """With BASE_DOMAIN unset the middleware must do nothing at all.
+
+    This is the state the whole existing suite runs in — host
+    `testserver`, users with and without tenants — and it is what makes
+    the iteration safe to merge before any DNS exists.
+    """
+
+    def setUp(self):
+        self.acme = self.create_tenant(
+            "acme", ["Country", "Province"], "Kenya"
+        )
+
+    def test_testserver_is_never_404(self):
+        response = self.client.get(PROFILE)
+        self.assertEqual(response.status_code, 401)
+
+    def test_no_tenant_is_attached(self):
+        response = self.client.get(PROFILE)
+        self.assertIsNone(response.wsgi_request.tenant)
+
+    def test_authenticated_request_is_not_enforced(self):
+        response = self.client.get(PROFILE, **self.bearer(self.acme.admin))
+        self.assertEqual(response.status_code, 200)

--- a/backend/api/v1/v1_users/tests/tests_tenant_middleware.py
+++ b/backend/api/v1/v1_users/tests/tests_tenant_middleware.py
@@ -45,6 +45,15 @@ class TenantMiddlewareTestCase(TestCase, TenantTestHelperMixin):
         )
         self.assertEqual(response.status_code, 403)
 
+    def test_the_403_names_the_right_workspace(self):
+        # Without this the frontend knows only that it is in the wrong
+        # place, not where the right one is — the profile call that
+        # would have told it is the very call being refused.
+        response = self.client.get(
+            PROFILE, HTTP_HOST="beta.app.com", **self.bearer(self.acme.admin)
+        )
+        self.assertEqual(response.json()["subdomain"], "acme")
+
     def test_base_domain_is_not_enforced(self):
         # The signup context belongs to no tenant, so there is nothing to
         # mismatch against — a session reaching it is not a violation.

--- a/backend/api/v1/v1_users/tests/tests_user_profile.py
+++ b/backend/api/v1/v1_users/tests/tests_user_profile.py
@@ -73,6 +73,7 @@ class UserProfileTestCase(TestCase, ProfileTestHelperMixin):
                 'administration',
                 'id',
                 'configured',
+                'subdomain',
             ]
         )
         self.assertEqual(data["email"], self.superuser.email)

--- a/backend/api/v1/v1_users/urls.py
+++ b/backend/api/v1/v1_users/urls.py
@@ -21,6 +21,7 @@ from api.v1.v1_users.views import (
     activate_account,
     resend_activation,
     configure_project,
+    tenant_info,
 )
 from api.v1.v1_profile.views import list_entity_data
 
@@ -35,6 +36,7 @@ urlpatterns = [
     ),
     re_path(r"^(?P<version>(v1))/profile", get_profile),
     re_path(r"^(?P<version>(v1))/login", login),
+    re_path(r"^(?P<version>(v1))/tenant-info$", tenant_info),
     re_path(r"^(?P<version>(v1))/register/activate$", activate_account),
     re_path(r"^(?P<version>(v1))/register/configure$", configure_project),
     re_path(

--- a/backend/api/v1/v1_users/views.py
+++ b/backend/api/v1/v1_users/views.py
@@ -70,6 +70,7 @@ from utils.custom_serializer_fields import validate_serializers_message
 from utils.default_serializers import DefaultResponseSerializer
 from utils.email_helper import send_email
 from utils.email_helper import ListEmailTypeRequestSerializer, EmailTypes
+from utils.tenant_host import tenant_web_url
 
 
 # A week is long enough to survive a weekend and a spam folder, short
@@ -80,11 +81,18 @@ ACTIVATION_LINK_MAX_AGE = 60 * 60 * 24 * 7
 def send_activation_email(user):
     # The signed pk is the whole token — no state to store and no row to
     # clean up if the link is never followed. `activate` bounds its age.
+    #
+    # The link points at the registrant's own workspace host, because
+    # everything past it is bound to that host: activation hands back a
+    # session, and that session is only valid there.
     send_email(
         type=EmailTypes.user_activation,
         context={
             "send_to": [user.email],
-            "button_url": f"{WEBDOMAIN}/activate/{signing.dumps(user.pk)}",
+            "button_url": (
+                f"{tenant_web_url(user.tenant)}"
+                f"/activate/{signing.dumps(user.pk)}"
+            ),
         },
     )
 

--- a/backend/api/v1/v1_users/views.py
+++ b/backend/api/v1/v1_users/views.py
@@ -308,7 +308,6 @@ def login(request, version):
             fields={
                 "subdomain": serializers.CharField(),
                 "name": serializers.CharField(),
-                "configured": serializers.BooleanField(),
             },
         ),
         204: OpenApiResponse(description="Not a workspace address"),
@@ -320,11 +319,12 @@ def login(request, version):
 def tenant_info(request, version):
     """Enough to brand the page before anyone has signed in.
 
-    Deliberately three fields and no more: this is anonymous, and the
-    host it answers for is guessable, so anything added here is
-    published to whoever tries the subdomain. `configured` is what lets
-    the frontend send a half-registered workspace to its configuration
-    form instead of a login it cannot complete.
+    Deliberately two fields and no more: this is anonymous, and the host
+    it answers for is guessable, so anything added here is published to
+    whoever tries the subdomain. Whether the workspace has finished
+    configuring itself is not among them — that decision belongs to the
+    signed-in user's own `configured` flag, and a visitor who has not
+    signed in cannot act on it.
     """
     tenant = getattr(request, "tenant", None)
     if not tenant:
@@ -341,7 +341,6 @@ def tenant_info(request, version):
             # The root unit is the workspace's name — the tenant row
             # itself only carries the subdomain.
             "name": root.name if root else "",
-            "configured": tenant_is_configured(tenant),
         },
         status=status.HTTP_200_OK,
     )

--- a/backend/api/v1/v1_users/views.py
+++ b/backend/api/v1/v1_users/views.py
@@ -196,6 +196,18 @@ def authenticated_response(user):
     return response
 
 
+def signing_in_elsewhere(request, user):
+    """Is this account signing in at another workspace's address?
+
+    Only the middleware's `request.tenant` is consulted, so this is
+    inert on a single-host deployment and on the base domain. The
+    middleware itself cannot cover login: the request carries no token
+    yet, so there is no session for it to compare against the host.
+    """
+    tenant = getattr(request, "tenant", None)
+    return bool(tenant and user.tenant_id != tenant.id)
+
+
 # TODO: Remove temp user entry and invite key from the response.
 @extend_schema(
     request=LoginSerializer,
@@ -204,6 +216,15 @@ def authenticated_response(user):
 )
 @api_view(["POST"])
 def login(request, version):
+    # On a SaaS deployment the main site signs people up; signing in
+    # happens at the workspace's own address. Refusing here, before the
+    # serializer, means the credentials are never even evaluated.
+    if settings.BASE_DOMAIN and getattr(request, "tenant", None) is None:
+        return Response(
+            {"message": "Sign in at your workspace address, not the main "
+                        "site"},
+            status=status.HTTP_400_BAD_REQUEST,
+        )
     serializer = LoginSerializer(data=request.data)
     if not serializer.is_valid():
         return Response(
@@ -232,6 +253,11 @@ def login(request, version):
                 {"message": "User has been deleted"},
                 status=status.HTTP_401_UNAUTHORIZED,
             )
+        if signing_in_elsewhere(request, user):
+            return Response(
+                {"message": "This account belongs to a different workspace"},
+                status=status.HTTP_401_UNAUTHORIZED,
+            )
         return authenticated_response(user)
     # authenticate() returns None for a wrong password AND for a correct
     # password on an unverified account. Telling those apart is what lets the
@@ -244,8 +270,12 @@ def login(request, version):
         is_active=False,
         deleted_at=None,
     ).first()
-    if unverified and unverified.check_password(
-        serializer.validated_data["password"]
+    if (
+        unverified
+        and unverified.check_password(serializer.validated_data["password"])
+        # …but only at that account's own workspace. Elsewhere the oracle
+        # would answer for a workspace the visitor has no business in.
+        and not signing_in_elsewhere(request, unverified)
     ):
         return Response(
             {
@@ -260,6 +290,52 @@ def login(request, version):
     return Response(
         {"message": "Invalid login credentials"},
         status=status.HTTP_401_UNAUTHORIZED,
+    )
+
+
+@extend_schema(
+    responses={
+        200: inline_serializer(
+            "TenantInfo",
+            fields={
+                "subdomain": serializers.CharField(),
+                "name": serializers.CharField(),
+                "configured": serializers.BooleanField(),
+            },
+        ),
+        204: OpenApiResponse(description="Not a workspace address"),
+    },
+    tags=["Auth"],
+    summary="Identify the workspace this address belongs to",
+)
+@api_view(["GET"])
+def tenant_info(request, version):
+    """Enough to brand the page before anyone has signed in.
+
+    Deliberately three fields and no more: this is anonymous, and the
+    host it answers for is guessable, so anything added here is
+    published to whoever tries the subdomain. `configured` is what lets
+    the frontend send a half-registered workspace to its configuration
+    form instead of a login it cannot complete.
+    """
+    tenant = getattr(request, "tenant", None)
+    if not tenant:
+        # The base domain, or a single-host deployment. Either way the
+        # caller learns there is no workspace here, which is the answer
+        # that sends it to the signup page.
+        return Response(status=status.HTTP_204_NO_CONTENT)
+    root = Administration.objects.filter(
+        tenant=tenant, parent__isnull=True
+    ).first()
+    return Response(
+        {
+            "subdomain": tenant.subdomain,
+            # The root unit is the workspace's name — the tenant row
+            # itself only carries the subdomain.
+            "name": root.name if root else "",
+            "configured": tenant_is_configured(tenant),
+        },
+        status=status.HTTP_200_OK,
     )
 
 

--- a/backend/middleware/tenant.py
+++ b/backend/middleware/tenant.py
@@ -1,0 +1,75 @@
+"""Bind every request to the workspace named by its host.
+
+Two jobs, in order:
+
+1. **Resolve.** `request.tenant` is the tenant the URL host belongs to,
+   or `None` on the tenant-less base domain. Everything downstream that
+   needs to know "which workspace is this page for" reads it from here
+   rather than parsing hosts again.
+2. **Enforce.** A session created for one workspace must not be usable on
+   another's host. This is defence in depth: `for_user` still decides
+   what data a query returns, and would keep doing so if this middleware
+   were removed. What it adds is a boundary that fails closed at the
+   edge, before any view has a chance to forget the scoping.
+
+With `BASE_DOMAIN` unset the whole thing is inert — every host is the
+base domain, nothing resolves, nothing is enforced — which is how the
+test suite and any single-host deployment run.
+"""
+from django.conf import settings
+from django.http import JsonResponse
+from rest_framework_simplejwt.authentication import JWTAuthentication
+
+from api.v1.v1_users.models import Tenant
+from utils.tenant_host import is_base_domain, resolve_tenant_from_host
+
+
+class TenantMiddleware:
+    def __init__(self, get_response):
+        self.get_response = get_response
+        self.jwt_auth = JWTAuthentication()
+
+    def __call__(self, request):
+        host = request.get_host()
+        request.tenant = self._resolve(request, host)
+
+        # A host that is neither the signup domain nor a workspace names
+        # nothing this deployment serves. Answering 404 before the view
+        # runs also means a typo'd subdomain gets "no such workspace"
+        # rather than a login page it could never log in to.
+        if request.tenant is None and not is_base_domain(host):
+            return JsonResponse({"message": "Workspace not found"}, status=404)
+
+        # Enforcement needs an account to compare, so it is skipped for
+        # anonymous requests — which is every public endpoint, including
+        # ones added after this was written. That is deliberate: an
+        # explicit exemption list would need editing by whoever adds the
+        # next public path, and nothing would remind them.
+        if request.tenant is not None:
+            user = self._authenticated_user(request)
+            if user is not None and user.tenant_id != request.tenant.id:
+                return JsonResponse(
+                    {"message": "This account belongs to a different "
+                                "workspace"},
+                    status=403,
+                )
+        return self.get_response(request)
+
+    def _resolve(self, request, host):
+        header = request.headers.get("X-Tenant-Subdomain")
+        if settings.ALLOW_TENANT_HEADER and header:
+            return Tenant.objects.filter(subdomain=header.lower()).first()
+        return resolve_tenant_from_host(host)
+
+    def _authenticated_user(self, request):
+        # JWT authentication happens at the view layer in this stack, so
+        # request.user is still anonymous here and we have to run it
+        # ourselves.
+        try:
+            result = self.jwt_auth.authenticate(request)
+        except Exception:
+            # A malformed, expired or revoked token is the view's 401 to
+            # give. Only a session that is genuinely valid can be on the
+            # wrong host, and only that deserves a 403.
+            return None
+        return result[0] if result else None

--- a/backend/middleware/tenant.py
+++ b/backend/middleware/tenant.py
@@ -16,11 +16,9 @@ With `BASE_DOMAIN` unset the whole thing is inert — every host is the
 base domain, nothing resolves, nothing is enforced — which is how the
 test suite and any single-host deployment run.
 """
-from django.conf import settings
 from django.http import JsonResponse
 from rest_framework_simplejwt.authentication import JWTAuthentication
 
-from api.v1.v1_users.models import Tenant
 from utils.tenant_host import is_base_domain, resolve_tenant_from_host
 
 
@@ -31,7 +29,7 @@ class TenantMiddleware:
 
     def __call__(self, request):
         host = request.get_host()
-        request.tenant = self._resolve(request, host)
+        request.tenant = resolve_tenant_from_host(host)
 
         # A host that is neither the signup domain nor a workspace names
         # nothing this deployment serves. Answering 404 before the view
@@ -65,12 +63,6 @@ class TenantMiddleware:
                     status=403,
                 )
         return self.get_response(request)
-
-    def _resolve(self, request, host):
-        header = request.headers.get("X-Tenant-Subdomain")
-        if settings.ALLOW_TENANT_HEADER and header:
-            return Tenant.objects.filter(subdomain=header.lower()).first()
-        return resolve_tenant_from_host(host)
 
     def _authenticated_user(self, request):
         # JWT authentication happens at the view layer in this stack, so

--- a/backend/middleware/tenant.py
+++ b/backend/middleware/tenant.py
@@ -49,8 +49,19 @@ class TenantMiddleware:
             user = self._authenticated_user(request)
             if user is not None and user.tenant_id != request.tenant.id:
                 return JsonResponse(
-                    {"message": "This account belongs to a different "
-                                "workspace"},
+                    {
+                        "message": "This account belongs to a different "
+                                   "workspace",
+                        # We already know both sides of the mismatch, so
+                        # naming the right address turns the frontend's
+                        # dead end into a redirect. The session itself is
+                        # valid — it is only in the wrong place — and
+                        # subdomains are guessable anyway, so this
+                        # discloses nothing the URL bar does not.
+                        "subdomain": (
+                            user.tenant.subdomain if user.tenant_id else ""
+                        ),
+                    },
                     status=403,
                 )
         return self.get_response(request)

--- a/backend/mis/settings.py
+++ b/backend/mis/settings.py
@@ -57,6 +57,18 @@ SECRET_KEY = environ["DJANGO_SECRET"]
 DEBUG = True if "DEBUG" in environ else False
 PROD = True if "PROD" in environ else False
 
+# Host-based tenant routing. Unset means single-host: every host is the
+# base domain, nothing resolves to a tenant, and the routing is inert —
+# which is how the test suite and any non-SaaS deployment run.
+BASE_DOMAIN = environ.get("BASE_DOMAIN", "")
+# Let an X-Tenant-Subdomain header stand in for the host. The Django test
+# client cannot vary /etc/hosts, so automated tests need this; nothing in
+# production should, and enabling it there would make the host boundary
+# spoofable by a request header.
+ALLOW_TENANT_HEADER = (
+    environ.get("ALLOW_TENANT_HEADER", "false").lower() == "true" or DEBUG
+)
+
 
 ALLOWED_HOSTS = ["*"]
 

--- a/backend/mis/settings.py
+++ b/backend/mis/settings.py
@@ -74,13 +74,6 @@ TESTING = sys.argv[1:2] == ["test"]
 # suite. The tests that exercise host routing opt back in with
 # override_settings, which is how they read anyway.
 BASE_DOMAIN = "" if TESTING else environ.get("BASE_DOMAIN", "")
-# Let an X-Tenant-Subdomain header stand in for the host. The Django test
-# client cannot vary /etc/hosts, so automated tests need this; nothing in
-# production should, and enabling it there would make the host boundary
-# spoofable by a request header.
-ALLOW_TENANT_HEADER = (
-    environ.get("ALLOW_TENANT_HEADER", "false").lower() == "true" or DEBUG
-)
 
 
 ALLOWED_HOSTS = ["*"]

--- a/backend/mis/settings.py
+++ b/backend/mis/settings.py
@@ -116,6 +116,7 @@ MIDDLEWARE = [
     "django.middleware.common.CommonMiddleware",
     "django.middleware.csrf.CsrfViewMiddleware",
     "django.contrib.auth.middleware.AuthenticationMiddleware",
+    "middleware.tenant.TenantMiddleware",
     "django.contrib.messages.middleware.MessageMiddleware",
     "django.middleware.clickjacking.XFrameOptionsMiddleware",
     "middleware.user_activity.UserActivity",

--- a/backend/mis/settings.py
+++ b/backend/mis/settings.py
@@ -56,11 +56,24 @@ SECRET_KEY = environ["DJANGO_SECRET"]
 # SECURITY WARNING: don't run with debug turned on in production!
 DEBUG = True if "DEBUG" in environ else False
 PROD = True if "PROD" in environ else False
+# True only when running under `manage.py test`. Used to keep legacy
+# test-only conveniences (the admin@akvo.org auto-create on login) out of
+# production code paths, and — since this iteration — to hold host
+# routing off for the suite. Matched positionally, so a stray "test"
+# argument to some other command cannot switch it on. Defined up here
+# because BASE_DOMAIN below now depends on it.
+TESTING = sys.argv[1:2] == ["test"]
 
 # Host-based tenant routing. Unset means single-host: every host is the
 # base domain, nothing resolves to a tenant, and the routing is inert —
 # which is how the test suite and any non-SaaS deployment run.
-BASE_DOMAIN = environ.get("BASE_DOMAIN", "")
+#
+# Forced off under `test` whatever the environment says. The Django test
+# client's host is "testserver", which is nobody's base domain, so a
+# BASE_DOMAIN inherited from a developer's .env would 404 the entire
+# suite. The tests that exercise host routing opt back in with
+# override_settings, which is how they read anyway.
+BASE_DOMAIN = "" if TESTING else environ.get("BASE_DOMAIN", "")
 # Let an X-Tenant-Subdomain header stand in for the host. The Django test
 # client cannot vary /etc/hosts, so automated tests need this; nothing in
 # production should, and enabling it there would make the host boundary
@@ -277,12 +290,6 @@ EMAIL_FROM = environ.get("EMAIL_FROM", "noreply@akvo.org")
 COUNTRY_NAME = "fiji"
 
 TEST_ENV = False
-
-# True only when running under `manage.py test`. Used to keep legacy
-# test-only conveniences (the admin@akvo.org auto-create on login) out
-# of production code paths. Matched positionally, so a stray "test"
-# argument to some other command cannot switch it on.
-TESTING = sys.argv[1:2] == ["test"]
 
 Q_CLUSTER = {
     "name": "DjangORM",

--- a/backend/utils/tenant_host.py
+++ b/backend/utils/tenant_host.py
@@ -9,6 +9,8 @@ With BASE_DOMAIN unset — the default, and what the test suite and any
 single-host deployment run with — every host is the base domain and no
 host resolves to a tenant, so host routing is inert.
 """
+from urllib.parse import urlparse
+
 from django.conf import settings
 
 from api.v1.v1_users.models import Tenant
@@ -48,3 +50,26 @@ def resolve_tenant_from_host(host):
     if not label or "." in label:
         return None
     return Tenant.objects.filter(subdomain=label).first()
+
+
+def tenant_web_url(tenant):
+    """Where this workspace's app lives — for links we send by email.
+
+    An activation link has to land on the workspace's own host, because
+    everything after it (the configuration form, then the app) is
+    enforced to that host. Sending it to the base domain would strand
+    the registrant one click from a login they cannot use.
+
+    `WEBDOMAIN` keeps supplying the scheme and port — which differ
+    between local development and production — while `BASE_DOMAIN`
+    supplies the host. With no base domain or no tenant there is only
+    one address, and it is `WEBDOMAIN` unchanged.
+    """
+    if not settings.BASE_DOMAIN or not tenant:
+        return settings.WEBDOMAIN
+    parsed = urlparse(settings.WEBDOMAIN)
+    port = f":{parsed.port}" if parsed.port else ""
+    return (
+        f"{parsed.scheme or 'https'}://"
+        f"{tenant.subdomain}.{settings.BASE_DOMAIN}{port}"
+    )

--- a/backend/utils/tenant_host.py
+++ b/backend/utils/tenant_host.py
@@ -18,8 +18,6 @@ from api.v1.v1_users.models import Tenant
 
 def _normalize(host):
     """Strip the port and case so `ACME.app.com:3000` compares equal."""
-    if not host:
-        return ""
     return host.split(":")[0].strip().lower()
 
 

--- a/backend/utils/tenant_host.py
+++ b/backend/utils/tenant_host.py
@@ -1,0 +1,50 @@
+"""Which tenant is this request for, according to its URL?
+
+The single seam for host-based tenant routing. Today a tenant lives at
+one subdomain of BASE_DOMAIN; a custom-domain tier would add a branch
+here and nowhere else, which is the whole reason host parsing is
+confined to this module.
+
+With BASE_DOMAIN unset — the default, and what the test suite and any
+single-host deployment run with — every host is the base domain and no
+host resolves to a tenant, so host routing is inert.
+"""
+from django.conf import settings
+
+from api.v1.v1_users.models import Tenant
+
+
+def _normalize(host):
+    """Strip the port and case so `ACME.app.com:3000` compares equal."""
+    if not host:
+        return ""
+    return host.split(":")[0].strip().lower()
+
+
+def is_base_domain(host):
+    """Is this the bare base domain — the tenant-less signup context?
+
+    Distinguishing this from "some other host" is what lets the caller
+    treat an unresolved host as a missing workspace rather than as the
+    signup page. `www.` is accepted because it is the same site.
+    """
+    if not settings.BASE_DOMAIN:
+        return True
+    base = settings.BASE_DOMAIN.lower()
+    return _normalize(host) in (base, f"www.{base}")
+
+
+def resolve_tenant_from_host(host):
+    """The tenant this host belongs to, or None if it belongs to none."""
+    if not settings.BASE_DOMAIN or is_base_domain(host):
+        return None
+    host = _normalize(host)
+    suffix = f".{settings.BASE_DOMAIN.lower()}"
+    if not host.endswith(suffix):
+        return None
+    label = host[: -len(suffix)]
+    # Exactly one label. Allowing dots would make `acme.staging.app.com`
+    # resolve to nothing useful, or worse, to a tenant it is not.
+    if not label or "." in label:
+        return None
+    return Tenant.objects.filter(subdomain=label).first()

--- a/backend/utils/tenant_host.py
+++ b/backend/utils/tenant_host.py
@@ -36,7 +36,7 @@ def is_base_domain(host):
 
 def resolve_tenant_from_host(host):
     """The tenant this host belongs to, or None if it belongs to none."""
-    if not settings.BASE_DOMAIN or is_base_domain(host):
+    if is_base_domain(host):
         return None
     host = _normalize(host)
     suffix = f".{settings.BASE_DOMAIN.lower()}"
@@ -68,6 +68,5 @@ def tenant_web_url(tenant):
     parsed = urlparse(settings.WEBDOMAIN)
     port = f":{parsed.port}" if parsed.port else ""
     return (
-        f"{parsed.scheme or 'https'}://"
-        f"{tenant.subdomain}.{settings.BASE_DOMAIN}{port}"
+        f"{parsed.scheme}://{tenant.subdomain}.{settings.BASE_DOMAIN}{port}"
     )

--- a/doc/notes/subdomain-local-dev.md
+++ b/doc/notes/subdomain-local-dev.md
@@ -1,0 +1,95 @@
+# Running subdomain routing locally
+
+Each workspace lives at its own host — `acme.app.com` — and a session is
+only valid on the host of the workspace it belongs to. In production that
+needs wildcard DNS and a wildcard TLS certificate for the base domain,
+which are operational, not code. Locally, `/etc/hosts` stands in for the
+wildcard, and the flow you get is the same one production has.
+
+None of this is on by default. With `BASE_DOMAIN` empty every host is the
+base domain, nothing resolves to a workspace, and the app behaves exactly
+as it did before subdomain routing existed. Turn it on only when you are
+working on it.
+
+## One-time setup
+
+**1. Pick a base domain and use it everywhere.** In `.env`:
+
+    BASE_DOMAIN=localapp.test
+
+Use a name you do not own on the real internet. `.test` is reserved for
+exactly this by RFC 2606, so it can never collide with a live domain.
+
+**2. Add the base domain to `/etc/hosts`:**
+
+    127.0.0.1  localapp.test
+
+**3. Restart the stack** so the backend and worker pick up the new
+variable, and the frontend picks up the base domain baked into
+`config.js`:
+
+    ./dc.sh up -d --force-recreate backend worker frontend
+
+Now `http://localapp.test:3000` is the main site: registration and a
+find-workspace field, no login.
+
+## Per workspace
+
+`/etc/hosts` has no wildcard, so each workspace you register needs its own
+line. This is the only repeated step.
+
+1. Open `http://localapp.test:3000/register` and create a workspace, say
+   `new-tenant`.
+2. Add its host:
+
+       127.0.0.1  new-tenant.localapp.test
+
+3. Read the activation email at http://localhost:8025 (Mailpit). Its link
+   already points at `http://new-tenant.localapp.test:3000/activate/...`,
+   because activation hands back a session and that session is only valid
+   there.
+4. Follow the link, fill in the configuration form, and use the app on
+   that host.
+
+## Four things that will bite you
+
+**The base domain and the workspace hosts must share a suffix.** The
+resolver finds a workspace by stripping `BASE_DOMAIN` off the host and
+looking up what is left. `BASE_DOMAIN=localapp.test` with a browser on
+`acme.localhost` resolves to nothing, and you get a 404.
+
+**`ALLOWED_HOSTS` must accept the subdomains.** It is currently `["*"]`,
+so this is already true. If it is ever tightened, Django's leading-dot
+form is a subdomain wildcard: `.localapp.test`.
+
+**The dev proxy must forward the browser's Host.** `setupProxy.js` sets
+`changeOrigin: false` on the API proxy for this reason — with it on, every
+request would reach Django as `127.0.0.1:8000` and no workspace would ever
+resolve. If you add a proxy entry that the app authenticates through,
+leave `changeOrigin` off.
+
+**The port is part of the local address.** The resolver strips it, so
+`:3000` does not affect which workspace is found; but redirects and
+emailed links carry it, and `http://acme.localapp.test` without the port
+reaches nothing.
+
+## Testing without hosts entries
+
+The Django test client cannot edit `/etc/hosts`, so tests send an
+`X-Tenant-Subdomain` header instead, which the middleware honours when
+`ALLOW_TENANT_HEADER` (or `DEBUG`) is set. It is a test affordance, not a
+development workflow — use real hosts locally, so that what you exercise
+is what production does. Production must never enable it: it would make
+the host boundary spoofable by a request header.
+
+## What you should be able to see
+
+- `http://localapp.test:3000/login` redirects to find-workspace — the
+  main site belongs to no workspace, and the backend refuses to sign
+  anyone in there.
+- `http://new-tenant.localapp.test:3000/login` shows the workspace's name.
+- A second workspace's user is refused at the first one's login (401).
+- A session from one workspace, used on another's host, is redirected
+  back to its own.
+- `http://nobody.localapp.test:3000` — after adding it to `/etc/hosts` —
+  answers 404 rather than a login page.

--- a/doc/notes/subdomain-local-dev.md
+++ b/doc/notes/subdomain-local-dev.md
@@ -75,12 +75,15 @@ reaches nothing.
 
 ## Testing without hosts entries
 
-The Django test client cannot edit `/etc/hosts`, so tests send an
-`X-Tenant-Subdomain` header instead, which the middleware honours when
-`ALLOW_TENANT_HEADER` (or `DEBUG`) is set. It is a test affordance, not a
-development workflow — use real hosts locally, so that what you exercise
-is what production does. Production must never enable it: it would make
-the host boundary spoofable by a request header.
+Tests need no setup at all: the Django test client takes the host as an
+argument — `self.client.get(path, HTTP_HOST="acme.app.com")` — and
+`ALLOWED_HOSTS` is `["*"]`, so the request arrives exactly as a browser's
+would. `BASE_DOMAIN` is forced empty under `manage.py test`, so a test
+that wants host routing sets it with `override_settings`.
+
+The same trick works from a shell: `curl -H "Host: acme.localapp.test"`
+reaches a workspace without touching `/etc/hosts`. Only the browser
+needs the hosts entries, because only the browser resolves the name.
 
 ## What you should be able to see
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -22,6 +22,7 @@ services:
       - APK_UPLOAD_SECRET
       - STORAGE_PATH
       - SENTRY_DSN
+      - BASE_DOMAIN
     depends_on:
       - db
   worker:
@@ -42,6 +43,9 @@ services:
       - APK_UPLOAD_SECRET
       - STORAGE_PATH
       - SENTRY_DSN
+      # The worker sends mail too, and an emailed link has to name the
+      # recipient's own workspace host.
+      - BASE_DOMAIN
     depends_on:
       - backend
   frontend:

--- a/env.example
+++ b/env.example
@@ -20,10 +20,6 @@ WEBDOMAIN="http://example.com"
 # lives at <subdomain>.<BASE_DOMAIN>. Locally this needs an /etc/hosts
 # line per workspace; see docs/subdomain-local-dev.md.
 BASE_DOMAIN=
-# Lets an X-Tenant-Subdomain header stand in for the host. Automated
-# tests need it; production must never have it, or the host boundary is
-# spoofable by a request header. Implied by DEBUG.
-ALLOW_TENANT_HEADER=false
 IP_ADDRESS="http://example.com/api/v1/device"
 APK_UPLOAD_SECRET="secret-apk-upload"
 STORAGE_PATH=

--- a/env.example
+++ b/env.example
@@ -15,6 +15,15 @@ DJANGO_SECRET=local-secret
 MAILJET_APIKEY=secret
 MAILJET_SECRET=secret
 WEBDOMAIN="http://example.com"
+# Subdomain routing. Empty (the default) means one host serves everything
+# and host-based tenant resolution is inert — set it and each workspace
+# lives at <subdomain>.<BASE_DOMAIN>. Locally this needs an /etc/hosts
+# line per workspace; see docs/subdomain-local-dev.md.
+BASE_DOMAIN=
+# Lets an X-Tenant-Subdomain header stand in for the host. Automated
+# tests need it; production must never have it, or the host boundary is
+# spoofable by a request header. Implied by DEBUG.
+ALLOW_TENANT_HEADER=false
 IP_ADDRESS="http://example.com/api/v1/device"
 APK_UPLOAD_SECRET="secret-apk-upload"
 STORAGE_PATH=

--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -53,6 +53,7 @@ import {
   FormBuilderList,
   FormBuilderCreate,
   FormBuilderEdit,
+  FindWorkspace,
 } from "./pages";
 import { useCookies } from "react-cookie";
 import { store, api, config } from "./lib";
@@ -61,6 +62,7 @@ import { useNotification } from "./util/hooks";
 import { eraseCookieFromAllPaths } from "./util/date";
 import { reloadData, fetchPublishedForms } from "./util/form";
 import { fetchLevels } from "./util/level";
+import { baseDomain, fetchTenant, workspaceUrl } from "./util/tenant";
 import { ability, AbilityContext } from "./components/can";
 
 // Session validity is not decided here. Two authorities already settle it and
@@ -97,7 +99,21 @@ const Private = ({ element: Element, alias }) => {
 };
 
 const RouteList = () => {
-  const { user: authUser } = store.useState((state) => state);
+  const {
+    user: authUser,
+    tenant,
+    tenantLoaded,
+  } = store.useState((state) => state);
+  // The main site of a SaaS deployment: it signs people up and points
+  // them at their workspace, but it belongs to none, so there is nothing
+  // to sign in to here — the backend refuses a login on it. A
+  // single-host deployment has no base domain and so never takes this
+  // branch, which is what keeps its /login working exactly as before.
+  //
+  // Held until the answer has actually arrived: redirecting to
+  // find-workspace changes the URL, and a tenant that resolves a moment
+  // later cannot undo it.
+  const onBaseDomain = Boolean(baseDomain()) && tenantLoaded && !tenant;
   return (
     <Routes>
       <Route
@@ -113,7 +129,12 @@ const RouteList = () => {
           )
         }
       />
-      <Route exact path="/login" element={<Login />} />
+      <Route
+        exact
+        path="/login"
+        element={onBaseDomain ? <Navigate to="/find-workspace" /> : <Login />}
+      />
+      <Route exact path="/find-workspace" element={<FindWorkspace />} />
       <Route exact path="/login/:invitationId" element={<Login />} />
       <Route exact path="/forgot-password" element={<Login />} />
       <Route exact path="/register" element={<Register />} />
@@ -342,7 +363,12 @@ const RouteList = () => {
 };
 
 const App = () => {
-  const { user: authUser, isLoggedIn } = store.useState((state) => state);
+  const {
+    user: authUser,
+    isLoggedIn,
+    tenant,
+    tenantLoaded,
+  } = store.useState((state) => state);
   const [cookies] = useCookies(["AUTH_TOKEN"]);
   const [loading, setLoading] = useState(true);
   const [formsLoading, setFormsLoading] = useState(true);
@@ -374,7 +400,11 @@ const App = () => {
     // the tenant-scoped request is in flight.
     setFormsLoading(true);
     fetchLevels();
-    fetchPublishedForms()
+    // Which workspace this host is, resolved under the same gate as the
+    // forms: no route decision may be made before the answer arrives, or
+    // the base domain renders /login for a moment before redirecting to
+    // find-workspace.
+    Promise.all([fetchTenant(), fetchPublishedForms()])
       .catch((err) => {
         console.error(err);
       })
@@ -400,7 +430,18 @@ const App = () => {
             setLoading(false);
           })
           .catch((err) => {
-            if (err.response.status === 401) {
+            // The host boundary refuses this session and names the
+            // workspace it does belong to. Nothing is wrong with the
+            // session — only with where it is being used — so the fix is
+            // to go there, not to sign out. This is also the only place
+            // the right address can come from: the profile call that
+            // would have carried it is the very call being refused.
+            const ownWorkspace = err.response?.data?.subdomain;
+            if (err.response?.status === 403 && ownWorkspace) {
+              window.location.replace(workspaceUrl(ownWorkspace));
+              return;
+            }
+            if (err.response?.status === 401) {
               notify({
                 type: "error",
                 message: "Your session has expired",
@@ -429,6 +470,21 @@ const App = () => {
       setLoading(false);
     }
   }, [authUser, isLoggedIn, cookies, notify]);
+
+  // A signed-in user on the main site is sent to their own workspace.
+  // The wrong-*workspace* case never reaches here — the profile call is
+  // refused there, so `authUser` stays empty and the 403 handler above
+  // does the redirecting. This branch covers only the tenant-less base
+  // domain, where the session loads fine but there is no app to show.
+  useEffect(() => {
+    const ownWorkspace = authUser?.subdomain;
+    if (!tenantLoaded || !baseDomain() || !ownWorkspace) {
+      return;
+    }
+    if (tenant?.subdomain !== ownWorkspace) {
+      window.location.replace(workspaceUrl(ownWorkspace));
+    }
+  }, [authUser, tenant, tenantLoaded]);
 
   useEffect(() => {
     // A workspace that has been activated but not yet configured owns no root

--- a/frontend/src/lib/__test__/__snapshots__/store.test.js.snap
+++ b/frontend/src/lib/__test__/__snapshots__/store.test.js.snap
@@ -94,6 +94,8 @@ Object {
   "selectedFormData": null,
   "showAdvancedFilters": false,
   "showContactFormModal": false,
+  "tenant": null,
+  "tenantLoaded": false,
   "user": null,
 }
 `;

--- a/frontend/src/lib/store.js
+++ b/frontend/src/lib/store.js
@@ -25,6 +25,14 @@ const defaultUIState = {
   forms: [],
   // Populated at runtime from GET /api/v1/levels (tenant-owned).
   levels: [],
+  // The workspace this host belongs to, from GET /api/v1/tenant-info.
+  // Null on the base domain and on a single-host deployment.
+  tenant: null,
+  // Whether that answer has arrived. "No workspace" and "not asked yet"
+  // are both `null` but demand opposite behaviour: acting on the second
+  // sends a workspace's own users to the find-workspace page, and a
+  // redirect is not something a later answer can undo.
+  tenantLoaded: false,
   selectedForm: null,
   selectedFormData: null,
   loadingForm: false,

--- a/frontend/src/pages/find-workspace/FindWorkspace.jsx
+++ b/frontend/src/pages/find-workspace/FindWorkspace.jsx
@@ -1,0 +1,57 @@
+import React from "react";
+import "../login/style.scss";
+import { Row, Col, Form, Input, Button } from "antd";
+import { Link } from "react-router-dom";
+import { baseDomain, workspaceUrl } from "../../util/tenant";
+
+// The main site has no workspace, so it cannot sign anyone in — the
+// backend refuses a login here. What it can do is send someone to the
+// right address.
+//
+// No lookup call: asking the server "does this workspace exist?" would
+// hand an anonymous visitor a way to enumerate every customer. Sending
+// the browser there instead costs nothing and lets the workspace's own
+// host answer, which for a wrong guess is a 404 that reveals only what
+// the guesser already typed.
+const FindWorkspace = () => {
+  const onFinish = ({ subdomain }) => {
+    window.location.href = workspaceUrl(subdomain.trim().toLowerCase());
+  };
+
+  return (
+    <div id="login">
+      <Row className="wrapper" align="middle">
+        <Col span={24} className="right-side">
+          <div className="login-form-container">
+            <h1>Go to your workspace</h1>
+            <p className="disclaimer">
+              Each workspace has its own address. Enter yours to sign in.
+            </p>
+            <Form name="find-workspace" layout="vertical" onFinish={onFinish}>
+              <Form.Item
+                name="subdomain"
+                label="Workspace address"
+                rules={[
+                  { required: true, message: "Enter your workspace address" },
+                ]}
+              >
+                <Input placeholder="acme" addonAfter={`.${baseDomain()}`} />
+              </Form.Item>
+              <Form.Item>
+                <Button type="primary" htmlType="submit" shape="round" block>
+                  Continue
+                </Button>
+              </Form.Item>
+              <p className="disclaimer">
+                Don&apos;t have one?{" "}
+                <Link to="/register">Create a workspace</Link>
+              </p>
+            </Form>
+          </div>
+        </Col>
+      </Row>
+    </div>
+  );
+};
+
+export default FindWorkspace;

--- a/frontend/src/pages/find-workspace/__test__/FindWorkspace.test.js
+++ b/frontend/src/pages/find-workspace/__test__/FindWorkspace.test.js
@@ -1,0 +1,88 @@
+import { render, screen, fireEvent } from "@testing-library/react";
+import axios from "axios";
+import TestApp from "../../../TestApp";
+import store from "../../../lib/store";
+import "@testing-library/jest-dom";
+
+jest.mock("axios");
+
+// Every host answers GET /tenant-info; what it answers is what the app
+// uses to decide which of the two contexts it is in.
+const servedAs = (tenant) => {
+  axios.mockImplementation((cfg) => {
+    if (cfg.url === "tenant-info") {
+      return Promise.resolve(
+        tenant ? { status: 200, data: tenant } : { status: 204, data: "" }
+      );
+    }
+    return Promise.resolve({ status: 200, data: [] });
+  });
+};
+
+describe("base domain vs workspace address", () => {
+  const appConfig = window.appConfig;
+  const realLocation = window.location;
+
+  beforeEach(() => {
+    window.appConfig = { ...appConfig, baseDomain: "app.com" };
+    store.update((s) => {
+      s.tenant = null;
+      s.tenantLoaded = false;
+      s.user = null;
+      s.isLoggedIn = false;
+    });
+  });
+
+  afterEach(() => {
+    window.appConfig = appConfig;
+    window.location = realLocation;
+  });
+
+  test("the main site offers to find a workspace, not to sign in", async () => {
+    servedAs(null);
+    render(<TestApp entryPoint={"/login"} />);
+    expect(
+      await screen.findByText(/Go to your workspace/i)
+    ).toBeInTheDocument();
+    expect(screen.queryByText(/Welcome back/i)).toBeNull();
+  });
+
+  test("entering an address goes to that workspace", async () => {
+    servedAs(null);
+    delete window.location;
+    window.location = {
+      ...realLocation,
+      protocol: "http:",
+      port: "",
+      href: "",
+    };
+    render(<TestApp entryPoint={"/find-workspace"} />);
+    fireEvent.change(await screen.findByPlaceholderText("acme"), {
+      target: { value: "Acme " },
+    });
+    fireEvent.click(screen.getByRole("button", { name: /Continue/i }));
+    // Trimmed and lower-cased: a host is neither case-sensitive nor
+    // tolerant of a stray space pasted in from an email.
+    await screen.findByText(/Go to your workspace/i);
+    expect(window.location.href).toBe("http://acme.app.com");
+  });
+
+  test("a workspace address says whose workspace it is", async () => {
+    servedAs({ subdomain: "acme", name: "Kenya", configured: true });
+    render(<TestApp entryPoint={"/login"} />);
+    expect(await screen.findByTestId("workspace-name")).toHaveTextContent(
+      "Kenya"
+    );
+  });
+
+  test("a single-host deployment signs in at /login as before", async () => {
+    // No base domain: tenant-info answers 204 here too, so only
+    // appConfig can tell the two apart — and it must, or every
+    // single-host install would lose its login page.
+    window.appConfig = { ...appConfig };
+    servedAs(null);
+    render(<TestApp entryPoint={"/login"} />);
+    expect(await screen.findByText(/Welcome back/i)).toBeInTheDocument();
+    expect(screen.queryByText(/Go to your workspace/i)).toBeNull();
+  });
+});

--- a/frontend/src/pages/find-workspace/__test__/FindWorkspace.test.js
+++ b/frontend/src/pages/find-workspace/__test__/FindWorkspace.test.js
@@ -68,7 +68,7 @@ describe("base domain vs workspace address", () => {
   });
 
   test("a workspace address says whose workspace it is", async () => {
-    servedAs({ subdomain: "acme", name: "Kenya", configured: true });
+    servedAs({ subdomain: "acme", name: "Kenya" });
     render(<TestApp entryPoint={"/login"} />);
     expect(await screen.findByTestId("workspace-name")).toHaveTextContent(
       "Kenya"

--- a/frontend/src/pages/index.js
+++ b/frontend/src/pages/index.js
@@ -28,6 +28,7 @@ export { default as AddAssignment } from "./mobile-assignment/AddAssignment";
 export { default as MasterData } from "./master-data/MasterData";
 export { default as Activate } from "./activate/Activate";
 export { default as Configure } from "./configure/Configure";
+export { default as FindWorkspace } from "./find-workspace/FindWorkspace";
 export { default as Levels } from "./master-data/levels/Levels";
 export { default as MasterDataAttributes } from "./master-data-attributes/MasterDataAttributes";
 export { default as ManageEntityTypes } from "./master-data-entities/ManageEntityTypes";

--- a/frontend/src/pages/login/Login.jsx
+++ b/frontend/src/pages/login/Login.jsx
@@ -29,7 +29,7 @@ const Login = () => {
   const [invitedUser, setInvitedUser] = useState(null);
   const [loading, setLoading] = useState(false);
 
-  const { language } = store.useState((s) => s);
+  const { language, tenant } = store.useState((s) => s);
   const { active: activeLang } = language;
   const text = useMemo(() => {
     return uiText[activeLang];
@@ -99,6 +99,19 @@ const Login = () => {
                       <img src="./logo-square.svg" alt="login-logo" />
                       <div className="login-content">
                         <h1>{text.loginTitle}</h1>
+                        {/* Which workspace this address is, so a user
+                            with access to more than one can see at a
+                            glance which they are signing in to. Absent
+                            on a single-host deployment, where there is
+                            only ever one. */}
+                        {tenant?.name ? (
+                          <p
+                            className="workspace-name"
+                            data-testid="workspace-name"
+                          >
+                            {tenant.name}
+                          </p>
+                        ) : null}
                         <ContactUsText />
                       </div>
                       <LoginForm />

--- a/frontend/src/pages/login/Login.jsx
+++ b/frontend/src/pages/login/Login.jsx
@@ -105,12 +105,7 @@ const Login = () => {
                             on a single-host deployment, where there is
                             only ever one. */}
                         {tenant?.name ? (
-                          <p
-                            className="workspace-name"
-                            data-testid="workspace-name"
-                          >
-                            {tenant.name}
-                          </p>
+                          <p data-testid="workspace-name">{tenant.name}</p>
                         ) : null}
                         <ContactUsText />
                       </div>

--- a/frontend/src/pages/register/Register.jsx
+++ b/frontend/src/pages/register/Register.jsx
@@ -7,9 +7,10 @@ import { useNotification, useResendActivation } from "../../util/hooks";
 
 const { Title, Text } = Typography;
 
-// The workspace address suffix is the host the browser is already on, so it
-// reads correctly on a deployment and during local development alike. There
-// is no configured base domain to draw on — subdomain routing arrives later.
+// Registration lives on the base domain, so the host the browser is already
+// on *is* the base domain — port and all. Reading it from the address bar
+// rather than from appConfig keeps this correct during local development,
+// where the port is part of the workspace address.
 const addressSuffix = `.${window.location.host}`;
 
 // Phase 1 of sign-up: just enough to claim a workspace. There is no login

--- a/frontend/src/setupProxy.js
+++ b/frontend/src/setupProxy.js
@@ -5,7 +5,12 @@ module.exports = function (app) {
     ["/api/**", "/static-files/**"],
     createProxyMiddleware({
       target: "http://127.0.0.1:8000",
-      changeOrigin: true,
+      // Deliberately false. changeOrigin rewrites the Host header to the
+      // proxy's target, which would make every request arrive at Django
+      // as "127.0.0.1:8000" — and the backend resolves the tenant from
+      // exactly that header. With it on, no amount of /etc/hosts setup
+      // can reach a workspace locally.
+      changeOrigin: false,
     })
   );
   app.use(

--- a/frontend/src/util/__test__/tenant.test.js
+++ b/frontend/src/util/__test__/tenant.test.js
@@ -51,7 +51,7 @@ describe("tenant util", () => {
   test("fetchTenant stores the workspace this host serves", async () => {
     axios.mockResolvedValue({
       status: 200,
-      data: { subdomain: "acme", name: "Kenya", configured: true },
+      data: { subdomain: "acme", name: "Kenya" },
     });
     const tenant = await fetchTenant();
     expect(tenant.name).toBe("Kenya");

--- a/frontend/src/util/__test__/tenant.test.js
+++ b/frontend/src/util/__test__/tenant.test.js
@@ -1,0 +1,73 @@
+import axios from "axios";
+import { baseDomain, fetchTenant, workspaceUrl } from "../tenant";
+import store from "../../lib/store";
+
+jest.mock("axios");
+
+const withLocation = (patch, run) => {
+  const original = window.location;
+  delete window.location;
+  window.location = { ...original, ...patch };
+  try {
+    run();
+  } finally {
+    window.location = original;
+  }
+};
+
+describe("tenant util", () => {
+  const appConfig = window.appConfig;
+
+  beforeEach(() => {
+    window.appConfig = { ...appConfig, baseDomain: "app.com" };
+    store.update((s) => {
+      s.tenant = null;
+    });
+  });
+
+  afterEach(() => {
+    window.appConfig = appConfig;
+  });
+
+  test("baseDomain is empty on a single-host deployment", () => {
+    window.appConfig = { ...appConfig };
+    expect(baseDomain()).toBe("");
+  });
+
+  test("workspaceUrl puts the workspace in front of the base domain", () => {
+    withLocation({ protocol: "https:", port: "" }, () => {
+      expect(workspaceUrl("acme")).toBe("https://acme.app.com");
+    });
+  });
+
+  test("workspaceUrl keeps the port the browser is already using", () => {
+    // Local development runs on :3000 and the redirect has to land
+    // there, not on the default port of a server that is not listening.
+    withLocation({ protocol: "http:", port: "3000" }, () => {
+      expect(workspaceUrl("acme")).toBe("http://acme.app.com:3000");
+    });
+  });
+
+  test("fetchTenant stores the workspace this host serves", async () => {
+    axios.mockResolvedValue({
+      status: 200,
+      data: { subdomain: "acme", name: "Kenya", configured: true },
+    });
+    const tenant = await fetchTenant();
+    expect(tenant.name).toBe("Kenya");
+    expect(store.getRawState().tenant.subdomain).toBe("acme");
+  });
+
+  test("a 204 means there is no workspace here", async () => {
+    // axios gives an empty body as "", which must not be mistaken for a
+    // workspace with a blank name.
+    axios.mockResolvedValue({ status: 204, data: "" });
+    expect(await fetchTenant()).toBeNull();
+    expect(store.getRawState().tenant).toBeNull();
+  });
+
+  test("a failed request leaves no workspace rather than throwing", async () => {
+    axios.mockRejectedValue(new Error("network"));
+    expect(await fetchTenant()).toBeNull();
+  });
+});

--- a/frontend/src/util/tenant.js
+++ b/frontend/src/util/tenant.js
@@ -1,0 +1,37 @@
+import { api, store } from "../lib";
+
+// Is this deployment serving one workspace per host?
+//
+// An empty base domain means one host for everything, and every
+// host-aware branch in the app switches itself off. The frontend cannot
+// work this out on its own: tenant-info answers 204 both on the base
+// domain of a SaaS deployment and on a single-host install, and those
+// two need opposite behaviour from the login route.
+export const baseDomain = () => window?.appConfig?.baseDomain || "";
+
+// Where a workspace's app lives. The port comes from the address the
+// browser is already on, so a local development port survives the
+// redirect and production — which has none — is unaffected.
+export const workspaceUrl = (subdomain) => {
+  const port = window.location.port ? `:${window.location.port}` : "";
+  return `${window.location.protocol}//${subdomain}.${baseDomain()}${port}`;
+};
+
+// The workspace this page is being served for. A 204 leaves it null,
+// which is the answer that means "no workspace here" — the base domain,
+// or a deployment that has none. A failed request is treated the same
+// way: the pre-login page is the safe place to be wrong.
+export const fetchTenant = () =>
+  api
+    .get("tenant-info")
+    .then(
+      (res) => res.data || null,
+      () => null
+    )
+    .then((tenant) => {
+      store.update((s) => {
+        s.tenant = tenant;
+        s.tenantLoaded = true;
+      });
+      return tenant;
+    });


### PR DESCRIPTION
Closes #275

Iteration 8 of the multi-tenant SaaS roadmap: the URL host becomes the
thing that says which workspace a request is for. Stacked on
`feature/274-admin-bulk-upload-hardening` (#286), which is still open —
that is the base branch.

---

## What this adds

Every tenant has had a subdomain since iteration 6, and nothing used it.
The app was served on one host and worked out the tenant purely from the
logged-in user. This makes the subdomain real:

**A resolver.** `resolve_tenant_from_host` maps a host to a tenant, and
is the only place in the codebase that parses one. A single-label
subdomain of `BASE_DOMAIN` resolves to its tenant; the bare base domain,
an unknown label, a nested label and a foreign host all resolve to
nothing. A custom-domain tier would add a branch here and touch nothing
else.

**A middleware** that attaches `request.tenant`, answers **404** for a
host that is neither the main site nor a workspace, and **403** when a
valid session is used on someone else's address. Because JWT auth is
view-layer in this stack, it runs simplejwt itself to learn the user; a
malformed or expired token is treated as no user at all and left to the
view's 401, since only a genuinely valid session can be in the wrong
place.

**Subdomain-scoped login.** The middleware cannot cover this one — a
login request carries no token yet — so the view enforces it: an account
signing in at another workspace's address is refused, and the main site
refuses to sign anyone in at all, before the credentials are evaluated.

**A public `tenant-info`** giving the host workspace's subdomain and
name, which brands the pre-login page. Two fields, because it is
anonymous and the host it answers for is guessable.

**A frontend split in two.** A workspace address gets the branded login
and the app; the main site gets registration and a find-workspace field,
and its `/login` redirects there. A signed-in user who is not on their
own address is sent to it.

This is defence in depth, not the isolation itself. `for_user` still
decides what data a query returns and would keep doing so if the
middleware were deleted. What this adds is a boundary that fails closed
at the edge, before a view has the chance to forget its scoping.

**Nothing is on by default.** With `BASE_DOMAIN` unset — the default,
and what every existing deployment runs — every host is the base domain,
nothing resolves, nothing is enforced, and the app behaves exactly as it
did before. Safe to merge before any DNS exists.

## Deviations from the approved plan

Five, each for a reason found while building.

**The exempt-path list is not here.** The plan specified an explicit list
of public paths exempt from enforcement. It would have been dead code:
enforcement already needs an account to compare against a host, so every
anonymous request passes untouched — which covers register, activation,
health and `config.js`, and every public endpoint added after this was
written, without anyone having to remember a list. The one authenticated
path the list would have exempted, `register/configure`, is better off
enforced.

**`DANGEROUSLY_DISABLE_HOST_CHECK` turned out to be unnecessary.**
react-scripts only narrows `allowedHosts` when `package.json` declares a
`proxy` field, and this project proxies through `setupProxy.js` instead,
so the dev server already accepts any host. Verified by serving a request
with `Host: acme.localapp.test:3000` before deciding to leave it out.

**`X-Tenant-Subdomain` was built, then removed.** The spec called for a
header override because "the Django test client cannot edit
`/etc/hosts`". True, and irrelevant — the test client takes the host as
an argument, `HTTP_HOST="acme.app.com"`, and `ALLOWED_HOSTS` is `["*"]`,
so the request arrives exactly as a browser's would. The middleware's own
test file was already doing this eleven times alongside three tests for
the override. The override bought nothing and cost a setting that
defaulted **on** under `DEBUG` — a switch whose only function was to make
the host boundary bypassable by a request header.

**`tenant-info` has no `configured` field.** Specified, built, and then
found to have no reader: the frontend gates the configuration form on the
signed-in user's own `configured` flag, which is where the decision
belongs, and a visitor who has not signed in cannot act on it. On an
anonymous endpoint, a field with no caller is only exposure.

**The 403 names the workspace the account belongs to.** Not in the plan,
and the frontend redirect is impossible without it: on the wrong
subdomain, the profile call that would carry the user's own subdomain is
the very call being refused. The middleware already knows both sides of
the mismatch.

## Two things that are less obvious than they look

**`baseDomain` comes from `appConfig`, not from the API.** `tenant-info`
answers 204 both on the main site of a SaaS deployment and on a
single-host install, and those two need opposite behaviour from
`/login`. Nothing else can tell them apart, and getting it wrong would
take the login page away from every non-SaaS deployment.

**`tenantLoaded` is a separate flag** because "no workspace here" and
"not asked yet" are both `null`. Acting on the second sent a workspace's
own users to find-workspace, and a redirect is not something a later
answer can undo. This was observed, not anticipated.

## Local development

Production needs wildcard DNS and a wildcard TLS certificate for the base
domain — operational, not code, and the reason this iteration was gated
in the roadmap. Locally, `/etc/hosts` stands in, and the flow that
produces is the same one production has.

The dev proxy stops rewriting the browser's `Host`: `changeOrigin: true`
replaced it with the proxy's target, so every API request reached Django
as `127.0.0.1:8000` — the exact header the backend resolves the tenant
from. With it on, no amount of `/etc/hosts` setup could ever reach a
workspace locally.

`doc/notes/subdomain-local-dev.md` carries the workflow: the one-time
setup, the per-workspace `/etc/hosts` line that is the only repeated
step, and the four things that break it. `CLAUDE.md` points at it and
states the per-workspace requirement up front, since that is the part
that makes a correct configuration still look broken.

`BASE_DOMAIN` is also forced empty under `manage.py test`. The test
client's host is `testserver`, which is nobody's base domain, so a value
inherited from a developer's `.env` would 404 the entire suite — roughly
fifteen hundred failures explaining nothing. Verified by running the
suite with it set.

## Verification

CI gates, run as `ci/build.sh` runs them:

```
docker compose -f docker-compose.test.yml -p backend-test run --rm backend ./run-qc.sh
  → exit 0, 1551 tests, coverage 88.4%
     middleware/tenant.py 100%, utils/tenant_host.py 100%

docker compose -f docker-compose.yml run --rm --no-deps frontend sh release.sh
  → exit 0, production build, eslint under the config that promotes
     every warn to error
```

Frontend suites: **38 suites / 282 tests**.

A **28-check walkthrough** against the running server, driving the real
HTTP API with `Host` headers — which is exactly what `/etc/hosts`
produces in a browser — all passing: the main site answers 204 and an
unknown or foreign host 404; registration on the main site emails a link
to `wsthree.localapp.test:3000`; activation and configuration succeed on
that host; the second workspace has its own name and its own single
level; login is accepted at its own address, refused 401 at the other
workspace's and 400 at the main site; a session passes on its own host,
is 403'd on another's with `subdomain` naming the right one, and is
unenforced on the main site; a bad token is 401 rather than 403; and
`X-Tenant-Subdomain` reaches nothing.

I also confirmed the dev proxy forwards the browser's `Host` through to
Django, so the documented local workflow is real rather than assumed.

Every test added here was run against the unfixed code first and observed
to fail.

## Not covered

Browser-level behaviour end to end. The redirects and the context split
are exercised by jest, and the host boundary by the walkthrough, but
nothing drives a real browser across two subdomains — that needs the
`/etc/hosts` entries, which need root.


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1216901353714106