### PR TITLE
[#277] Scope v1_jobs export/download to the tenant

### DIFF
--- a/backend/api/v1/v1_jobs/job.py
+++ b/backend/api/v1/v1_jobs/job.py
@@ -79,7 +79,13 @@ def download_data(
     date_to: str = None,
     selection_ids: list = None,
     filter_child_form_ids: list = None,
+    user: SystemUser = None,
 ) -> list:
+    # Belt-and-suspenders: floors every FormData lookup to the acting
+    # user's tenant, so a form id that slipped past request validation
+    # (or a future caller of this task) can never surface another
+    # tenant's rows, even though `form` itself is trusted by this point.
+    scoped_form_data = FormData.objects.for_user(user)
     if child_form_ids is None:
         child_form_ids = []
     # filter_child_form_ids controls which child forms are used when
@@ -92,7 +98,8 @@ def download_data(
     )
 
     if selection_ids:
-        data = form.form_form_data.filter(
+        data = scoped_form_data.filter(
+            form=form,
             id__in=selection_ids,
             is_pending=False,
             is_draft=False,
@@ -137,31 +144,31 @@ def download_data(
         }
         if administration_ids:
             child_filter["administration_id__in"] = administration_ids
-        matched_children = FormData.objects.filter(**child_filter)
+        matched_children = scoped_form_data.filter(**child_filter)
         parent_ids_from_children = set(
             matched_children.values_list("parent_id", flat=True)
         )
         # Parents in date range themselves
         parent_date_filter = {**filter_data, **date_filter}
         parent_ids_in_range = set(
-            form.form_form_data.filter(**parent_date_filter)
+            scoped_form_data.filter(form=form, **parent_date_filter)
             .values_list("id", flat=True)
         )
         # Union: parents with in-range children OR in-range themselves
         all_parent_ids = parent_ids_from_children | parent_ids_in_range
-        data = form.form_form_data.filter(
-            id__in=all_parent_ids, **filter_data
+        data = scoped_form_data.filter(
+            form=form, id__in=all_parent_ids, **filter_data
         ).order_by("id").all()
     elif has_date_filter:
         # No child forms — filter parents directly by date
         filter_data.update(date_filter)
-        data = form.form_form_data.filter(
-            **filter_data
+        data = scoped_form_data.filter(
+            form=form, **filter_data
         ).order_by("id").all()
     else:
         # No date filter — existing behavior
-        data = form.form_form_data.filter(
-            **filter_data
+        data = scoped_form_data.filter(
+            form=form, **filter_data
         ).order_by("id").all()
 
     data_items = []
@@ -234,6 +241,7 @@ def generate_data_sheet(
     date_to: str = None,
     selection_ids: list = None,
     filter_child_form_ids: list = None,
+    user: SystemUser = None,
 ) -> None:
     if child_form_ids is None:
         child_form_ids = []
@@ -251,6 +259,7 @@ def generate_data_sheet(
         date_to=date_to,
         selection_ids=selection_ids,
         filter_child_form_ids=filter_child_form_ids,
+        user=user,
     )
     if len(data):
         df = pd.DataFrame(data)
@@ -317,6 +326,7 @@ def download_monitoring_data(
     date_from: str = None,
     date_to: str = None,
     selection_ids: list = None,
+    user: SystemUser = None,
 ) -> list:
     date_filter = _build_date_filter(date_from, date_to)
     filter_data = {
@@ -332,7 +342,10 @@ def download_monitoring_data(
         filter_data["parent__administration_id__in"] = administration_ids
     filter_data.update(date_filter)
 
-    queryset = FormData.objects.filter(
+    # Belt-and-suspenders, matching download_data: floors the query to
+    # the acting user's tenant regardless of what child_form/parent_form
+    # were resolved to upstream.
+    queryset = FormData.objects.for_user(user).filter(
         **filter_data
     ).select_related("parent", "parent__administration", "created_by")
 
@@ -371,6 +384,7 @@ def generate_monitoring_data_sheet(
     date_from: str = None,
     date_to: str = None,
     selection_ids: list = None,
+    user: SystemUser = None,
 ) -> None:
     questions = get_question_names(form=child_form)
     data = download_monitoring_data(
@@ -381,6 +395,7 @@ def generate_monitoring_data_sheet(
         date_from=date_from,
         date_to=date_to,
         selection_ids=selection_ids,
+        user=user,
     )
     if len(data):
         df = pd.DataFrame(data)
@@ -562,6 +577,7 @@ def _generate_excel_download(job, **kwargs):
             date_from=date_from,
             date_to=date_to,
             selection_ids=selection_ids or None,
+            user=job.user,
         )
         monitoring_forms = form.children.filter(pk__in=child_form_ids).all()
         _write_context_sheet(
@@ -613,6 +629,7 @@ def _generate_zip_download(job, **kwargs):
                     # falls within the date range are included even when the
                     # registration itself was created before date_from.
                     filter_child_form_ids=child_form_ids,
+                    user=job.user,
                 )
                 _write_context_sheet(
                     rw, form, child_forms, job,
@@ -642,6 +659,7 @@ def _generate_zip_download(job, **kwargs):
                         date_from=date_from,
                         date_to=date_to,
                         selection_ids=selection_ids or None,
+                        user=job.user,
                     )
                 zf.write(child_path, f"{child_name}.xlsx")
 
@@ -663,7 +681,10 @@ def job_generate_data_download(job_id, **kwargs):
 
 
 def transform_form_data_for_report(
-    form: Forms, selection_ids: list = None, child_form_ids: list = []
+    form: Forms,
+    selection_ids: list = None,
+    child_form_ids: list = [],
+    user: SystemUser = None,
 ):
     """
     Transform form data from database into the format expected by the
@@ -674,6 +695,9 @@ def transform_form_data_for_report(
     (without form filter) to support selection of child form data directly.
     This ensures all available answers for each selection_id are included.
     """
+    # Belt-and-suspenders, matching download_data: floors every FormData
+    # lookup below to the acting user's tenant.
+    scoped_form_data = FormData.objects.for_user(user)
     try:
         forms = [form]
         child_forms = list(form.children.all())
@@ -684,7 +708,7 @@ def transform_form_data_for_report(
         # When selection_ids is provided, query by ID only (no form filter)
         # This allows child form data IDs to be included directly
         if selection_ids and len(selection_ids):
-            main_form_data_queryset = FormData.objects.filter(
+            main_form_data_queryset = scoped_form_data.filter(
                 id__in=selection_ids, is_pending=False
             )
             # Also include forms from the selected FormData to ensure
@@ -701,7 +725,7 @@ def transform_form_data_for_report(
                         pass
                         # If a referenced form no longer exists, skip it
         else:
-            main_form_data_queryset = FormData.objects.filter(
+            main_form_data_queryset = scoped_form_data.filter(
                 form=form, is_pending=False
             )
         main_form_data = main_form_data_queryset.order_by("id").all()
@@ -997,6 +1021,7 @@ def job_generate_data_report(job_id: int, **kwargs):
             form=form,
             selection_ids=selection_ids,
             child_form_ids=child_form_ids,
+            user=job.user,
         )
 
         # Fallback to empty list if no data found

--- a/backend/api/v1/v1_jobs/serializers.py
+++ b/backend/api/v1/v1_jobs/serializers.py
@@ -9,16 +9,16 @@ from api.v1.v1_jobs.models import Jobs
 from api.v1.v1_profile.models import Administration, AdministrationAttribute
 from api.v1.v1_data.models import FormData
 from utils.custom_serializer_fields import (
-    CustomPrimaryKeyRelatedField,
     CustomFileField,
     CustomChoiceField,
     CustomListField,
+    TenantScopedPrimaryKeyRelatedField,
 )
 
 
 class DownloadDataRequestSerializer(serializers.Serializer):
-    form_id = CustomPrimaryKeyRelatedField(queryset=Forms.objects.none())
-    administration_id = CustomPrimaryKeyRelatedField(
+    form_id = TenantScopedPrimaryKeyRelatedField(queryset=Forms.objects.none())
+    administration_id = TenantScopedPrimaryKeyRelatedField(
         queryset=Administration.objects.none(), required=False
     )
     type = CustomChoiceField(
@@ -29,7 +29,7 @@ class DownloadDataRequestSerializer(serializers.Serializer):
     )
     use_label = serializers.BooleanField(required=False)
     child_form_ids = CustomListField(
-        child=CustomPrimaryKeyRelatedField(
+        child=TenantScopedPrimaryKeyRelatedField(
             queryset=Forms.objects.none()
         ),
         required=False,
@@ -37,7 +37,7 @@ class DownloadDataRequestSerializer(serializers.Serializer):
     date_from = serializers.DateField(required=False, allow_null=True)
     date_to = serializers.DateField(required=False, allow_null=True)
     selection_ids = CustomListField(
-        child=CustomPrimaryKeyRelatedField(
+        child=TenantScopedPrimaryKeyRelatedField(
             queryset=FormData.objects.none()
         ),
         required=False,
@@ -205,15 +205,15 @@ class UploadExcelSerializer(serializers.Serializer):
 
 
 class FormDataReportSerializer(serializers.Serializer):
-    form_id = CustomPrimaryKeyRelatedField(queryset=Forms.objects.none())
+    form_id = TenantScopedPrimaryKeyRelatedField(queryset=Forms.objects.none())
     child_form_ids = CustomListField(
-        child=CustomPrimaryKeyRelatedField(
+        child=TenantScopedPrimaryKeyRelatedField(
             queryset=Forms.objects.none()
         ),
         required=False,
     )
     selection_ids = CustomListField(
-        child=CustomPrimaryKeyRelatedField(
+        child=TenantScopedPrimaryKeyRelatedField(
             queryset=FormData.objects.none()
         ),
         required=False,

--- a/backend/api/v1/v1_jobs/tests/tests_tenant_isolation.py
+++ b/backend/api/v1/v1_jobs/tests/tests_tenant_isolation.py
@@ -1,0 +1,155 @@
+import os
+
+from django.test.utils import override_settings
+
+from api.v1.v1_data.models import FormData
+from api.v1.v1_forms.constants import FormStatus
+from api.v1.v1_forms.models import Forms
+from api.v1.v1_jobs.constants import JobStatus, JobTypes, DataDownloadTypes
+from api.v1.v1_jobs.models import Jobs
+from utils import storage
+from utils.tenant_test_case import TenantIsolationTestCase
+
+
+def _write_result_file(filename):
+    path = f"./{filename}"
+    with open(path, "a") as f:
+        f.write("This is a test file!")
+    storage.upload(file=path, filename=filename, folder="download")
+
+
+@override_settings(USE_TZ=False, TEST_ENV=True)
+class JobsTenantIsolationTestCase(TenantIsolationTestCase):
+    def setUp(self):
+        self._result_files = []
+        super().setUp()
+
+    def tearDown(self):
+        for filename in self._result_files:
+            if os.path.exists(f"./{filename}"):
+                os.remove(f"./{filename}")
+            storage.delete(url=f"download/{filename}")
+
+    def make_tenant(self, sub):
+        tenant = super().make_tenant(sub)
+        result_filename = f"{sub}-download.xlsx"
+        _write_result_file(result_filename)
+        self._result_files.append(result_filename)
+        tenant["job"] = Jobs.objects.create(
+            type=JobTypes.download,
+            user=tenant["user"],
+            status=JobStatus.done,
+            task_id=f"{sub}-task-id",
+            info={
+                "form_id": tenant["form"].id,
+                "download_type": DataDownloadTypes.all,
+            },
+            result=result_filename,
+        )
+        tenant["data"] = FormData.objects.create(
+            name=f"{sub}-dp",
+            form=tenant["form"],
+            administration=tenant["child"],
+            created_by=tenant["user"],
+        )
+        tenant["monitoring_form"] = Forms.objects.create(
+            name=f"{sub}-monitoring",
+            tenant=tenant["tenant"],
+            status=FormStatus.published,
+            parent=tenant["form"],
+        )
+        tenant["monitoring_data"] = FormData.objects.create(
+            name=f"{sub}-mdp",
+            form=tenant["monitoring_form"],
+            administration=tenant["child"],
+            created_by=tenant["user"],
+            parent=tenant["data"],
+        )
+        return tenant
+
+    def test_download_file_404_on_foreign_job(self):
+        res = self.client.get(
+            f"/api/v1/download/file/{self.b['job'].result}",
+            **self.auth(self.a["user"]),
+        )
+        self.assertEqual(res.status_code, 404)
+
+    def test_download_status_404_on_foreign_job(self):
+        res = self.client.get(
+            f"/api/v1/download/status/{self.b['job'].task_id}",
+            **self.auth(self.a["user"]),
+        )
+        self.assertEqual(res.status_code, 404)
+
+    def test_download_generate_400_on_foreign_form(self):
+        res = self.client.get(
+            "/api/v1/download/generate",
+            {"form_id": self.b["form"].id},
+            **self.auth(self.a["user"]),
+        )
+        self.assertEqual(res.status_code, 400)
+
+    def test_download_generate_400_on_foreign_administration(self):
+        res = self.client.get(
+            "/api/v1/download/generate",
+            {
+                "form_id": self.a["form"].id,
+                "administration_id": self.b["root"].id,
+            },
+            **self.auth(self.a["user"]),
+        )
+        self.assertEqual(res.status_code, 400)
+
+    def test_datapoint_report_400_on_foreign_form(self):
+        res = self.client.get(
+            "/api/v1/download/datapoint-report",
+            {"form_id": self.b["form"].id},
+            **self.auth(self.a["user"]),
+        )
+        self.assertEqual(res.status_code, 400)
+
+    def test_upload_excel_404_on_foreign_form(self):
+        res = self.client.post(
+            f"/api/v1/upload/excel/{self.b['form'].id}",
+            {},
+            **self.auth(self.a["user"]),
+        )
+        self.assertEqual(res.status_code, 404)
+        self.assertEqual(
+            Jobs.objects.filter(user=self.a["user"]).count(), 1
+        )
+
+    def test_download_data_worker_scoped_by_job_user(self):
+        # Belt-and-suspenders: even if a foreign form id slipped past
+        # request validation (or a future caller invokes the task
+        # directly), the worker's own FormData query must not surface
+        # another tenant's rows.
+        from api.v1.v1_jobs.job import download_data
+
+        items = download_data(
+            form=self.b["form"],
+            selection_ids=[self.b["data"].id],
+            user=self.a["user"],
+        )
+        self.assertEqual(items, [])
+
+    def test_download_monitoring_data_worker_scoped_by_job_user(self):
+        from api.v1.v1_jobs.job import download_monitoring_data
+
+        items = download_monitoring_data(
+            parent_form=self.b["form"],
+            child_form=self.b["monitoring_form"],
+            selection_ids=[self.b["data"].id],
+            user=self.a["user"],
+        )
+        self.assertEqual(items, [])
+
+    def test_transform_form_data_for_report_scoped_by_job_user(self):
+        from api.v1.v1_jobs.job import transform_form_data_for_report
+
+        result = transform_form_data_for_report(
+            form=self.b["form"],
+            selection_ids=[self.b["data"].id],
+            user=self.a["user"],
+        )
+        self.assertEqual(result, [])

--- a/backend/api/v1/v1_jobs/views.py
+++ b/backend/api/v1/v1_jobs/views.py
@@ -115,7 +115,9 @@ from utils.custom_serializer_fields import validate_serializers_message
 @api_view(["GET"])
 @permission_classes([IsAuthenticated])
 def download_generate(request, version):
-    serializer = DownloadDataRequestSerializer(data=request.GET)
+    serializer = DownloadDataRequestSerializer(
+        data=request.GET, context={"user": request.user}
+    )
     if not serializer.is_valid():
         return Response(
             {"message": validate_serializers_message(serializer.errors)},
@@ -177,7 +179,9 @@ def download_generate(request, version):
 @api_view(["GET"])
 @permission_classes([IsAuthenticated])
 def download_status(request, version, task_id):
-    job = get_object_or_404(Jobs, task_id=task_id)
+    job = get_object_or_404(
+        Jobs.objects.filter(user=request.user), task_id=task_id
+    )
     return Response(
         {"status": JobStatus.FieldStr.get(job.status)},
         status=status.HTTP_200_OK,
@@ -200,7 +204,9 @@ def download_status(request, version, task_id):
 @api_view(["GET"])
 @permission_classes([IsAuthenticated])
 def download_file(request, version, file_name):
-    job = get_object_or_404(Jobs, result=file_name)
+    job = get_object_or_404(
+        Jobs.objects.filter(user=request.user), result=file_name
+    )
     type = request.GET.get("type") if request.GET.get("type") else "download"
     url = f"{type}/{job.result}"
     filepath = storage.download(url)
@@ -284,7 +290,9 @@ def download_list(request, version):
 @parser_classes([MultiPartParser])
 @permission_classes([IsAuthenticated])
 def upload_excel(request, form_id, version):
-    form = get_object_or_404(Forms, pk=form_id)
+    form = get_object_or_404(
+        Forms.objects.for_user(request.user), pk=form_id
+    )
     serializer = UploadExcelSerializer(data=request.data)
     if not serializer.is_valid():
         return Response(
@@ -490,7 +498,9 @@ def upload_bulk_entities(request, version):
 @api_view(["GET"])
 @permission_classes([IsAuthenticated])
 def download_data_report(request, version):
-    serializer = FormDataReportSerializer(data=request.GET)
+    serializer = FormDataReportSerializer(
+        data=request.GET, context={"user": request.user}
+    )
     if not serializer.is_valid():
         return Response(
             {"message": validate_serializers_message(serializer.errors)},


### PR DESCRIPTION
## Summary
- Filter `Jobs` by `user=request.user` in `download_file`/`download_status` so a foreign job's filename or task id 404s instead of streaming another tenant's export.
- Tenant-scope the download-generate and datapoint-report request serializers' form/administration/child-form/selection-id fields via `TenantScopedPrimaryKeyRelatedField`, rejecting a foreign id with 400 before a job is ever queued.
- Scope `upload_excel`'s form lookup by `for_user` so bulk data can't be uploaded into another tenant's form.
- Belt-and-suspenders: float every `FormData` query in the worker (`download_data`, `download_monitoring_data`, `transform_form_data_for_report`) through `for_user(job.user)`, so a foreign id that slipped past request validation still can't surface cross-tenant rows.

Design doc: `doc/design/MT-009-jobs-export-download-tenant-scoping.md`

## Test plan
- [x] New `api.v1.v1_jobs.tests.tests_tenant_isolation` (9 tests, TDD red→green) covering all four leaks
- [x] Full `v1_jobs` suite (185 tests) green, no regressions
- [x] Full backend suite (1560 tests, non-parallel) green
- [x] `flake8` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1216901353714122