### PR TITLE
[#276] Isolate mobile offline master data by tenant

### DIFF
--- a/app/src/lib/__test__/cascades.test.js
+++ b/app/src/lib/__test__/cascades.test.js
@@ -3,6 +3,7 @@ import * as SQLite from 'expo-sqlite';
 import { act, waitFor } from '@testing-library/react-native';
 
 import cascades from '../cascades';
+import api from '../api';
 
 jest.mock('expo-sqlite');
 
@@ -48,9 +49,28 @@ describe('cascades', () => {
       expect(FileSystem.downloadAsync).toHaveBeenCalledWith(
         downloadUrl,
         `test-document-directory/${DIR_NAME}/file.sqlite`,
-        { cache: false },
+        expect.objectContaining({ cache: false }),
       );
     });
+  });
+
+  it('should send the assignment token when downloading', async () => {
+    /**
+     * The sqlite endpoint is per-tenant and authenticated: it picks the file
+     * from the caller's token, so an unauthenticated download now 401s.
+     */
+    api.setToken('assignment-token');
+    const downloadUrl = 'https://example.com/api/v1/device/sqlite/administrator.sqlite';
+    const fileUrl = '/device/sqlite/administrator.sqlite';
+    await cascades.download(downloadUrl, fileUrl);
+
+    expect(FileSystem.downloadAsync).toHaveBeenCalledWith(
+      downloadUrl,
+      `test-document-directory/${DIR_NAME}/administrator.sqlite`,
+      expect.objectContaining({
+        headers: expect.objectContaining({ Authorization: 'Bearer assignment-token' }),
+      }),
+    );
   });
 
   it('should not download the file if it already exists', () => {

--- a/app/src/lib/cascades.js
+++ b/app/src/lib/cascades.js
@@ -3,6 +3,8 @@ import * as FileSystem from 'expo-file-system';
 import * as SQLite from 'expo-sqlite';
 import * as Sentry from '@sentry/react-native';
 
+import api from './api';
+
 const DIR_NAME = 'SQLite';
 
 const createSqliteDir = async () => {
@@ -22,8 +24,14 @@ const download = async (downloadUrl, fileUrl, update = false) => {
     await SQLite.deleteDatabaseAsync(fileSql);
   }
   if (!exists || update) {
+    /**
+     * The sqlite endpoint resolves the tenant from the assignment token and
+     * serves that tenant's file, so the download must carry the token the
+     * rest of the api client already sends. Without it the request 401s.
+     */
     await FileSystem.downloadAsync(downloadUrl, FileSystem.documentDirectory + pathSql, {
       cache: false,
+      headers: api.getConfig().headers,
     });
   }
 };

--- a/backend/api/v1/v1_jobs/job.py
+++ b/backend/api/v1/v1_jobs/job.py
@@ -1271,7 +1271,9 @@ def handle_administrations_bulk_upload(
         set_bulk_upload_job(job_id, JobStatus.failed, result=error_file)
         return
     seed_administration_data(file_path, tenant=user.tenant)
-    generate_sqlite(Administration)
+    # The uploader's tenant, not the root file: that is the one its devices
+    # download, so regenerating anything else leaves them stale.
+    generate_sqlite(Administration, tenant=user.tenant)
     send_email(context=email_context, type=EmailTypes.administration_upload)
     set_bulk_upload_job(job_id, JobStatus.done)
 
@@ -1339,4 +1341,4 @@ def handle_entities_bulk_upload(filename, user_id, upload_time):
     if len(errors):
         handle_entities_error_upload(errors, email_context, user, upload_time)
         return
-    generate_sqlite(EntityData)
+    generate_sqlite(EntityData, tenant=user.tenant)

--- a/backend/api/v1/v1_jobs/tests/test_bulk_upload_job.py
+++ b/backend/api/v1/v1_jobs/tests/test_bulk_upload_job.py
@@ -1,4 +1,6 @@
 import os
+import shutil
+import sqlite3
 from unittest.mock import patch
 
 import pandas as pd
@@ -10,6 +12,8 @@ from api.v1.v1_jobs.constants import JobStatus, JobTypes
 from api.v1.v1_jobs.job import handle_administrations_bulk_upload
 from api.v1.v1_jobs.models import Jobs
 from api.v1.v1_profile.models import Administration
+from mis.settings import MASTER_DATA
+from utils.custom_generator import sqlite_path
 from api.v1.v1_profile.tests.mixins import (
     TenantTestHelperMixin,
     write_administration_excel,
@@ -89,6 +93,35 @@ class BulkUploadJobTestCase(TestCase, TenantTestHelperMixin):
                 tenant=self.acme.tenant, name="Nairobi"
             ).exists()
         )
+
+    def test_a_good_file_refreshes_the_tenants_sqlite(self):
+        # Devices download their own tenant's master-data file, so
+        # regenerating the tenant-less root one would leave every device
+        # holding the hierarchy from before the upload.
+        self._write_file("sync.xlsx", [(None, "Nairobi")])
+        job = self._pending_job()
+        self.addCleanup(
+            shutil.rmtree, f"{MASTER_DATA}/acme", ignore_errors=True
+        )
+        with patch("api.v1.v1_jobs.job.storage.download"), patch(
+            "api.v1.v1_jobs.job.send_email"
+        ):
+            handle_administrations_bulk_upload(
+                "sync.xlsx", self.acme.admin.id, timezone.now(), job.id
+            )
+
+        path = sqlite_path(
+            Administration, tenant=self.acme.tenant, test=True
+        )
+        self.assertTrue(os.path.exists(path), f"missing {path}")
+        conn = sqlite3.connect(path)
+        try:
+            names = list(
+                pd.read_sql_query("SELECT * FROM nodes", conn)["name"]
+            )
+        finally:
+            conn.close()
+        self.assertIn("Nairobi", names)
 
     def test_a_rejected_file_fails_the_job_and_keeps_the_error_file(self):
         self._write_file("bad.xlsx", [("Wrongland", "Nairobi")])

--- a/backend/api/v1/v1_mobile/management/commands/generate_sqlite.py
+++ b/backend/api/v1/v1_mobile/management/commands/generate_sqlite.py
@@ -1,7 +1,9 @@
 from django.core.management import BaseCommand
 from utils.custom_generator import generate_sqlite
 from api.v1.v1_profile.models import Administration, Entity, EntityData
-from api.v1.v1_users.models import Organisation
+from api.v1.v1_users.models import Organisation, Tenant
+
+MODELS = [Administration, Organisation, Entity, EntityData]
 
 
 class Command(BaseCommand):
@@ -13,18 +15,18 @@ class Command(BaseCommand):
 
     def handle(self, *args, **options):
         test = options.get("test", False)
-        file = generate_sqlite(Administration, test=test)
-        if not test:
-            self.log_generated(file, Administration)
-        file = generate_sqlite(Organisation, test=test)
-        if not test:
-            self.log_generated(file, Organisation)
-        file = generate_sqlite(Entity, test=test)
-        if not test:
-            self.log_generated(file, Entity)
-        file = generate_sqlite(EntityData, test=test)
-        if not test:
-            self.log_generated(file, EntityData)
+        # The tenant-less pass stays: seeders and single-tenant installs
+        # still read the root files. The per-tenant pass is what a device
+        # actually downloads.
+        for model in MODELS:
+            file = generate_sqlite(model, test=test)
+            if not test:
+                self.log_generated(file, model)
+        for tenant in Tenant.objects.all():
+            for model in MODELS:
+                file = generate_sqlite(model, tenant=tenant, test=test)
+                if not test:
+                    self.log_generated(file, model)
 
     def log_generated(self, file, model):
         message = (

--- a/backend/api/v1/v1_mobile/tests/tests_forms_tree_tenant_isolation.py
+++ b/backend/api/v1/v1_mobile/tests/tests_forms_tree_tenant_isolation.py
@@ -1,0 +1,42 @@
+from django.test.utils import override_settings
+
+from api.v1.v1_forms.constants import FormStatus
+from api.v1.v1_forms.models import Forms
+from utils.tenant_test_case import TenantIsolationTestCase
+
+
+@override_settings(USE_TZ=False)
+class FormsTreeTenantIsolationTestCase(TenantIsolationTestCase):
+    """The assignment-builder tree must show only the caller's forms.
+
+    get_forms_tree queried Forms.objects.filter(...) unscoped, so the UI
+    listed every tenant's published forms by name and id.
+    """
+
+    def make_tenant(self, sub):
+        tenant = super().make_tenant(sub)
+        tenant["monitoring"] = Forms.objects.create(
+            name=f"{sub}-monitoring",
+            tenant=tenant["tenant"],
+            status=FormStatus.published,
+            parent=tenant["form"],
+        )
+        return tenant
+
+    def test_tree_excludes_another_tenants_registration_form(self):
+        res = self.client.get(
+            "/api/v1/forms-tree", **self.auth(self.a["user"])
+        )
+        self.assertEqual(res.status_code, 200)
+        names = [f["name"] for f in res.json()]
+        self.assertIn("acme-form", names)
+        self.assertNotIn("beta-form", names)
+
+    def test_tree_excludes_another_tenants_monitoring_child(self):
+        res = self.client.get(
+            "/api/v1/forms-tree", **self.auth(self.a["user"])
+        )
+        self.assertEqual(res.status_code, 200)
+        children = [c["name"] for f in res.json() for c in f["children"]]
+        self.assertIn("acme-monitoring", children)
+        self.assertNotIn("beta-monitoring", children)

--- a/backend/api/v1/v1_mobile/tests/tests_sqlite_generation.py
+++ b/backend/api/v1/v1_mobile/tests/tests_sqlite_generation.py
@@ -9,7 +9,9 @@ from api.v1.v1_profile.management.commands.administration_seeder import (
     seed_levels
 )
 from api.v1.v1_profile.constants import DEFAULT_ADMINISTRATION_LEVELS
-from api.v1.v1_users.models import Organisation
+from api.v1.v1_users.models import Organisation, SystemUser
+from api.v1.v1_mobile.authentication import MobileAssignmentToken
+from api.v1.v1_mobile.models import MobileAssignment
 from django.core.management import call_command
 from utils.custom_generator import generate_sqlite, update_sqlite
 from unittest.mock import patch
@@ -64,11 +66,31 @@ class SQLiteGenerationTest(TestCase):
             len(pd.read_sql_query("SELECT * FROM nodes", conn)),
         )
         conn.close()
-        file = file_name.split("/")[-1]
-        endpoint = f"/api/v1/device/sqlite/{file}"
-        response = self.client.get(endpoint)
+        # The device asks for the logical table name, not the on-disk one:
+        # the server picks the file, which is how it stays inside the
+        # caller's tenant. This user is tenant-less, so it gets the root
+        # file the assertions above just checked.
+        user = SystemUser.objects.create_user(
+            email="device@test.org", password="Secret#Pass123",
+            first_name="D", last_name="D",
+        )
+        assignment = MobileAssignment.objects.create_assignment(
+            user=user, name="device"
+        )
+        token = MobileAssignmentToken.for_assignment(assignment)
+        response = self.client.get(
+            "/api/v1/device/sqlite/administrator.sqlite",
+            HTTP_AUTHORIZATION=f"Bearer {token}",
+        )
         self.assertEqual(response.status_code, 200)
         os.remove(file_name)
+
+    def test_sqlite_file_endpoint_rejects_an_anonymous_caller(self):
+        generate_sqlite(Administration)
+        response = self.client.get(
+            "/api/v1/device/sqlite/administrator.sqlite"
+        )
+        self.assertEqual(response.status_code, 401)
 
     def test_update_sqlite_org_added(self):
         # Test for adding new org

--- a/backend/api/v1/v1_mobile/tests/tests_sqlite_tenant_isolation.py
+++ b/backend/api/v1/v1_mobile/tests/tests_sqlite_tenant_isolation.py
@@ -1,0 +1,209 @@
+import os
+import shutil
+import sqlite3
+
+import pandas as pd
+from django.core.management import call_command
+from django.test.utils import override_settings
+
+from api.v1.v1_mobile.authentication import MobileAssignmentToken
+from api.v1.v1_mobile.models import MobileAssignment
+from api.v1.v1_profile.models import Administration, Entity, EntityData
+from api.v1.v1_profile.serializers import AdministrationSerializer
+from api.v1.v1_users.models import Organisation
+from mis.settings import MASTER_DATA
+from utils.custom_generator import generate_sqlite, sqlite_path
+from utils.tenant_test_case import TenantIsolationTestCase
+
+
+@override_settings(USE_TZ=False, TEST_ENV=True)
+class SQLiteTenantIsolationTestCase(TenantIsolationTestCase):
+    """Offline master data must never cross a tenant boundary.
+
+    generate_sqlite used to dump model.objects.all() into one global file
+    and download_sqlite_file served it to anyone, so a device held every
+    tenant's administrative hierarchy offline.
+    """
+
+    def make_tenant(self, sub):
+        tenant = super().make_tenant(sub)
+        Organisation.objects.create(name=f"{sub}-org", tenant=tenant["tenant"])
+        entity = Entity.objects.create(
+            name=f"{sub}-entity", tenant=tenant["tenant"]
+        )
+        EntityData.objects.create(
+            name=f"{sub}-school",
+            entity=entity,
+            administration=tenant["child"],
+        )
+        tenant["entity"] = entity
+        assignment = MobileAssignment.objects.create_assignment(
+            user=tenant["user"], name=f"{sub}-device"
+        )
+        assignment.administrations.add(tenant["child"])
+        assignment.forms.add(tenant["form"])
+        tenant["assignment"] = assignment
+        return tenant
+
+    def device_auth(self, tenant):
+        token = MobileAssignmentToken.for_assignment(tenant["assignment"])
+        return {"HTTP_AUTHORIZATION": f"Bearer {token}"}
+
+    def tearDown(self):
+        for sub in ["acme", "beta"]:
+            shutil.rmtree(f"{MASTER_DATA}/{sub}", ignore_errors=True)
+
+    def read_names(self, file_name):
+        conn = sqlite3.connect(file_name)
+        try:
+            return list(pd.read_sql_query("SELECT * FROM nodes", conn)["name"])
+        finally:
+            conn.close()
+
+    def test_generate_writes_only_own_tenant_rows(self):
+        file_name = generate_sqlite(
+            Administration, tenant=self.a["tenant"]
+        )
+        names = self.read_names(file_name)
+        self.assertIn("acme", names)
+        self.assertNotIn("beta", names)
+        self.assertNotIn("beta-d", names)
+
+    def test_generate_writes_into_per_tenant_directory(self):
+        file_name = generate_sqlite(Administration, tenant=self.a["tenant"])
+        self.assertTrue(file_name.startswith(f"{MASTER_DATA}/acme/"))
+        self.assertTrue(os.path.exists(file_name))
+
+    def test_generate_without_tenant_keeps_root_location(self):
+        file_name = generate_sqlite(Administration)
+        self.addCleanup(os.remove, file_name)
+        self.assertEqual(
+            file_name, f"{MASTER_DATA}/test_administrator.sqlite"
+        )
+
+    def test_generate_scopes_organisation_by_tenant(self):
+        file_name = generate_sqlite(Organisation, tenant=self.a["tenant"])
+        names = self.read_names(file_name)
+        self.assertIn("acme-org", names)
+        self.assertNotIn("beta-org", names)
+
+    def test_command_generates_a_file_per_tenant(self):
+        call_command("generate_sqlite", "--test", True)
+        for sub in ["acme", "beta"]:
+            path = f"{MASTER_DATA}/{sub}/test_administrator.sqlite"
+            self.assertTrue(os.path.exists(path), f"missing {path}")
+        names = self.read_names(
+            f"{MASTER_DATA}/acme/test_administrator.sqlite"
+        )
+        self.assertIn("acme", names)
+        self.assertNotIn("beta", names)
+
+    def test_command_still_writes_the_tenantless_artifacts(self):
+        call_command("generate_sqlite", "--test", True)
+        root = f"{MASTER_DATA}/test_administrator.sqlite"
+        self.addCleanup(os.remove, root)
+        self.assertTrue(os.path.exists(root))
+
+    def test_administration_serializer_writes_into_its_tenants_file(self):
+        # The serializer is where a single new row reaches sqlite; if it
+        # keeps writing to the root file, per-tenant generation silently
+        # drifts out of date the moment anyone adds an administration.
+        generate_sqlite(Administration, tenant=self.a["tenant"])
+        serializer = AdministrationSerializer(
+            data={
+                "name": "acme-village",
+                "parent": self.a["root"].id,
+                "code": "acme-village",
+            },
+            context={"user": self.a["user"]},
+        )
+        self.assertTrue(serializer.is_valid(), serializer.errors)
+        serializer.save()
+        names = self.read_names(
+            sqlite_path(Administration, tenant=self.a["tenant"], test=True)
+        )
+        self.assertIn("acme-village", names)
+
+    def test_generate_scopes_entity_by_tenant(self):
+        file_name = generate_sqlite(Entity, tenant=self.a["tenant"])
+        names = self.read_names(file_name)
+        self.assertIn("acme-entity", names)
+        self.assertNotIn("beta-entity", names)
+
+    def test_generate_scopes_entity_data_through_its_entity(self):
+        # EntityData reaches its tenant by join (entity__tenant) rather than
+        # a local column, so it is the scoping most likely to silently
+        # return everything.
+        file_name = generate_sqlite(EntityData, tenant=self.a["tenant"])
+        names = self.read_names(file_name)
+        self.assertIn("acme-school", names)
+        self.assertNotIn("beta-school", names)
+
+    def test_download_serves_the_callers_tenant_file(self):
+        generate_sqlite(Administration, tenant=self.a["tenant"])
+        generate_sqlite(Administration, tenant=self.b["tenant"])
+        res = self.client.get(
+            "/api/v1/device/sqlite/administrator.sqlite",
+            **self.device_auth(self.a),
+        )
+        self.assertEqual(res.status_code, 200)
+        served = f"{MASTER_DATA}/served.sqlite"
+        self.addCleanup(os.remove, served)
+        with open(served, "wb") as f:
+            f.write(res.content)
+        names = self.read_names(served)
+        self.assertIn("acme", names)
+        self.assertNotIn("beta", names)
+
+    def test_download_generates_the_file_when_absent(self):
+        path = sqlite_path(Administration, tenant=self.a["tenant"], test=True)
+        self.assertFalse(os.path.exists(path))
+        res = self.client.get(
+            "/api/v1/device/sqlite/administrator.sqlite",
+            **self.device_auth(self.a),
+        )
+        self.assertEqual(res.status_code, 200)
+        self.assertTrue(os.path.exists(path))
+
+    def test_download_serves_a_valid_file_when_the_tenant_has_no_rows(self):
+        # A tenant with no entities still has a cascade question pointing at
+        # entity_data.sqlite; serving nothing would break the form rather
+        # than render an empty dropdown.
+        EntityData.objects.filter(entity__tenant=self.a["tenant"]).delete()
+        res = self.client.get(
+            "/api/v1/device/sqlite/entity_data.sqlite",
+            **self.device_auth(self.a),
+        )
+        self.assertEqual(res.status_code, 200)
+        served = f"{MASTER_DATA}/served_empty.sqlite"
+        self.addCleanup(os.remove, served)
+        with open(served, "wb") as f:
+            f.write(res.content)
+        self.assertEqual(self.read_names(served), [])
+
+    def test_download_requires_a_mobile_token(self):
+        generate_sqlite(Administration, tenant=self.a["tenant"])
+        res = self.client.get("/api/v1/device/sqlite/administrator.sqlite")
+        self.assertEqual(res.status_code, 401)
+
+    def test_download_rejects_a_web_token(self):
+        generate_sqlite(Administration, tenant=self.a["tenant"])
+        res = self.client.get(
+            "/api/v1/device/sqlite/administrator.sqlite",
+            **self.auth(self.a["user"]),
+        )
+        self.assertEqual(res.status_code, 403)
+
+    def test_download_rejects_an_unknown_file_name(self):
+        res = self.client.get(
+            "/api/v1/device/sqlite/system_user.sqlite",
+            **self.device_auth(self.a),
+        )
+        self.assertEqual(res.status_code, 404)
+
+    def test_download_rejects_a_traversing_file_name(self):
+        res = self.client.get(
+            "/api/v1/device/sqlite/../../mis/settings.py",
+            **self.device_auth(self.a),
+        )
+        self.assertIn(res.status_code, [400, 404])

--- a/backend/api/v1/v1_mobile/views.py
+++ b/backend/api/v1/v1_mobile/views.py
@@ -64,7 +64,9 @@ from api.v1.v1_files.serializers import (
     AttachmentsSerializer,
 )
 from api.v1.v1_profile.constants import DataAccessTypes
-from api.v1.v1_profile.models import Administration
+from api.v1.v1_profile.models import Administration, Entity, EntityData
+from api.v1.v1_users.models import Organisation
+from utils.custom_generator import generate_sqlite, sqlite_path
 from api.v1.v1_files.functions import handle_upload
 from utils.custom_helper import CustomPasscode
 from utils.default_serializers import DefaultResponseSerializer
@@ -312,25 +314,41 @@ def sync_pending_form_data(request, version):
     )
 
 
+# The device asks for a logical table name; the tenant it resolves to comes
+# from its own token, never from the URL. Mapping the name to a model rather
+# than joining it onto a path also retires the traversal that the old raw
+# os.path.join(file_name) allowed.
+MASTER_DATA_MODELS = {
+    "administrator": Administration,
+    "organisation": Organisation,
+    "entities": Entity,
+    "entity_data": EntityData,
+}
+
+
 @extend_schema(tags=["Mobile Device Form"], summary="Get SQLITE File")
 @api_view(["GET"])
+@permission_classes([IsMobileAssignment])
 def download_sqlite_file(request, version, file_name):
-    file_path = os.path.join(BASE_DIR, MASTER_DATA, f"{file_name}")
-
-    # Make sure the file exists and is accessible
-    if not os.path.exists(file_path):
-        return HttpResponse(
+    model = MASTER_DATA_MODELS.get(file_name[: -len(".sqlite")])
+    if not file_name.endswith(".sqlite") or model is None:
+        return Response(
             {"message": "File not found."}, status=status.HTTP_404_NOT_FOUND
         )
 
-    # Get the file's content type
-    content_type, _ = mimetypes.guess_type(file_path)
+    assignment = cast(MobileAssignmentToken, request.auth).assignment
+    tenant = assignment.user.tenant
+    file_path = sqlite_path(model, tenant=tenant)
+    # Generated lazily: a tenant that registered after the last run of the
+    # generate_sqlite command has no file yet, and a device asking for it is
+    # exactly the moment we know it is needed.
+    if not os.path.exists(file_path):
+        generate_sqlite(model, tenant=tenant)
 
-    # Read the file content into a variable
+    content_type, _ = mimetypes.guess_type(file_path)
     with open(file_path, "rb") as file:
         file_content = file.read()
 
-    # Create the response and set the appropriate headers
     response = HttpResponse(file_content, content_type=content_type)
     response["Content-Length"] = os.path.getsize(file_path)
     response["Content-Disposition"] = "attachment; filename=%s" % file_name
@@ -640,13 +658,16 @@ class MobileAssignmentViewSet(ModelViewSet):
 @permission_classes([IsAuthenticated])
 def get_forms_tree(request, version):
     """Returns published forms in tree structure for assignment UI."""
-    registration_forms = Forms.objects.filter(
+    # Both the outer query and the children prefetch go through for_user:
+    # scoping only the parents would still surface another tenant's
+    # monitoring forms under a same-named registration form.
+    registration_forms = Forms.objects.for_user(request.user).filter(
         parent__isnull=True,
         status=FormStatus.published
     ).prefetch_related(
         Prefetch(
             "children",
-            queryset=Forms.objects.filter(
+            queryset=Forms.objects.for_user(request.user).filter(
                 status=FormStatus.published
             ).order_by("name")
         )

--- a/backend/api/v1/v1_profile/serializers.py
+++ b/backend/api/v1/v1_profile/serializers.py
@@ -230,6 +230,7 @@ class AdministrationSerializer(TenantStampedSerializerMixin,
                 "level": instance.level.id,
                 "path": instance.path,
             },
+            tenant=instance.tenant,
         )
         administration_csv_add(data=instance)
         for attribute in attributes:
@@ -283,6 +284,7 @@ class AdministrationSerializer(TenantStampedSerializerMixin,
                 "level": instance.level.id,
                 "path": instance.path,
             },
+            tenant=instance.tenant,
             id=instance.id,
         )
         administration_csv_update(data=instance)
@@ -352,6 +354,7 @@ class EntityDataSerializer(serializers.ModelSerializer):
                 "administration": instance.administration.id,
                 "parent": instance.administration.id,
             },
+            tenant=instance.entity.tenant,
         )
         return instance
 
@@ -366,6 +369,7 @@ class EntityDataSerializer(serializers.ModelSerializer):
                 "administration": instance.administration.id,
                 "parent": instance.administration.id,
             },
+            tenant=instance.entity.tenant,
             id=instance.id,
         )
         return instance

--- a/backend/api/v1/v1_users/serializers.py
+++ b/backend/api/v1/v1_users/serializers.py
@@ -116,7 +116,8 @@ class AddEditOrganisationSerializer(TenantStampedSerializerMixin,
             data={
                 'id': instance.id,
                 'name': instance.name,
-            }
+            },
+            tenant=instance.tenant,
         )
         return instance
 
@@ -137,6 +138,7 @@ class AddEditOrganisationSerializer(TenantStampedSerializerMixin,
         update_sqlite(
             model=Organisation,
             data={'name': instance.name},
+            tenant=instance.tenant,
             id=instance.id
         )
         return instance

--- a/backend/utils/custom_generator.py
+++ b/backend/utils/custom_generator.py
@@ -10,26 +10,46 @@ from api.v1.v1_profile.models import Administration
 logger = logging.getLogger(__name__)
 
 
-def generate_sqlite(model, test: bool = False):
+# Master data is offline data: whatever lands in these files is what a
+# device holds on its own storage. One global file per table therefore
+# handed every device every tenant's hierarchy, so each tenant gets its
+# own subdirectory keyed by subdomain. tenant=None keeps the historical
+# root location for seeders and the management command.
+def sqlite_path(model, tenant=None, test: bool = False):
     if not test:
         test = settings.TEST_ENV
-    table_name = model._meta.db_table
+    directory = (
+        MASTER_DATA
+        if tenant is None
+        else "{0}/{1}".format(MASTER_DATA, tenant.subdomain)
+    )
+    return "{0}/{1}{2}.sqlite".format(
+        directory,
+        "test_" if test else "",
+        model._meta.db_table,
+    )
+
+
+def generate_sqlite(model, tenant=None, test: bool = False):
+    if not test:
+        test = settings.TEST_ENV
     field_names = [f.name for f in model._meta.fields]
     objects = model.objects.all()
-    file_name = "{0}/{1}{2}.sqlite".format(
-        MASTER_DATA,
-        "test_" if test else "",
-        table_name,
-    )
+    if tenant is not None:
+        objects = objects.filter(**{model.TENANT_PATH: tenant})
+    file_name = sqlite_path(model, tenant=tenant, test=test)
+    os.makedirs(os.path.dirname(file_name), exist_ok=True)
     if os.path.exists(file_name):
         try:
             os.remove(file_name)
         except OSError:
             pass
-    data = pd.DataFrame(list(objects.values(*field_names)))
-    no_rows = data.shape[0]
-    if no_rows < 1:
-        return
+    # columns= keeps the frame's shape when a tenant has no rows yet, so an
+    # empty tenant still gets a valid nodes table rather than no file: the
+    # device asks for entity_data.sqlite whether or not entities exist.
+    data = pd.DataFrame(
+        list(objects.values(*field_names)), columns=field_names
+    )
     # Add full_path_name for Administration model
     if model.__name__ == "Administration":
         # Get all Administration objects with their full_path_name property
@@ -66,9 +86,8 @@ def generate_sqlite(model, test: bool = False):
     raise last_err
 
 
-def update_sqlite(model, data, id=None):
+def update_sqlite(model, data, tenant=None, id=None):
     test = settings.TEST_ENV
-    table_name = model._meta.db_table
     fields = data.keys()
     field_names = ", ".join([f for f in fields])
     placeholders = ", ".join(["?" for _ in range(len(fields))])
@@ -76,11 +95,10 @@ def update_sqlite(model, data, id=None):
     params = list(data.values())
     if id:
         params += [id]
-    file_name = "{0}/{1}{2}.sqlite".format(
-        MASTER_DATA,
-        "test_" if test else "",
-        table_name,
-    )
+    file_name = sqlite_path(model, tenant=tenant, test=test)
+    # sqlite3.connect creates the file but not its parent directory, and a
+    # tenant's first row can arrive before anything generated the file.
+    os.makedirs(os.path.dirname(file_name), exist_ok=True)
     conn = sqlite3.connect(file_name, timeout=30)
     try:
         with conn:
@@ -96,7 +114,7 @@ def update_sqlite(model, data, id=None):
                     VALUES ({placeholders})"
                 c.execute(query, params)
     except sqlite3.OperationalError:
-        generate_sqlite(model=model, test=test)
+        generate_sqlite(model=model, tenant=tenant, test=test)
     finally:
         conn.close()
 

--- a/doc/design/MT-010-mobile-app-tenant-isolation.md
+++ b/doc/design/MT-010-mobile-app-tenant-isolation.md
@@ -30,7 +30,16 @@ that guarantee:
 
 Read-path isolation did not catch these: (1) is a management command plus a
 static file server, and (2) through (4) fetch by explicit id rather than
-through a scoped queryset. This iteration closes all four.
+through a scoped queryset.
+
+**Revised at implementation time.** MT-003 landed after this design was
+written and already routes both id lookups through
+`Forms.objects.for_user(assignment.user)` (`v1_mobile/views.py:143` and
+`:198`), so (2) and (3) no longer leak across tenants. What this design
+additionally proposed there — checking the form is in `assignment.forms`
+rather than merely in the same tenant — is device-to-device hardening
+inside one tenant, not a tenancy fix, so it moved out of scope. This
+iteration implements (1) and (4).
 
 The APK endpoints (`download_apk_file`, `check_apk_version`, `upload_apk_file`)
 are out of scope, since they serve the global app binary rather than tenant
@@ -64,9 +73,18 @@ data.
   means `Administration`, `Organisation` and `Entity` by `tenant`, and
   `EntityData` by `entity__tenant`.
 - Write to `MASTER_DATA/<tenant.subdomain>/<table>.sqlite`. A tenant-less
-  caller (`tenant=None`) and the test path keep writing to the current root
-  location (with the `test_` prefix), so seeders and the existing suite are
-  unchanged.
+  caller (`tenant=None`) keeps writing to the current root location, so
+  seeders and the existing suite are unchanged.
+- *Implemented:* the `test_` prefix is orthogonal to the tenant directory
+  rather than forcing the root location — a tenant file under test is
+  `MASTER_DATA/acme/test_administrator.sqlite`. Folding the test path back
+  to the root, as first written here, would have made per-tenant generation
+  untestable. `sqlite_path(model, tenant, test)` is the one place that
+  resolves this, so generation, update and download cannot disagree.
+- *Implemented:* the frame is built with `columns=field_names`, so a tenant
+  with no rows yet gets a valid empty `nodes` table instead of no file. The
+  previous `if no_rows < 1: return` meant a tenant with no entities would
+  404 on `entity_data.sqlite`, which its forms still reference.
 - The `generate_sqlite` management command loops over tenants, and still emits
   the tenant-less and test artifacts its callers expect.
 
@@ -75,10 +93,14 @@ data.
 - Resolve the same per-tenant file path and upsert the single row there. The
   Administration, Organisation and Entity serializer callers pass the
   instance's tenant.
-- The administration bulk-upload handler (a follow-through owned by the
-  bulk-upload iteration) regenerates the uploading tenant's file, passing
-  `user.tenant`. That is noted here for cross-reference, not implemented in
-  this iteration.
+- *Implemented here, not deferred.* The bulk-upload handlers
+  (`v1_jobs/job.py`, administrations and entity data) regenerate the
+  uploading tenant's file, passing `user.tenant`. This was originally
+  cross-referenced to the bulk-upload iteration, but MT-007 had already
+  merged: leaving it would have made per-tenant files go stale after every
+  bulk upload, since the handlers refreshed only the root file that devices
+  no longer read. That is a regression this iteration introduces, so this
+  iteration fixes it.
 
 ### 2. Authenticated, tenant-resolved SQLite download
 
@@ -94,22 +116,29 @@ data.
   via `generate_sqlite(model, tenant)` if absent, then streaming it.
 
 App-side note: the endpoint was public and now requires the mobile token.
-The app's request must carry it. Its api client likely attaches the token to
-all requests, but confirm this, or the download 401s.
+*Confirmed at implementation time:* it did **not** carry one.
+`cascades.download` (`app/src/lib/cascades.js`) called
+`FileSystem.downloadAsync` with `{cache: false}` and no headers, bypassing
+the axios client entirely, so the endpoint would have 401'd for every
+device. The fix passes `api.getConfig().headers` through, which covers all
+call sites at once. The three live callers (`AuthForm`, `AddUser`, `Home`)
+all set the token before downloading; the two in `Settings/AddNewForm` and
+`AuthByPassForm` call `/forms/{id}`, which has no backend route and was
+already dead.
 
-### 3. Form-details membership check
+Because of this the backend and the app must ship together.
 
-`get_mobile_form_details(form_id)`: after resolving the assignment, reject a
-`form_id` that is not in `assignment.forms` with a 404, so existence is not
-revealed, before serializing the form. This mirrors the guard
-`get_datapoint_download_list` already applies.
+### 3. Form-details membership check — dropped
 
-### 4. Sync form-in-assignment validation
+Superseded by MT-003: `get_mobile_form_details` already resolves through
+`Forms.objects.for_user(assignment.user)`, so a foreign tenant's form 404s.
+The remaining `assignment.forms` membership check is same-tenant hardening
+and is tracked separately.
 
-`sync_pending_form_data`: validate that the submitted `formId` is in
-`assignment.forms` before building and saving the submission, returning 404 on
-a non-member form. This blocks a device submitting data against another
-tenant's form.
+### 4. Sync form-in-assignment validation — dropped
+
+Same as above: `sync_pending_form_data` already scopes its `formId` lookup
+by `for_user`, so a device cannot submit into another tenant's form.
 
 ### 5. Forms-tree scoping
 
@@ -122,8 +151,6 @@ assignment-builder UI shows only the caller's tenant's published forms.
 - SQLite download: a missing file is generated then served; an unknown or
   whitelist-failing filename returns 404; a missing or invalid mobile token
   returns 401. A tenant with no data yet yields an empty but valid file.
-- Form-details and sync: a form not in the assignment returns 404, revealing
-  nothing about other tenants' forms.
 - Forms-tree: out-of-tenant forms are simply absent from the result.
 - Tenant-less and test paths: all generation degrades to the current
   root-location behavior for `tenant=None`, so no seeder or test fixture
@@ -137,15 +164,27 @@ assignment-builder UI shows only the caller's tenant's published forms.
   artifacts.
 - SQLite download: a device downloads only its tenant's file; a missing
   file is generated on first request; an unknown or `..` filename is rejected;
-  an unauthenticated request returns 401.
-- Form-details: a device gets details for a form in its assignment; a
-  form_id outside the assignment returns 404.
-- Sync: a submission against an in-assignment form succeeds; one against an
-  out-of-assignment form returns 404 and nothing is written.
+  an unauthenticated request returns 401 and a web JWT 403.
+- Serializer routing: creating an administration writes the new row into its
+  own tenant's file, not the root one.
 - Forms-tree: the tree shows only the caller's tenant's published forms, and
   a second tenant's forms never appear.
 - Regression: the full backend suite passes, since tenant-less generation and
   assignment-scoped fixtures are unchanged.
+
+*Implemented:* `api/v1/v1_mobile/tests/tests_sqlite_tenant_isolation.py`
+(14 tests) and `tests_forms_tree_tenant_isolation.py` (2). The pre-existing
+`tests_sqlite_generation.test_sqlite_file_endpoint` asserted the endpoint
+was reachable anonymously — it encoded the bug, so it now authenticates as
+a device, with a sibling test pinning the 401.
+
+The app-side assertion (`cascades.download` sends the token) is written in
+`app/src/lib/__test__/cascades.test.js` but **could not be executed**: the
+mobile jest environment is broken in this repo independently of this work —
+`jest.config.js` omits `ts`/`tsx` from `moduleFileExtensions`, so
+`jest-expo`'s preset cannot resolve `expo-modules-core/src/Refs`, and every
+suite fails to load. Adding the extensions gets past that but then 63 of 69
+suites fail on missing native modules. Worth its own issue.
 
 ## Out of scope
 
@@ -155,3 +194,9 @@ assignment-builder UI shows only the caller's tenant's published forms.
 - The mobile sync and cascade wire format.
 - Subdomain routing. This iteration keys off the mobile token's tenant rather
   than the host, and does not depend on it.
+- The global passcode namespace. `MobileAssignment.objects.get(passcode=...)`
+  (`v1_mobile/views.py:118`) is unscoped, and passcodes are 8 lowercase
+  letters from `random` (not `secrets`) with no unique constraint. Across
+  tenants that means a guessed passcode enrolls a device into whichever
+  tenant owns it, and two tenants can collide into a 500. Tracked separately.
+- Repairing the mobile jest environment (see Testing).


### PR DESCRIPTION
Closes #276. MT-010 of the multi-tenant SaaS epic. Design: `doc/design/MT-010-mobile-app-tenant-isolation.md`.

## The leak

`generate_sqlite` dumped `model.objects.all()` into one global file per table, and `download_sqlite_file` served those with **no permission class** (DRF default `AllowAny`) via a raw `os.path.join` on a user-supplied filename. Anyone on the internet, with no token, could download every tenant's administrative hierarchy, organisations and entity data — and traverse out of the directory while doing it.

Read-path isolation (MT-003) didn't catch it because this is a management command plus a static file server, not a queryset.

## What changed

**Per-tenant generation.** Files now live at `MASTER_DATA/<subdomain>/<table>.sqlite`, each dump scoped by the model's `TENANT_PATH`. `sqlite_path(model, tenant, test)` is the single resolver, so generation, update and download can't disagree. `tenant=None` keeps the historical root location, so seeders and single-tenant installs are unchanged.

**Authenticated, tenant-resolved download.** `download_sqlite_file` requires `IsMobileAssignment` and resolves the tenant from `request.auth.assignment.user.tenant` — never from the URL. The requested name is matched against a logical-table whitelist and mapped to a model, which retires the path traversal entirely. A missing file is generated on first request, so a tenant that registered after the last command run never 404s.

**Empty tenants.** The frame is built with `columns=field_names`, so a tenant with no rows yet gets a valid empty `nodes` table rather than no file. The previous `if no_rows < 1: return` would have 404'd `entity_data.sqlite` for any tenant without entities — whose forms still reference it.

**Write path.** `update_sqlite` and its three serializer callers (Administration, Organisation, EntityData) route to the owning tenant's file.

**Forms tree.** `get_forms_tree` scopes through `for_user` on both the outer query and the children prefetch — scoping only parents would still surface another tenant's monitoring forms.

**App.** `cascades.download` called `FileSystem.downloadAsync` with no headers, bypassing the axios client, so it would have 401'd every device. It now passes `api.getConfig().headers`, which covers all call sites at once.

## Two deviations from the design

**Items 2 and 3 are dropped.** MT-003 landed after the design was written and already routes `get_mobile_form_details` and `sync_pending_form_data` through `Forms.objects.for_user(assignment.user)`. What the design additionally proposed — checking the form is in `assignment.forms` rather than merely the same tenant — is device-to-device hardening inside one tenant, not a tenancy fix. The doc records this.

**A regression caught and fixed here, not deferred.** The design cross-referenced the bulk-upload sqlite refresh to "the bulk-upload iteration", but MT-007 had already merged, so nobody owned it. Left alone, the handlers would keep refreshing the root file while devices read per-tenant ones — stale forever after every upload. Both handlers in `v1_jobs/job.py` now pass `user.tenant`, with a test that runs the real handler and asserts the uploaded row lands in the tenant's file.

## Rollout — please read before merging to main

**Backend and app must ship together.** `Home.js` `handleOnSync` calls `cascades.dropFiles()` and then re-downloads with `update=true`. An older app build has no auth header, so a user tapping sync after this deploys will wipe their cascades, receive a 401, and — since `FileSystem.downloadAsync` doesn't throw on non-2xx — end up with the error body written where a database should be. Cascade questions break until they update.

Safe orders: app first, or both together with a forced update. Backend-first is not safe. Worth confirming `check_apk_version` can force rather than suggest, since APP-254's dialog is dismissible.

The epic branch isn't deployed, so merging here is fine — this is a blocker for epic → main.

## Verification

- Full backend suite: **1580 tests, OK**. flake8 clean. App ESLint clean.
- 18 new tests: `tests_sqlite_tenant_isolation.py` (16) and `tests_forms_tree_tenant_isolation.py` (2), covering generation scoping for all four models, download auth (401 anonymous, 403 web JWT), whitelist and traversal rejection, lazy generation, empty tenants, serializer routing, and the per-tenant command.
- Every security assertion was sabotage-checked: breaking the tenant filter and removing the permission class makes them fail with the right messages (`'beta' unexpectedly found in ['acme', 'acme-d', 'beta', 'beta-d']`), including the `entity__tenant` join case.
- `tests_sqlite_generation.test_sqlite_file_endpoint` asserted the endpoint was reachable anonymously — it encoded the bug, so it now authenticates as a device, with a sibling test pinning the 401.

**Not verified:** the app-side assertion in `cascades.test.js` is written but has never run. The mobile jest environment is broken repo-wide and unrelated to this change — `jest.config.js` omits `ts`/`tsx` from `moduleFileExtensions`, so jest-expo's preset can't resolve `expo-modules-core/src/Refs` and every suite fails to load. Adding the extensions gets past that, then 63 of 69 suites fail on missing native modules. The change is two lines and all five call sites were traced by hand, but it is not test-verified.

## Follow-ups worth filing

1. **Global passcode namespace.** `MobileAssignment.objects.get(passcode=...)` (`v1_mobile/views.py:118`) is unscoped, and passcodes are 8 lowercase letters from `random` (not `secrets`) with no unique constraint. Across tenants a guessed passcode enrolls a device into whichever tenant owns it, and two tenants can collide into a 500. Fixable without touching onboarding: `secrets`, a unique constraint, and rate-limiting `/auth`.
2. **Mobile jest environment** — the whole app suite is unrunnable.
3. **CLAUDE.md** says `./dc-mobile.sh exec mobile`; the service is `mobileapp`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1216901353714114