### PR TITLE
[#292] Exempt the health check from host-based tenant routing

### DIFF
--- a/backend/api/v1/v1_users/tests/tests_tenant_middleware.py
+++ b/backend/api/v1/v1_users/tests/tests_tenant_middleware.py
@@ -78,6 +78,51 @@ class TenantMiddlewareTestCase(TestCase, TenantTestHelperMixin):
         self.assertEqual(response.status_code, 401)
 
 
+@override_settings(BASE_DOMAIN="app.com")
+class HealthCheckHostTestCase(TestCase, TenantTestHelperMixin):
+    """Infrastructure reaches the pod directly, with no workspace host.
+
+    A kubelet probe connects to the pod IP, so the request arrives with
+    `Host: <pod-ip>:8000` — neither the base domain nor a workspace. The
+    404 that is right for a typo'd subdomain is wrong here: it fails the
+    readiness probe, which holds the rollout, so enabling BASE_DOMAIN
+    would make every deploy time out.
+    """
+
+    HEALTH = "/api/v1/health/check"
+
+    def setUp(self):
+        self.acme = self.create_tenant(
+            "acme", ["Country", "Province"], "Kenya"
+        )
+
+    def test_a_pod_ip_host_can_reach_the_health_check(self):
+        response = self.client.get(self.HEALTH, HTTP_HOST="10.4.2.15:8000")
+        self.assertEqual(response.status_code, 200)
+
+    def test_a_cluster_dns_host_can_reach_the_health_check(self):
+        # Service-to-service inside the cluster, and `kubectl
+        # port-forward` during an incident, look the same way.
+        response = self.client.get(
+            self.HEALTH, HTTP_HOST="backend-service.akvo-mis-namespace.svc"
+        )
+        self.assertEqual(response.status_code, 200)
+
+    def test_the_base_domain_still_reaches_the_health_check(self):
+        response = self.client.get(self.HEALTH, HTTP_HOST="app.com")
+        self.assertEqual(response.status_code, 200)
+
+    def test_a_workspace_host_still_reaches_the_health_check(self):
+        response = self.client.get(self.HEALTH, HTTP_HOST="acme.app.com")
+        self.assertEqual(response.status_code, 200)
+
+    def test_the_exemption_does_not_leak_to_other_paths(self):
+        # Only liveness is exempt. An unrecognised host reaching anything
+        # else is still nothing this deployment serves.
+        response = self.client.get(PROFILE, HTTP_HOST="10.4.2.15:8000")
+        self.assertEqual(response.status_code, 404)
+
+
 class SingleHostTestCase(TestCase, TenantTestHelperMixin):
     """With BASE_DOMAIN unset the middleware must do nothing at all.
 

--- a/backend/middleware/tenant.py
+++ b/backend/middleware/tenant.py
@@ -21,6 +21,20 @@ from rest_framework_simplejwt.authentication import JWTAuthentication
 
 from utils.tenant_host import is_base_domain, resolve_tenant_from_host
 
+# Infrastructure reaches the pod directly — a kubelet probe connects to the
+# pod IP, so the request carries `Host: <pod-ip>:8000`, which names no
+# workspace. The 404 that is right for a typo'd subdomain is wrong here: it
+# fails the readiness probe, which holds the rollout, so setting
+# BASE_DOMAIN would make every deploy time out. Cluster DNS and
+# `kubectl port-forward` arrive the same way.
+#
+# This is one path, not the start of an exemption list. The distinction the
+# class docstring draws — public *API* endpoints are exempted by being
+# anonymous, never by being listed — still holds. Liveness is not an API
+# endpoint; it answers "is this process up", it has no tenant by
+# construction, and it will not grow siblings.
+HEALTH_CHECK_PATH = "/api/v1/health/check"
+
 
 class TenantMiddleware:
     def __init__(self, get_response):
@@ -30,6 +44,12 @@ class TenantMiddleware:
     def __call__(self, request):
         host = request.get_host()
         request.tenant = resolve_tenant_from_host(host)
+
+        # Resolved first, so a probe arriving on a real workspace host
+        # still reports that tenant, then exempted from both the 404 and
+        # enforcement below.
+        if request.path.startswith(HEALTH_CHECK_PATH):
+            return self.get_response(request)
 
         # A host that is neither the signup domain nor a workspace names
         # nothing this deployment serves. Answering 404 before the view


### PR DESCRIPTION
Part of #292 — the application-side half, which is a prerequisite for any of the infra work being testable.

## Problem

A kubelet probe connects to the pod IP, so the request arrives with `Host: <pod-ip>:8000`. That is neither the base domain nor a `<sub>.BASE_DOMAIN`, so `TenantMiddleware` returned 404 **before the view ran** — including for `/api/v1/health/check`, which had no exemption.

`ci/deploy.sh` blocks on `kubectl rollout status deployment/backend-deployment --timeout=5m`, and its own comment notes the readiness probe holds the rollout until health returns 200. So the moment `BASE_DOMAIN` is set in the cluster, **every deploy would time out** — on a 404 that looks like an ingress/routing problem rather than a probe one.

Same failure reaches anything else that talks to the backend without a workspace host: GCLB health checks, cluster DNS service-to-service calls, `kubectl port-forward` during an incident, metrics scrapes.

## Fix

`request.tenant` is resolved first, so a probe arriving on a real workspace host still reports that tenant, and the health path then skips both the 404 and the enforcement branch.

## Why app-side rather than probe `httpHeaders`

Setting `Host` on the probe manifest fixes exactly one caller and leaves the rest as landmines that surface one at a time. The 404 is produced by application code deciding "no recognisable host means no service", so the app is where the liveness carve-out belongs — and here it is an assertion in the suite rather than something only verifiable by deploying.

This is deliberately one path, not the start of an exemption list. The middleware's docstring rejects such a list because whoever adds the next public path would have to remember to edit it — but that reasoning is about public *API* endpoints, which stay exempt by being anonymous. Liveness is a different category: it has no tenant by construction and will not grow siblings.

## Verification

Full backend suite **1585 tests, OK**; flake8 clean. Five new tests in `HealthCheckHostTestCase`, all under `override_settings(BASE_DOMAIN="app.com")`:

- pod IP host reaches health → 200 (failed 404 before the fix)
- cluster DNS host reaches health → 200 (failed 404 before the fix)
- base domain and workspace hosts still reach health → 200
- the exemption does not leak: `/api/v1/profile` from a pod IP host is still 404

The two infrastructure-host tests were watched failing with `AssertionError: 404 != 200` before the middleware change.

Also confirmed while investigating #292, and noted there: `frontend/nginx/conf.d/default.conf` already sets `proxy_set_header Host $host` on every `/api`, `/config.js` and `/static-files` route, so the browser's Host already reaches Django through the frontend pod. Only the cluster ingress still needs verifying.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
