### PR TITLE
[#295] Post MT-002: Enforce tenant-aware invite policy and fix cross-tenant restore leak

### DIFF
--- a/backend/api/v1/v1_mobile/tests/tests_upload_image_from_device.py
+++ b/backend/api/v1/v1_mobile/tests/tests_upload_image_from_device.py
@@ -11,29 +11,29 @@ from utils import storage
 
 
 def generate_file(filename: str):
-    f = open(filename, 'a')
-    f.write('This is a test file!')
+    f = open(filename, "a")
+    f.write("This is a test file!")
     f.close()
     return filename
 
 
 class MobileAssignmentUploadImages(TestCase, AssignmentTokenTestHelperMixin):
     def setUp(self):
-        call_command('administration_seeder', '--test')
-        call_command('form_seeder', '--test')
+        call_command("administration_seeder", "--test")
+        call_command("form_seeder", "--test")
         self.user = SystemUser.objects.create_user(
-            email='test@test.org',
-            password='test1234',
-            first_name='test',
-            last_name='testing',
+            email="test@test.org",
+            password="test1234",
+            first_name="test",
+            last_name="testing",
         )
         self.administration = Administration.objects.filter(
             parent__isnull=True
         ).first()
         self.form = Forms.objects.first()
-        self.passcode = 'passcode1234'
+        self.passcode = "passcode1234"
         MobileAssignment.objects.create_assignment(
-            user=self.user, name='test', passcode=self.passcode
+            user=self.user, name="test", passcode=self.passcode
         )
         self.mobile_assignment = MobileAssignment.objects.get(user=self.user)
         self.mobile_assignment.forms.add(self.form)
@@ -43,37 +43,37 @@ class MobileAssignmentUploadImages(TestCase, AssignmentTokenTestHelperMixin):
         self.mobile_assignment.administrations.add(
             *self.administration_children
         )
-        self.filename = generate_file(filename='test_image.jpg')
+        self.filename = generate_file(filename="test_image.jpg")
 
-    # Delete Images after all finish
     def tearDown(self):
-        os.remove(self.filename)
+        if hasattr(self, "filename") and os.path.exists(self.filename):
+            os.remove(self.filename)
 
     def test_upload_image(self):
         token = self.get_assignment_token(self.passcode)
 
         response = self.client.post(
-            '/api/v1/device/images',
-            {'file': open(self.filename, 'rb')},
-            HTTP_AUTHORIZATION=f'Bearer {token}',
+            "/api/v1/device/images",
+            {"file": open(self.filename, "rb")},
+            HTTP_AUTHORIZATION=f"Bearer {token}",
         )
         self.assertEqual(response.status_code, 200)
-        self.assertEqual(list(response.json()), ['message', 'file'])
-        uploaded_filename = response.json().get('file')
-        uploaded_filename = uploaded_filename.split('/')[-1]
+        self.assertEqual(list(response.json()), ["message", "file"])
+        uploaded_filename = response.json().get("file")
+        uploaded_filename = uploaded_filename.split("/")[-1]
         self.assertTrue(
             storage.check(f"/images/{uploaded_filename}"),
-            'File exists',
+            "File exists",
         )
-        os.remove(f'{STORAGE_PATH}/images/{uploaded_filename}')
+        os.remove(f"{STORAGE_PATH}/images/{uploaded_filename}")
 
     def test_upload_image_without_credentials(self):
         response = self.client.post(
-            '/api/v1/device/images',
-            {'file': open(self.filename, 'rb')},
+            "/api/v1/device/images",
+            {"file": open(self.filename, "rb")},
         )
         self.assertEqual(response.status_code, 401)
         self.assertEqual(
-            response.json().get('detail'),
-            'Authentication credentials were not provided.',
+            response.json().get("detail"),
+            "Authentication credentials were not provided.",
         )

--- a/backend/api/v1/v1_users/serializers.py
+++ b/backend/api/v1/v1_users/serializers.py
@@ -40,17 +40,17 @@ from utils.custom_serializer_fields import (
 from api.v1.v1_profile.constants import FeatureAccessTypes
 from utils.custom_helper import CustomPasscode
 from utils.custom_generator import update_sqlite
-from utils.tenant_scoped_model import TenantStampedSerializerMixin
+from utils.tenant_scoped_model import TenantStampedSerializerMixin, acting_user
 
 
 class OrganisationSerializer(serializers.ModelSerializer):
     class Meta:
         model = Organisation
-        fields = ['id', 'name']
+        fields = ["id", "name"]
 
 
 class OrganisationAttributeSerializer(serializers.ModelSerializer):
-    type_id = serializers.ReadOnlyField(source='type')
+    type_id = serializers.ReadOnlyField(source="type")
     name = serializers.SerializerMethodField()
 
     @extend_schema_field(OpenApiTypes.STR)
@@ -59,11 +59,11 @@ class OrganisationAttributeSerializer(serializers.ModelSerializer):
 
     class Meta:
         model = OrganisationAttribute
-        fields = ['type_id', 'name']
+        fields = ["type_id", "name"]
 
 
 class OrganisationAttributeChildrenSerializer(serializers.ModelSerializer):
-    type_id = serializers.ReadOnlyField(source='type')
+    type_id = serializers.ReadOnlyField(source="type")
     name = serializers.SerializerMethodField()
     children = serializers.SerializerMethodField()
 
@@ -80,12 +80,12 @@ class OrganisationAttributeChildrenSerializer(serializers.ModelSerializer):
 
     class Meta:
         model = OrganisationAttribute
-        fields = ['type_id', 'name', 'children']
+        fields = ["type_id", "name", "children"]
 
 
 class OrganisationListSerializer(serializers.ModelSerializer):
     attributes = serializers.SerializerMethodField()
-    users = serializers.IntegerField(source='user_count')
+    users = serializers.IntegerField(source="user_count")
 
     @extend_schema_field(OrganisationAttributeSerializer(many=True))
     def get_attributes(self, instance: Organisation):
@@ -95,57 +95,63 @@ class OrganisationListSerializer(serializers.ModelSerializer):
 
     class Meta:
         model = Organisation
-        fields = ['id', 'name', 'attributes', 'users']
+        fields = ["id", "name", "attributes", "users"]
 
 
-class AddEditOrganisationSerializer(TenantStampedSerializerMixin,
-                                    serializers.ModelSerializer):
-    attributes = CustomMultipleChoiceField(choices=list(
-        OrganisationTypes.FieldStr.keys()),
-                                           required=True)
+class AddEditOrganisationSerializer(
+    TenantStampedSerializerMixin, serializers.ModelSerializer
+):
+    attributes = CustomMultipleChoiceField(
+        choices=list(OrganisationTypes.FieldStr.keys()), required=True
+    )
 
     def create(self, validated_data):
-        attributes = validated_data.pop('attributes')
-        instance = super(AddEditOrganisationSerializer,
-                         self).create(validated_data)
+        attributes = validated_data.pop("attributes")
+        instance = super(AddEditOrganisationSerializer, self).create(
+            validated_data
+        )
         for attr in attributes:
-            OrganisationAttribute.objects.create(organisation=instance,
-                                                 type=attr)
+            OrganisationAttribute.objects.create(
+                organisation=instance, type=attr
+            )
         update_sqlite(
             model=Organisation,
             data={
-                'id': instance.id,
-                'name': instance.name,
+                "id": instance.id,
+                "name": instance.name,
             },
             tenant=instance.tenant,
         )
         return instance
 
     def update(self, instance, validated_data):
-        attributes = validated_data.pop('attributes')
-        instance: Organisation = super(AddEditOrganisationSerializer,
-                                       self).update(instance, validated_data)
+        attributes = validated_data.pop("attributes")
+        instance: Organisation = super(
+            AddEditOrganisationSerializer, self
+        ).update(instance, validated_data)
         instance.save()
         current_attributes = OrganisationAttribute.objects.filter(
-            organisation=instance).all()
+            organisation=instance
+        ).all()
         for attr in current_attributes:
             if attr.type not in attributes:
                 attr.delete()
         for attr in attributes:
             attr, created = OrganisationAttribute.objects.get_or_create(
-                organisation=instance, type=attr)
+                organisation=instance, type=attr
+            )
             attr.save()
         update_sqlite(
             model=Organisation,
-            data={'name': instance.name},
+            data={"name": instance.name},
             tenant=instance.tenant,
-            id=instance.id
+            id=instance.id,
         )
         return instance
 
     class Meta:
         model = Organisation
-        fields = ['name', 'attributes']
+        fields = ["name", "attributes"]
 
 
 class LoginSerializer(serializers.Serializer):
@@ -160,7 +166,7 @@ class ForgotPasswordSerializer(serializers.Serializer):
         try:
             user = SystemUser.objects.get(email=email, deleted_at=None)
         except SystemUser.DoesNotExist:
-            raise ValidationError('Invalid email, user not found')
+            raise ValidationError("Invalid email, user not found")
         return user
 
 
@@ -172,9 +178,9 @@ class VerifyInviteSerializer(serializers.Serializer):
             pk = signing.loads(invite)
             user = SystemUser.objects.get(pk=pk)
         except BadSignature:
-            raise ValidationError('Invalid invite code')
+            raise ValidationError("Invalid invite code")
         except SystemUser.DoesNotExist:
-            raise ValidationError('Invalid invite code')
+            raise ValidationError("Invalid invite code")
         return user
 
 
@@ -188,18 +194,19 @@ class SetUserPasswordSerializer(serializers.Serializer):
             pk = signing.loads(invite)
             user = SystemUser.objects.get(pk=pk, deleted_at=None)
         except BadSignature:
-            raise ValidationError('Invalid invite code')
+            raise ValidationError("Invalid invite code")
         except SystemUser.DoesNotExist:
-            raise ValidationError('Invalid invite code')
+            raise ValidationError("Invalid invite code")
         return user
 
     def validate(self, attrs):
-        if attrs.get('password') != attrs.get('confirm_password'):
-            raise ValidationError({
-                'confirm_password':
-                'Confirm password and password'
-                ' are not same'
-            })
+        if attrs.get("password") != attrs.get("confirm_password"):
+            raise ValidationError(
+                {
+                    "confirm_password": "Confirm password and password"
+                    " are not same"
+                }
+            )
         return attrs
 
 
@@ -212,37 +219,40 @@ class ListAdministrationChildrenSerializer(serializers.ModelSerializer):
 
     class Meta:
         model = Administration
-        fields = ['id', 'parent', 'path', 'level', 'name', 'full_name']
+        fields = ["id", "parent", "path", "level", "name", "full_name"]
 
 
 class ListAdministrationSerializer(serializers.ModelSerializer):
     full_name = serializers.SerializerMethodField()
     children = serializers.SerializerMethodField()
-    level_name = serializers.ReadOnlyField(source='level.name')
-    level = serializers.ReadOnlyField(source='level.level')
+    level_name = serializers.ReadOnlyField(source="level.name")
+    level = serializers.ReadOnlyField(source="level.level")
     children_level_name = serializers.SerializerMethodField()
 
     @extend_schema_field(ListAdministrationChildrenSerializer(many=True))
     def get_children(self, instance: Administration):
-        max_level = self.context.get('max_level')
-        filter_children = self.context.get('filter_children')
+        max_level = self.context.get("max_level")
+        filter_children = self.context.get("filter_children")
         if max_level:
             if int(max_level) <= instance.level.level:
                 return []
-        filter = self.context.get('filter')
+        filter = self.context.get("filter")
         if filter:
-            filtered_administration = Administration.objects.filter(
-                id=filter).all().order_by('name')
+            filtered_administration = (
+                Administration.objects.filter(id=filter).all().order_by("name")
+            )
             return ListAdministrationChildrenSerializer(
-                filtered_administration, many=True).data
-        children = instance.parent_administration.all().order_by('name')
+                filtered_administration, many=True
+            ).data
+        children = instance.parent_administration.all().order_by("name")
         if len(filter_children):
-            children = instance.parent_administration.filter(
-                pk__in=filter_children
-            ).all().order_by('name')
+            children = (
+                instance.parent_administration.filter(pk__in=filter_children)
+                .all()
+                .order_by("name")
+            )
         return ListAdministrationChildrenSerializer(
-            instance=children,
-            many=True
+            instance=children, many=True
         ).data
 
     @extend_schema_field(OpenApiTypes.STR)
@@ -259,9 +269,15 @@ class ListAdministrationSerializer(serializers.ModelSerializer):
     class Meta:
         model = Administration
         fields = [
-            'id', 'full_name', 'path', 'parent', 'name',
-            'level_name', 'level', 'children',
-            'children_level_name'
+            "id",
+            "full_name",
+            "path",
+            "parent",
+            "name",
+            "level_name",
+            "level",
+            "children",
+            "children_level_name",
         ]
 
 
@@ -269,30 +285,28 @@ class AddRolesSerializer(serializers.Serializer):
     role = TenantScopedPrimaryKeyRelatedField(
         queryset=Role.objects.none(),
         required=True,
-        help_text='Role to assign to user'
+        help_text="Role to assign to user",
     )
     administration = TenantScopedPrimaryKeyRelatedField(
         queryset=Administration.objects.none(),
         required=True,
-        help_text='Administration to assign role to user'
+        help_text="Administration to assign role to user",
     )
 
     def validate_administration(self, administration):
-        user = self.context.get('user')
+        user = self.context.get("user")
         if user.is_superuser:
             return administration
         if not user:
             raise ValidationError(
-                'User context is required for role validation'
+                "User context is required for role validation"
             )
         invite_u = FeatureAccessTypes.invite_user
         user_role = user.user_user_role.filter(
             role__role_role_feature_access__access=invite_u,
         ).first()
         if not user_role:
-            raise ValidationError(
-                'You do not have permission to assign roles'
-            )
+            raise ValidationError("You do not have permission to assign roles")
         user_adm_level = user_role.administration.level.level
         if user_adm_level > administration.level.level:
             raise ValidationError(
@@ -305,15 +319,16 @@ class AddRolesSerializer(serializers.Serializer):
             for ur in user.user_user_role.all()
         ]
         invalid_children = (
-            administration.level.level > user_adm_level and
-            not any(
+            administration.level.level > user_adm_level
+            and not any(
                 administration.path.startswith(path) for path in user_adm_paths
             )
         )
         invalid_adm = (
-            administration.level.level == user_adm_level and
-            administration.id not in user.user_user_role.values_list(
-                'administration__id', flat=True
+            administration.level.level == user_adm_level
+            and administration.id
+            not in user.user_user_role.values_list(
+                "administration__id", flat=True
             )
         )
         if invalid_children or invalid_adm:
@@ -324,21 +339,19 @@ class AddRolesSerializer(serializers.Serializer):
         return administration
 
     def validate_role(self, role):
-        user = self.context.get('user')
+        user = self.context.get("user")
         if user.is_superuser:
             return role
         if not user:
             raise ValidationError(
-                'User context is required for role validation'
+                "User context is required for role validation"
             )
         invite_u = FeatureAccessTypes.invite_user
         user_role = user.user_user_role.filter(
             role__role_role_feature_access__access=invite_u,
         ).first()
         if not user_role:
-            raise ValidationError(
-                'You do not have permission to assign roles'
-            )
+            raise ValidationError("You do not have permission to assign roles")
         user_adm_level = user_role.administration.level.level
         if user_adm_level > role.administration_level.level:
             raise ValidationError(
@@ -348,29 +361,29 @@ class AddRolesSerializer(serializers.Serializer):
         return role
 
     def validate(self, attrs):
-        role = attrs.get('role')
-        administration = attrs.get('administration')
+        role = attrs.get("role")
+        administration = attrs.get("administration")
         # check adm level mismatch between role and administration
         if role.administration_level.level != administration.level.level:
-            raise ValidationError(
-                "Role and administration level mismatch"
-            )
+            raise ValidationError("Role and administration level mismatch")
         return attrs
 
     def __init__(self, **kwargs):
         super().__init__(**kwargs)
-        self.fields.get('role').queryset = Role.objects.all()
-        admin_field = self.fields.get('administration')
+        self.fields.get("role").queryset = Role.objects.all()
+        admin_field = self.fields.get("administration")
         admin_field.queryset = Administration.objects.all()
 
     class Meta:
-        fields = ['role', 'administration']
+        fields = ["role", "administration"]
 
 
-class AddEditUserSerializer(TenantStampedSerializerMixin,
-                            serializers.ModelSerializer):
+class AddEditUserSerializer(
+    TenantStampedSerializerMixin, serializers.ModelSerializer
+):
     organisation = TenantScopedPrimaryKeyRelatedField(
-        queryset=Organisation.objects.none(), required=False)
+        queryset=Organisation.objects.none(), required=False
+    )
     trained = CustomBooleanField(default=False)
     roles = AddRolesSerializer(many=True, required=False)
     forms = CustomPrimaryKeyRelatedField(
@@ -384,68 +397,90 @@ class AddEditUserSerializer(TenantStampedSerializerMixin,
     is_superuser = CustomBooleanField(
         default=False,
         required=False,
-        help_text='Set user as superuser. Superuser can access all data.'
+        help_text="Set user as superuser. Superuser can access all data.",
     )
 
     def __init__(self, **kwargs):
         super().__init__(**kwargs)
-        self.fields.get('organisation').queryset = Organisation.objects.all()
+        self.fields.get("organisation").queryset = Organisation.objects.all()
 
     def validate_roles(self, roles):
         return AddRolesSerializer(
             data=roles, many=True, context=self.context
         ).is_valid(raise_exception=True)
 
-    def create(self, validated_data):
-        try:
-            user_deleted = SystemUser.objects_deleted.get(
-                email=validated_data['email']
+    def validate_email(self, value):
+        acting = acting_user(self.context)
+        existing = SystemUser.objects_with_deleted.filter(email=value).first()
+
+        if existing is None:
+            return value
+
+        if self.instance and self.instance.pk == existing.pk:
+            return value
+
+        if existing.tenant_id == getattr(acting, "tenant_id", None):
+            if existing.deleted_at is not None:
+                return value
+            raise serializers.ValidationError(
+                "This email is already in your workspace. "
+                "To make changes, edit the existing user."
             )
-            if user_deleted:
-                user_deleted.restore()
-                self.update(
-                    instance=user_deleted,
-                    validated_data=validated_data
+
+        raise serializers.ValidationError(
+            "This email address is already registered to another workspace. "
+            "An account can only belong to one workspace — ask them to use "
+            "a different address, or contact support."
+        )
+
+    def create(self, validated_data):
+        acting = acting_user(self.context)
+        user_deleted = (
+            SystemUser.objects_deleted.for_user(acting)
+            .filter(email=validated_data["email"])
+            .first()
+        )
+        if user_deleted:
+            user_deleted.restore()
+            self.update(instance=user_deleted, validated_data=validated_data)
+            return user_deleted
+
+        # delete inform_user payload
+        validated_data.pop("inform_user", None)
+        roles_data = validated_data.pop("roles", [])
+        forms = validated_data.pop("forms", [])
+        user = super(AddEditUserSerializer, self).create(validated_data)
+        # Assign roles to user
+        if roles_data:
+            for role_data in roles_data:
+                UserRole.objects.create(
+                    user=user,
+                    administration=role_data["administration"],
+                    role=role_data["role"],
                 )
-                return user_deleted
-        except SystemUser.DoesNotExist:
-            # delete inform_user payload
-            validated_data.pop('inform_user', None)
-            roles_data = validated_data.pop('roles', [])
-            forms = validated_data.pop('forms', [])
-            user = super(AddEditUserSerializer, self).create(validated_data)
-            # Assign roles to user
-            if roles_data:
-                for role_data in roles_data:
-                    UserRole.objects.create(
-                        user=user,
-                        administration=role_data['administration'],
-                        role=role_data['role']
-                    )
-            # add new user forms
-            for form in forms:
+        # add new user forms
+        for form in forms:
+            UserForms.objects.create(user=user, form=form)
+        # if forms is empty and is_superuser is True
+        # then assign all published forms to user
+        if not forms and user.is_superuser:
+            published_forms = Forms.objects.filter(
+                status=FormStatus.published
+            ).all()
+            for form in published_forms:
                 UserForms.objects.create(user=user, form=form)
-            # if forms is empty and is_superuser is True
-            # then assign all published forms to user
-            if not forms and user.is_superuser:
-                published_forms = Forms.objects.filter(
-                    status=FormStatus.published
-                ).all()
-                for form in published_forms:
-                    UserForms.objects.create(user=user, form=form)
-            return user
+        return user
 
     def update(self, instance, validated_data):
         # delete inform_user payload
-        validated_data.pop('inform_user', None)
+        validated_data.pop("inform_user", None)
         # pop roles request data
-        roles_data = validated_data.pop('roles', None)
+        roles_data = validated_data.pop("roles", None)
         # pop forms request data
-        forms = validated_data.pop('forms', None)
-        instance: SystemUser = super(
-            AddEditUserSerializer,
-            self
-        ).update(instance, validated_data)
+        forms = validated_data.pop("forms", None)
+        instance: SystemUser = super(AddEditUserSerializer, self).update(
+            instance, validated_data
+        )
         instance.updated = timezone.now()
         instance.save()
 
@@ -468,8 +503,8 @@ class AddEditUserSerializer(TenantStampedSerializerMixin,
             # Create a set of unique identifiers for new roles
             new_role_identifiers = {}
             for role_data in roles_data:
-                role_id = str(role_data['role'].id)
-                admin_id = str(role_data['administration'].id)
+                role_id = str(role_data["role"].id)
+                admin_id = str(role_data["administration"].id)
                 new_role_identifiers[(role_id, admin_id)] = role_data
             # Delete roles that are not in the new set
             for key, role in list(existing_role_identifiers.items()):
@@ -480,15 +515,15 @@ class AddEditUserSerializer(TenantStampedSerializerMixin,
                 if key in existing_role_identifiers:
                     # Update existing role
                     role = existing_role_identifiers[key]
-                    role.role = role_data['role']
-                    role.administration = role_data['administration']
+                    role.role = role_data["role"]
+                    role.administration = role_data["administration"]
                     role.save()
                 else:
                     # Create new role
                     UserRole.objects.create(
                         user=instance,
-                        administration=role_data['administration'],
-                        role=role_data['role']
+                        administration=role_data["administration"],
+                        role=role_data["role"],
                     )
         else:
             # If no roles provided, delete all roles
@@ -496,7 +531,7 @@ class AddEditUserSerializer(TenantStampedSerializerMixin,
         return instance
 
     def to_internal_value(self, data):
-        roles_data = data.pop('roles', None)
+        roles_data = data.pop("roles", None)
         internal_value = super().to_internal_value(data)
 
         if roles_data:
@@ -507,14 +542,14 @@ class AddEditUserSerializer(TenantStampedSerializerMixin,
             if not serializer.is_valid():
                 errors = {}
                 # Process role validation errors
-                if any('role' in item for item in serializer.errors):
+                if any("role" in item for item in serializer.errors):
                     role_errors = []
                     for i, error_item in enumerate(serializer.errors):
-                        if 'role' in error_item:
-                            for err in error_item['role']:
-                                if 'does not exist' in str(err):
+                        if "role" in error_item:
+                            for err in error_item["role"]:
+                                if "does not exist" in str(err):
                                     try:
-                                        invalid_id = str(roles_data[i]['role'])
+                                        invalid_id = str(roles_data[i]["role"])
                                         role_errors.append(
                                             f"Invalid role ID: {invalid_id}"
                                         )
@@ -523,18 +558,18 @@ class AddEditUserSerializer(TenantStampedSerializerMixin,
                                 else:
                                     role_errors.append(str(err))
                     if role_errors:
-                        errors['role'] = role_errors
+                        errors["role"] = role_errors
 
                 # Process administration validation errors
-                if any('administration' in item for item in serializer.errors):
+                if any("administration" in item for item in serializer.errors):
                     admin_errors = []
                     for i, error_item in enumerate(serializer.errors):
-                        if 'administration' in error_item:
-                            for err in error_item['administration']:
-                                if 'does not exist' in str(err):
+                        if "administration" in error_item:
+                            for err in error_item["administration"]:
+                                if "does not exist" in str(err):
                                     try:
                                         invalid_id = str(
-                                            roles_data[i]['administration']
+                                            roles_data[i]["administration"]
                                         )
                                         admin_errors.append(
                                             f"Invalid administration ID: "
@@ -547,13 +582,13 @@ class AddEditUserSerializer(TenantStampedSerializerMixin,
                                 else:
                                     admin_errors.append(str(err))
                     if admin_errors:
-                        errors['administration'] = admin_errors
+                        errors["administration"] = admin_errors
                 # Raise custom ValidationError with better error messages
                 if errors:
                     raise ValidationError(errors)
                 # Otherwise, re-raise the original errors
                 raise ValidationError(serializer.errors)
-            internal_value['roles'] = serializer.validated_data
+            internal_value["roles"] = serializer.validated_data
 
         return internal_value
 
@@ -565,25 +600,37 @@ class AddEditUserSerializer(TenantStampedSerializerMixin,
         # Convert roles to representation
         roles_data = []
         for role in user_roles:
-            roles_data.append({
-                'role': role.role.id,
-                'administration': role.administration.id
-            })
+            roles_data.append(
+                {
+                    "role": role.role.id,
+                    "administration": role.administration.id,
+                }
+            )
 
-        representation['roles'] = roles_data
+        representation["roles"] = roles_data
         return representation
 
     class Meta:
         model = SystemUser
         fields = [
-            'first_name', 'last_name', 'email',
-            'organisation', 'trained', 'roles', 'phone_number',
-            'forms', 'inform_user', 'is_superuser'
+            "first_name",
+            "last_name",
+            "email",
+            "organisation",
+            "trained",
+            "roles",
+            "phone_number",
+            "forms",
+            "inform_user",
+            "is_superuser",
         ]
+        extra_kwargs = {
+            "email": {"validators": []},
+        }
 
 
 class UserAdministrationSerializer(serializers.ModelSerializer):
-    level = serializers.ReadOnlyField(source='level.level')
+    level = serializers.ReadOnlyField(source="level.level")
     full_name = serializers.SerializerMethodField()
 
     def get_full_name(self, instance: Administration):
@@ -591,12 +638,12 @@ class UserAdministrationSerializer(serializers.ModelSerializer):
 
     class Meta:
         model = Administration
-        fields = ['id', 'name', 'level', 'level_id', 'full_name']
+        fields = ["id", "name", "level", "level_id", "full_name"]
 
 
 class UserFormSerializer(serializers.ModelSerializer):
-    id = serializers.ReadOnlyField(source='form.id')
-    name = serializers.ReadOnlyField(source='form.name')
+    id = serializers.ReadOnlyField(source="form.id")
+    name = serializers.ReadOnlyField(source="form.name")
 
     class Meta:
         model = UserForms
@@ -604,14 +651,14 @@ class UserFormSerializer(serializers.ModelSerializer):
 
 
 class UserRoleSerializer(serializers.ModelSerializer):
-    role = serializers.CharField(source='role.name')
-    administration = serializers.CharField(source='administration.full_name')
+    role = serializers.CharField(source="role.name")
+    administration = serializers.CharField(source="administration.full_name")
 
     class Meta:
         model = UserRole
         fields = [
-            'role',
-            'administration',
+            "role",
+            "administration",
         ]
 
 
@@ -640,8 +687,9 @@ class ListUserSerializer(serializers.ModelSerializer):
 
     @extend_schema_field(UserFormSerializer(many=True))
     def get_forms(self, instance: SystemUser):
-        return UserFormSerializer(instance=instance.user_form.all(),
-                                  many=True).data
+        return UserFormSerializer(
+            instance=instance.user_form.all(), many=True
+        ).data
 
     @extend_schema_field(OpenApiTypes.INT)
     def get_last_login(self, instance):
@@ -652,34 +700,46 @@ class ListUserSerializer(serializers.ModelSerializer):
     class Meta:
         model = SystemUser
         fields = [
-            'id', 'first_name', 'last_name', 'email', 'roles',
-            'organisation', 'trained', 'phone_number',
-            'invite', 'forms', 'last_login'
+            "id",
+            "first_name",
+            "last_name",
+            "email",
+            "roles",
+            "organisation",
+            "trained",
+            "phone_number",
+            "invite",
+            "forms",
+            "last_login",
         ]
 
 
 class ListUserRequestSerializer(serializers.Serializer):
     trained = CustomCharField(required=False, default=None)
     organisation = CustomPrimaryKeyRelatedField(
-        queryset=Organisation.objects.none(), required=False)
+        queryset=Organisation.objects.none(), required=False
+    )
     administration = CustomPrimaryKeyRelatedField(
-        queryset=Administration.objects.none(), required=False)
+        queryset=Administration.objects.none(), required=False
+    )
     role = CustomPrimaryKeyRelatedField(
-        queryset=Role.objects.none(), required=False)
+        queryset=Role.objects.none(), required=False
+    )
     pending = CustomBooleanField(default=False)
     descendants = CustomBooleanField(default=True)
     search = CustomCharField(required=False)
 
     def __init__(self, **kwargs):
         super().__init__(**kwargs)
-        self.fields.get(
-            'administration').queryset = Administration.objects.all()
-        self.fields.get('organisation').queryset = Organisation.objects.all()
-        self.fields.get('role').queryset = Role.objects.all()
+        self.fields.get("administration").queryset = (
+            Administration.objects.all()
+        )
+        self.fields.get("organisation").queryset = Organisation.objects.all()
+        self.fields.get("role").queryset = Role.objects.all()
 
 
 class UserRoleListSerializer(serializers.ModelSerializer):
-    role = serializers.CharField(source='role.name')
+    role = serializers.CharField(source="role.name")
     administration = serializers.SerializerMethodField()
 
     @extend_schema_field(UserAdministrationSerializer)
@@ -693,11 +753,19 @@ class UserRoleListSerializer(serializers.ModelSerializer):
     class Meta:
         model = UserRole
         fields = [
-            'id', 'role', 'administration',
-            'is_approver', 'is_submitter', 'is_editor',
-            'can_delete', 'can_invite_user', 'can_form_builder',
-            'can_form_delete', 'can_form_create', 'can_form_edit',
-            'can_form_publish',
+            "id",
+            "role",
+            "administration",
+            "is_approver",
+            "is_submitter",
+            "is_editor",
+            "can_delete",
+            "can_invite_user",
+            "can_form_builder",
+            "can_form_delete",
+            "can_form_create",
+            "can_form_edit",
+            "can_form_publish",
         ]
 
 
@@ -716,9 +784,9 @@ def tenant_is_configured(tenant):
     """
     if not tenant:
         return True
-    has_named_level_zero = Levels.objects.filter(
-        tenant=tenant, level=0
-    ).exclude(name="").exists()
+    has_named_level_zero = (
+        Levels.objects.filter(tenant=tenant, level=0).exclude(name="").exists()
+    )
     has_root = Administration.objects.filter(
         tenant=tenant, parent__isnull=True
     ).exists()
@@ -751,8 +819,8 @@ class UserSerializer(serializers.ModelSerializer):
             return UserAdministrationSerializer(instance=adm).data
         # Check if there are multiple user roles at the minimum level
         min_level = instance.user_user_role.aggregate(
-            min_level=Min('administration__level__level')
-        )['min_level']
+            min_level=Min("administration__level__level")
+        )["min_level"]
         # Count how many roles are at the minimum level
         roles_at_min_level = instance.user_user_role.filter(
             administration__level__level=min_level
@@ -762,12 +830,13 @@ class UserSerializer(serializers.ModelSerializer):
             first_role = roles_at_min_level.first()
             if first_role and first_role.administration.parent:
                 parent = first_role.administration.parent
-                return UserAdministrationSerializer(
-                    instance=parent
-                ).data
+                return UserAdministrationSerializer(instance=parent).data
         # Order UserRole by administration level and get the first one
-        user_role = UserRole.objects.filter(user=instance) \
-            .order_by('administration__level__level').first()
+        user_role = (
+            UserRole.objects.filter(user=instance)
+            .order_by("administration__level__level")
+            .first()
+        )
         if user_role:
             return UserAdministrationSerializer(
                 instance=user_role.administration
@@ -792,8 +861,9 @@ class UserSerializer(serializers.ModelSerializer):
 
     @extend_schema_field(UserFormSerializer(many=True))
     def get_forms(self, instance: SystemUser):
-        return UserFormSerializer(instance=instance.user_form.all(),
-                                  many=True).data
+        return UserFormSerializer(
+            instance=instance.user_form.all(), many=True
+        ).data
 
     @extend_schema_field(OpenApiTypes.INT)
     def get_last_login(self, instance):
@@ -803,8 +873,9 @@ class UserSerializer(serializers.ModelSerializer):
 
     @extend_schema_field(OpenApiTypes.STR)
     def get_passcode(self, instance: SystemUser):
-        mobile_assignment = MobileAssignment \
-            .objects.filter(user=instance).first()
+        mobile_assignment = MobileAssignment.objects.filter(
+            user=instance
+        ).first()
         if mobile_assignment:
             passcode = CustomPasscode().decode(mobile_assignment.passcode)
             return passcode
@@ -827,35 +898,45 @@ class UserSerializer(serializers.ModelSerializer):
     class Meta:
         model = SystemUser
         fields = [
-            'email', 'name', 'roles', 'trained',
-            'phone_number', 'forms', 'organisation',
-            'last_login', 'passcode', 'is_superuser',
-            'administration', 'id', 'configured', 'subdomain',
+            "email",
+            "name",
+            "roles",
+            "trained",
+            "phone_number",
+            "forms",
+            "organisation",
+            "last_login",
+            "passcode",
+            "is_superuser",
+            "administration",
+            "id",
+            "configured",
+            "subdomain",
         ]
 
 
 class ListLevelSerializer(serializers.ModelSerializer):
     class Meta:
         model = Levels
-        fields = ['id', 'name', 'level']
+        fields = ["id", "name", "level"]
 
 
 class UserRoleEditSerializer(serializers.ModelSerializer):
-    role = serializers.IntegerField(source='role.id')
+    role = serializers.IntegerField(source="role.id")
     adm_path = serializers.SerializerMethodField()
 
     @extend_schema_field(OpenApiTypes.ANY)
     def get_adm_path(self, instance: UserRole):
         if instance.administration.path:
             adm = instance.administration
-            return [
-                int(p) for p in adm.path.split('.') if p.isdigit()
-            ] + [adm.id]
+            return [int(p) for p in adm.path.split(".") if p.isdigit()] + [
+                adm.id
+            ]
         return [instance.administration.id]
 
     class Meta:
         model = UserRole
-        fields = ['role', 'administration', 'adm_path']
+        fields = ["role", "administration", "adm_path"]
 
 
 class UserDetailSerializer(serializers.ModelSerializer):
@@ -869,11 +950,11 @@ class UserDetailSerializer(serializers.ModelSerializer):
 
     @extend_schema_field(UserRoleEditSerializer(many=True))
     def get_roles(self, instance: SystemUser):
-        user = self.context.get('user')
+        user = self.context.get("user")
         return UserRoleEditSerializer(
             instance=instance.user_user_role.all(),
             many=True,
-            context={'user': user}
+            context={"user": user},
         ).data
 
     @extend_schema_field(OrganisationSerializer)
@@ -882,16 +963,18 @@ class UserDetailSerializer(serializers.ModelSerializer):
 
     @extend_schema_field(UserFormSerializer(many=True))
     def get_forms(self, instance: SystemUser):
-        return UserFormSerializer(instance=instance.user_form.all(),
-                                  many=True).data
+        return UserFormSerializer(
+            instance=instance.user_form.all(), many=True
+        ).data
 
     @extend_schema_field(OpenApiTypes.INT)
     def get_pending_approval(self, instance: SystemUser):
         batch_q = Q(approved=False)
         for ur in instance.user_user_role.all():
             adm = ur.administration
-            path = adm.path \
-                if hasattr(adm, 'path') and adm.path else f"{adm.id}."
+            path = (
+                adm.path if hasattr(adm, "path") and adm.path else f"{adm.id}."
+            )
             batch_q |= Q(
                 administration__path__startswith=path,
                 approved=False,
@@ -905,23 +988,30 @@ class UserDetailSerializer(serializers.ModelSerializer):
 
     @extend_schema_field(OpenApiTypes.INT)
     def get_pending_batch(self, instance: SystemUser):
-        return instance.user_data_batch.filter(
-            approved=False).all().count()
+        return instance.user_data_batch.filter(approved=False).all().count()
 
     class Meta:
         model = SystemUser
         fields = [
-            'first_name', 'last_name', 'email', 'roles',
-            'organisation', 'trained', 'phone_number',
-            'forms', 'pending_approval', 'data',
-            'pending_batch', 'is_superuser',
+            "first_name",
+            "last_name",
+            "email",
+            "roles",
+            "organisation",
+            "trained",
+            "phone_number",
+            "forms",
+            "pending_approval",
+            "data",
+            "pending_batch",
+            "is_superuser",
         ]
 
 
 class RoleOptionSerializer(serializers.ModelSerializer):
-    label = serializers.CharField(source='name')
-    value = serializers.IntegerField(source='id')
-    level = serializers.ReadOnlyField(source='administration_level.level')
+    label = serializers.CharField(source="name")
+    value = serializers.IntegerField(source="id")
+    level = serializers.ReadOnlyField(source="administration_level.level")
 
     class Meta:
         model = Role
@@ -953,7 +1043,7 @@ class UpdateProfileSerializer(serializers.ModelSerializer):
             "first_name",
             "last_name",
             "phone_number",
-            "organisation"
+            "organisation",
         ]
 
 

--- a/backend/api/v1/v1_users/tests/tests_add_user.py
+++ b/backend/api/v1/v1_users/tests/tests_add_user.py
@@ -403,7 +403,11 @@ class AddUserTestCase(TestCase):
         data = response.json()["details"]
         self.assertIn("email", data)
         self.assertEqual(
-            data["email"], ["system user with this email already exists."]
+            data["email"],
+            [
+                "This email is already in your workspace. "
+                "To make changes, edit the existing user."
+            ],
         )
 
     def test_add_user_with_missing_fields(self):

--- a/backend/api/v1/v1_users/tests/tests_tenant_isolation.py
+++ b/backend/api/v1/v1_users/tests/tests_tenant_isolation.py
@@ -2,8 +2,9 @@ from django.db.utils import IntegrityError
 from django.test.utils import override_settings
 from django.urls import NoReverseMatch, reverse
 
-from api.v1.v1_profile.models import Role
-from api.v1.v1_users.models import Organisation
+from api.v1.v1_profile.models import Role, UserRole
+from api.v1.v1_forms.models import UserForms
+from api.v1.v1_users.models import Organisation, SystemUser
 from utils.tenant_test_case import TenantIsolationTestCase
 
 
@@ -111,3 +112,136 @@ class UsersTenantIsolationTestCase(TenantIsolationTestCase):
             reverse("public-administrations-list")
         res = self.client.get("/api/v1/public/administrations")
         self.assertEqual(res.status_code, 404)
+
+    def test_invite_active_user_from_other_workspace_returns_policy_error(
+        self,
+    ):
+        res = self.client.post(
+            "/api/v1/user",
+            {
+                "first_name": "Test",
+                "last_name": "User",
+                "email": self.b["user"].email,
+                "forms": [],
+                "trained": False,
+            },
+            content_type="application/json",
+            **self.auth(self.a["user"]),
+        )
+        self.assertEqual(res.status_code, 400)
+        data = res.json()["details"]
+        self.assertIn("email", data)
+        self.assertIn("another workspace", data["email"][0])
+
+    def test_invite_soft_deleted_user_from_other_workspace_not_restored(self):
+        self.b["user"].soft_delete()
+
+        res = self.client.post(
+            "/api/v1/user",
+            {
+                "first_name": "Test",
+                "last_name": "User",
+                "email": self.b["user"].email,
+                "forms": [],
+                "trained": False,
+            },
+            content_type="application/json",
+            **self.auth(self.a["user"]),
+        )
+        self.assertEqual(res.status_code, 400)
+        data = res.json()["details"]
+        self.assertIn("email", data)
+        self.assertIn("another workspace", data["email"][0])
+
+        # Assert target user remains deleted and tenant_id is unchanged
+        user_b = SystemUser.objects_with_deleted.get(pk=self.b["user"].pk)
+        self.assertEqual(user_b.tenant_id, self.b["tenant"].id)
+        self.assertIsNotNone(user_b.deleted_at)
+        self.assertFalse(
+            UserRole.objects.filter(
+                user=user_b, administration=self.a["root"]
+            ).exists()
+        )
+        self.assertFalse(
+            UserForms.objects.filter(user=user_b, form=self.a["form"]).exists()
+        )
+
+    def test_invite_pending_user_from_other_workspace_returns_policy_error(
+        self,
+    ):
+        pending_user = SystemUser.objects.create_user(
+            email="pending@beta.org",
+            password="Secret#Pass123",
+            first_name="Pending",
+            last_name="User",
+            tenant=self.b["tenant"],
+            is_active=False,
+        )
+
+        res = self.client.post(
+            "/api/v1/user",
+            {
+                "first_name": "Test",
+                "last_name": "User",
+                "email": pending_user.email,
+                "forms": [],
+                "trained": False,
+            },
+            content_type="application/json",
+            **self.auth(self.a["user"]),
+        )
+        self.assertEqual(res.status_code, 400)
+        data = res.json()["details"]
+        self.assertIn("email", data)
+        self.assertIn("another workspace", data["email"][0])
+
+    def test_invite_duplicate_in_same_workspace_returns_same_workspace_error(
+        self,
+    ):
+        res = self.client.post(
+            "/api/v1/user",
+            {
+                "first_name": "Test",
+                "last_name": "User",
+                "email": self.a["user"].email,
+                "forms": [],
+                "trained": False,
+            },
+            content_type="application/json",
+            **self.auth(self.a["user"]),
+        )
+        self.assertEqual(res.status_code, 400)
+        data = res.json()["details"]
+        self.assertIn("email", data)
+        self.assertIn("already in your workspace", data["email"][0])
+
+    def test_reinvite_soft_deleted_user_in_same_workspace_restores(self):
+        # Create a second superuser in workspace A
+        # so they can perform the invite
+        admin_a2 = SystemUser.objects.create_superuser(
+            email="admin2@acme.org",
+            password="Secret#Pass123",
+            first_name="A2",
+            last_name="A2",
+            tenant=self.a["tenant"],
+        )
+
+        self.a["user"].soft_delete()
+
+        res = self.client.post(
+            "/api/v1/user",
+            {
+                "first_name": "Restored",
+                "last_name": "User",
+                "email": self.a["user"].email,
+                "forms": [],
+                "trained": False,
+            },
+            content_type="application/json",
+            **self.auth(admin_a2),
+        )
+        self.assertIn(res.status_code, (200, 201))
+
+        user_a = SystemUser.objects_with_deleted.get(pk=self.a["user"].pk)
+        self.assertIsNone(user_a.deleted_at)
+        self.assertEqual(user_a.first_name, "Restored")

--- a/doc/design/MT-011-cross-workspace-invite-policy.md
+++ b/doc/design/MT-011-cross-workspace-invite-policy.md
@@ -441,17 +441,51 @@ line 76):
 ./dc.sh exec backend flake8
 ```
 
-### Manual Verification Steps
+### Manual Verification Scenarios
 
-1. Log in as Workspace B admin → *Control Center → Users → Add User*
-2. Enter email of an **active** Workspace A user → submit
-   → expect inline email error + error toast; no new user in Workspace B list
-3. Repeat with a **soft-deleted** Workspace A email → same outcome
-4. Repeat with an **`is_active=False`** Workspace A email → same outcome
-5. Enter a **fresh** email → expect 201 success
-6. Enter a **Workspace B** duplicate email → expect "already in your workspace"
-   inline error + toast
-7. Re-invite a **soft-deleted Workspace B** email → expect 201 and user restored
+#### Scenario 1: Cross-Workspace Invite (New Policy Error)
+
+1. Identify an email address registered in **Workspace A** (e.g., `user_a@acme.org`).
+2. Log in as an Administrator in **Workspace B**.
+3. Navigate to **Control Center → Users → Add User** (`/control-center/users/add`).
+4. Fill in the form:
+   - **First Name**: Test
+   - **Last Name**: CrossTenant
+   - **Email**: `user_a@acme.org` (email belonging to Workspace A)
+5. Click **Add User**.
+6. **Expected Outcome**:
+   - **Inline Error**: Red text appears below the Email field:
+     > *"This email address is already registered to another workspace. An account can only belong to one workspace — ask them to use a different address, or contact support."*
+   - **Toast Notification**: Error toast appears with the same policy message.
+   - **Data Integrity**: No user is created in Workspace B's list.
+
+#### Scenario 2: Same-Workspace Duplicate Invite
+
+1. While logged in as **Workspace B** Admin, attempt to invite an email address that **already exists in Workspace B** (e.g., `user_b@beta.org`).
+2. Click **Add User**.
+3. **Expected Outcome**:
+   - **Inline Error**: Red text appears below the Email field:
+     > *"This email is already in your workspace. To make changes, edit the existing user."*
+   - **Toast Notification**: Error toast with the same message.
+
+#### Scenario 3: Same-Workspace Soft-Deleted User (Restore Flow)
+
+1. Soft-delete a user in **Workspace B** (from *Control Center → Users → Delete*).
+2. Re-invite that **exact same email address** in Workspace B (*Add User* form).
+3. Click **Add User**.
+4. **Expected Outcome**:
+   - Success toast: *"User added"*
+   - The soft-deleted user in Workspace B is successfully restored and updated.
+
+#### Scenario 4: Cross-Workspace Soft-Deleted User (Prevent Leak)
+
+1. Soft-delete a user in **Workspace A**.
+2. Log in as **Workspace B** Admin.
+3. Try to invite the email address of Workspace A's soft-deleted user.
+4. Click **Add User**.
+5. **Expected Outcome**:
+   - **Rejection**: 400 Bad Request with policy message (*"This email address is already registered to another workspace..."*).
+   - **Security**: Workspace A's soft-deleted user is **NOT** restored or transferred into Workspace B.
 
 ---
 

--- a/doc/design/MT-011-cross-workspace-invite-policy.md
+++ b/doc/design/MT-011-cross-workspace-invite-policy.md
@@ -1,0 +1,534 @@
+# Feature Design Document
+
+> **Purpose**: Implementation plan for #295. Complete before implementation begins.
+
+---
+
+## Feature: Cross-Workspace Invite Policy & Cross-Tenant Restore Leak Fix
+
+**Task ID**: MT-011
+**Issue**: #295
+**Author**: Galih Pratama
+**Date**: 2026-08-12
+**Status**: Approved
+**Branch**: `feature/295-post-mt-002-inviting-a-user-who-already-belongs-to-another-workspace-fails-with-a-raw-error`
+
+---
+
+## 1. Context & Problem Statement
+
+```
+Currently:
+- POST /api/v1/user returns 400 {"email":["system user with this email already
+  exists."]} when inviting an address that already belongs to another workspace.
+- The message is a raw DRF UniqueValidator error — it reads as a bug, not a rule.
+- AddEditUserSerializer.create() looks up soft-deleted users via
+  SystemUser.objects_deleted.get(email=...) without scoping to the acting user's
+  tenant. A soft-deleted user in workspace A can be silently un-deleted and its
+  UserRole/UserForms rows mutated by a workspace B admin.
+- No product documentation says "one account, one workspace".
+
+Goal:
+- Replace the implicit UniqueValidator with an explicit, tenant-aware email check.
+- Return a clear, differentiated message for each case.
+- Scope the soft-deleted restore lookup to the acting user's tenant.
+- Surface field-level errors both inline on the Add User form AND as a toast.
+- Document the one-account-one-workspace policy in start.rst.
+```
+
+---
+
+## 2. Architecture Overview
+
+The validation currently happens in two layers:
+
+1. **DRF field validation** — `UniqueValidator` fires during `is_valid()`, before
+   any serializer method runs.
+2. **`AddEditUserSerializer.create()`** — soft-delete restore logic runs only
+   after the field passes.
+
+The fix suppresses the auto-generated `UniqueValidator` on `email` by overriding
+`extra_kwargs` and replaces it with an explicit `validate_email()` method that
+is fully tenant-aware.
+
+```mermaid
+sequenceDiagram
+    actor Admin as Workspace B Admin
+    participant FE as AddUser.jsx
+    participant API as POST /api/v1/user
+    participant Ser as AddEditUserSerializer
+    participant DB as SystemUser table
+
+    Admin->>FE: fills email + submits
+    FE->>API: POST email x@y.com
+    API->>Ser: is_valid()
+    Ser->>DB: objects_with_deleted.filter(email).first()
+    alt email not found at all
+        Ser-->>API: valid, proceed to create()
+        API-->>FE: 201 Created
+    else email found in same tenant
+        Ser-->>API: 400 same-workspace message
+        API-->>FE: 400 inline error + toast
+    else email found in different tenant
+        Ser-->>API: 400 cross-workspace policy message
+        API-->>FE: 400 inline error + toast
+    end
+
+    Note over Ser: create() restore path
+    Ser->>DB: objects_deleted.for_user(acting).filter(email).first()
+    alt soft-deleted in same tenant
+        Ser->>DB: restore() then update()
+    else soft-deleted in different tenant
+        Note over Ser: blocked by validate_email above
+    end
+```
+
+---
+
+## 3. Requirements
+
+### User Acceptance Criteria
+
+- [ ] Inviting an address that exists in **another** workspace returns `400` with the
+  policy message, and creates nothing.
+- [ ] Inviting an address that exists in **the current** workspace returns a clear
+  "already in this workspace" message and creates nothing.
+- [ ] Both hold when the existing account is soft-deleted or an unactivated pending
+  invitation (`is_active=False`).
+- [ ] A soft-deleted user in **another** tenant is **never** restored by an invite
+  from a different tenant.
+- [ ] Soft-deleted users in the **same** tenant are still restored by re-inviting
+  them (today's behaviour must not regress).
+- [ ] The Add User form displays the error message **inline** on the email field
+  **and** as an error toast.
+- [ ] The rule "one account per workspace" appears in `docs/source/start.rst`.
+
+### Technical Acceptance Criteria
+
+- [ ] `AddEditUserSerializer.validate_email()` performs the explicit check using
+  `SystemUser.objects_with_deleted`.
+- [ ] `extra_kwargs = {'email': {'validators': []}}` suppresses DRF's auto-derived
+  `UniqueValidator`.
+- [ ] `AddEditUserSerializer.create()` scopes the soft-delete restore lookup with
+  `.for_user(acting_user(self.context))`.
+- [ ] Five regression tests added to
+  `backend/api/v1/v1_users/tests/tests_tenant_isolation.py`.
+- [ ] `./dc.sh exec backend flake8` passes.
+- [ ] Full backend test suite passes.
+
+---
+
+## 4. Backend Implementation
+
+### Data Model Changes
+
+**None.** `email = models.EmailField(unique=True)` on `SystemUser` is **kept
+as-is**. The DB-level constraint is the actual policy enforcer; the serializer
+only improves the error message.
+
+### Modified File: `backend/api/v1/v1_users/serializers.py`
+
+#### Change 1 — Suppress auto-generated UniqueValidator + explicit validation
+
+Add `extra_kwargs` to the existing `Meta` inner class (line ~576) and add a new
+`validate_email()` method immediately before or after `validate_roles()`:
+
+```python
+class Meta:
+    model = SystemUser
+    fields = [
+        'first_name', 'last_name', 'email',
+        'organisation', 'trained', 'roles', 'phone_number',
+        'forms', 'inform_user', 'is_superuser'
+    ]
+    extra_kwargs = {
+        # Suppress the auto-derived UniqueValidator so we can perform our
+        # own tenant-aware check in validate_email() below.
+        'email': {'validators': []},
+    }
+
+def validate_email(self, value):
+    """
+    Tenant-aware email uniqueness guard.
+
+    Uses objects_with_deleted so that soft-deleted accounts and unactivated
+    pending invitations (is_active=False) are both included — they still
+    occupy the address at the DB level.
+    """
+    acting = acting_user(self.context)
+    existing = SystemUser.objects_with_deleted.filter(email=value).first()
+
+    if existing is None:
+        return value
+
+    # Update path: the instance being edited is exempt from the check.
+    if self.instance and self.instance.pk == existing.pk:
+        return value
+
+    if existing.tenant_id == getattr(acting, 'tenant_id', None):
+        raise serializers.ValidationError(
+            "This email is already in your workspace. "
+            "To make changes, edit the existing user."
+        )
+
+    raise serializers.ValidationError(
+        "This email address is already registered to another workspace. "
+        "An account can only belong to one workspace — ask them to use "
+        "a different address, or contact support."
+    )
+```
+
+#### Change 2 — Scope soft-delete restore lookup in `create()` (line ~399)
+
+```python
+# BEFORE
+def create(self, validated_data):
+    try:
+        user_deleted = SystemUser.objects_deleted.get(
+            email=validated_data['email']
+        )
+        if user_deleted:
+            user_deleted.restore()
+            self.update(instance=user_deleted, validated_data=validated_data)
+            return user_deleted
+    except SystemUser.DoesNotExist:
+        ...
+
+# AFTER
+def create(self, validated_data):
+    acting = acting_user(self.context)
+    user_deleted = (
+        SystemUser.objects_deleted
+        .for_user(acting)
+        .filter(email=validated_data['email'])
+        .first()
+    )
+    if user_deleted:
+        user_deleted.restore()
+        self.update(
+            instance=user_deleted,
+            validated_data=validated_data,
+        )
+        return user_deleted
+
+    # Normal creation path (unchanged)
+    validated_data.pop('inform_user', None)
+    roles_data = validated_data.pop('roles', [])
+    forms = validated_data.pop('forms', [])
+    user = super(AddEditUserSerializer, self).create(validated_data)
+    ...
+```
+
+> **Why this is safe**: `validate_email()` runs before `create()`. By the time
+> `create()` runs, any cross-tenant address has already been rejected with 400.
+> The `.for_user()` scoping is a defence-in-depth measure.
+
+#### Import check
+
+`acting_user` is imported at the top of `serializers.py` via:
+
+```python
+from utils.tenant_scoped_model import acting_user
+```
+
+Confirm this import exists; if not, add it.
+
+### API Contract
+
+No new endpoints. Error response shape is unchanged (`message` + `details`):
+
+```json
+// POST /api/v1/user  →  400 (cross-workspace)
+{
+  "message": "This email address is already registered to another workspace. An account can only belong to one workspace — ask them to use a different address, or contact support.",
+  "details": {
+    "email": [
+      "This email address is already registered to another workspace. An account can only belong to one workspace — ask them to use a different address, or contact support."
+    ]
+  }
+}
+```
+
+```json
+// POST /api/v1/user  →  400 (same-workspace)
+{
+  "message": "This email is already in your workspace. To make changes, edit the existing user.",
+  "details": {
+    "email": [
+      "This email is already in your workspace. To make changes, edit the existing user."
+    ]
+  }
+}
+```
+
+---
+
+## 5. Frontend Implementation
+
+### File: `frontend/src/pages/add-user/AddUser.jsx`
+
+#### Current catch block (lines 102–114)
+
+```jsx
+.catch((err) => {
+  if (err?.response?.status === 403) {
+    setIsModalVisible(true);
+    setModalContent(err?.response?.data?.message);
+  } else {
+    notify({
+      type: "error",
+      message:
+        err?.response?.data?.message ||
+        `User could not be ${id ? "updated" : "added"}`,
+    });
+  }
+  setSubmitting(false);
+});
+```
+
+#### Updated catch block
+
+Show both an inline field error on the email `<Form.Item>` **and** an error toast
+when `details.email` is present. Other field errors fall back to the existing
+toast-only behaviour.
+
+```jsx
+.catch((err) => {
+  if (err?.response?.status === 403) {
+    setIsModalVisible(true);
+    setModalContent(err?.response?.data?.message);
+  } else {
+    const details = err?.response?.data?.details || {};
+    if (details.email) {
+      // Surface inline under the email field
+      form.setFields([
+        {
+          name: "email",
+          errors: Array.isArray(details.email)
+            ? details.email
+            : [details.email],
+        },
+      ]);
+      // Also show a toast so the error is noticeable even if the field
+      // is scrolled out of view
+      notify({
+        type: "error",
+        message:
+          err?.response?.data?.message ||
+          `User could not be ${id ? "updated" : "added"}`,
+      });
+    } else {
+      notify({
+        type: "error",
+        message:
+          err?.response?.data?.message ||
+          `User could not be ${id ? "updated" : "added"}`,
+      });
+    }
+  }
+  setSubmitting(false);
+});
+```
+
+#### Wireframe — inline email error state
+
+```text
++---------------------------------------------------------+
+| Add User                                                |
++---------------------------------------------------------+
+| First Name  [ John                                    ] |
+| Last Name   [ Doe                                     ] |
+| Email       [ john@other-workspace.com                ] |
+|             ⚠ This email address is already registered  |
+|               to another workspace. An account can only |
+|               belong to one workspace — ask them to use |
+|               a different address, or contact support.  |
+| Phone       [                                         ] |
+|                                                         |
+| [Toast]  ✖ This email address is already registered...  |
++---------------------------------------------------------+
+```
+
+---
+
+## 6. Documentation
+
+### File: `docs/source/start.rst`
+
+Extend the **Invite Users** bullet under the `User access` section (around
+line 76):
+
+```rst
+- **Invite Users**: Administrators can invite new users to join the system by
+  sending them an invitation email. The invited user will need to set up their
+  account by creating a password.
+
+  .. note::
+
+     **One account per workspace.**  An email address can belong to only one
+     workspace. If the address is already registered elsewhere — as an owner,
+     a member, or a pending invitation — it cannot be invited into a second
+     workspace. Ask the person to use a different email address, or contact
+     support if you need help.
+```
+
+---
+
+## 7. Compatibility & Migration
+
+### Backward Compatibility
+
+- [x] No schema migration required
+- [x] Error response shape (`message` + `details`) unchanged
+- [x] `unique=True` DB constraint retained
+- [x] Existing valid add-user flows unaffected
+
+### Mobile App Impact
+
+- Sync endpoints affected: None — admin invite path only
+- SQLite schema changes: No
+- Version detection: N/A
+
+### Seeder / CLI Compatibility
+
+- [x] Existing seeders work — no model changes
+
+---
+
+## 8. Security Considerations
+
+- [x] **Information-disclosure decision accepted**: The error response confirms
+  that *some* account holds the email address. This is unavoidable — any response
+  to an invite attempt reveals at minimum "this address is taken". Wording uses
+  policy language rather than ORM internals (deliberate, not a regression).
+- [x] **Cross-tenant restore blocked**: `.for_user()` scoping in `create()`
+  prevents a workspace B admin from un-deleting a workspace A soft-deleted
+  account.
+- [x] **Tenant stamp unchanged**: Restored accounts keep their original
+  `tenant_id`; `validate_email()` ensures cross-tenant addresses never reach
+  the restore branch.
+- [x] No new attack vectors introduced.
+
+---
+
+## 9. Testing & Verification
+
+### New Tests
+
+**File**: `backend/api/v1/v1_users/tests/tests_tenant_isolation.py`
+**Class**: `UsersTenantIsolationTestCase` (extend existing class)
+
+| # | Test name | Asserts |
+|---|-----------|---------|
+| T-1 | `test_invite_active_user_from_other_workspace_returns_policy_error` | `400`; response contains cross-workspace message |
+| T-2 | `test_invite_soft_deleted_user_from_other_workspace_not_restored` | `400`; `self.b["user"].tenant_id` unchanged (DB re-query); no new `UserRole`/`UserForms` rows for that user |
+| T-3 | `test_invite_pending_user_from_other_workspace_returns_policy_error` | `400`; `is_active=False` account in workspace A triggers policy message |
+| T-4 | `test_invite_duplicate_in_same_workspace_returns_same_workspace_error` | `400`; response contains same-workspace message |
+| T-5 | `test_reinvite_soft_deleted_user_in_same_workspace_restores` | `201`; `deleted_at` is `None` after call (regression guard) |
+
+### Automated Test Commands
+
+```bash
+# Full suite
+./dc.sh exec backend python manage.py test
+
+# Targeted (faster feedback)
+./dc.sh exec backend python manage.py test \
+    api.v1.v1_users.tests.tests_tenant_isolation \
+    api.v1.v1_users.tests.tests_add_user
+
+# Lint
+./dc.sh exec backend flake8
+```
+
+### Manual Verification Steps
+
+1. Log in as Workspace B admin → *Control Center → Users → Add User*
+2. Enter email of an **active** Workspace A user → submit
+   → expect inline email error + error toast; no new user in Workspace B list
+3. Repeat with a **soft-deleted** Workspace A email → same outcome
+4. Repeat with an **`is_active=False`** Workspace A email → same outcome
+5. Enter a **fresh** email → expect 201 success
+6. Enter a **Workspace B** duplicate email → expect "already in your workspace"
+   inline error + toast
+7. Re-invite a **soft-deleted Workspace B** email → expect 201 and user restored
+
+---
+
+## 10. Epic & Ballpark Estimation
+
+- **Confidence Level**: High — narrow, well-understood scope
+- **Dependencies**: None
+
+| Task ID | Component & Description | Est. Hours (Min – Max) | Priority |
+|---------|-------------------------|------------------------|----------|
+| T-001 | **Backend** — `validate_email()` + `extra_kwargs` in `AddEditUserSerializer` | 1h – 2h | Must Have |
+| T-002 | **Backend** — Scope restore lookup in `create()` with `.for_user()` | 0.5h – 1h | Must Have |
+| T-003 | **Backend** — 5 regression tests in `tests_tenant_isolation.py` | 2h – 3h | Must Have |
+| T-004 | **Frontend** — Inline field error + toast in `onFinish` catch block | 0.5h – 1h | Must Have |
+| T-005 | **Docs** — "One account per workspace" note in `start.rst` | 0.5h – 1h | Must Have |
+| **Total** | | **4.5h – 8h** | |
+
+---
+
+## 11. Decision Log
+
+### D-1: Suppress UniqueValidator via `extra_kwargs` vs. custom field class
+
+**Options Considered**:
+1. `extra_kwargs = {'email': {'validators': []}}` + `validate_email()`
+2. Replace the email field declaration with a hand-written `EmailField(validators=[])`
+
+**Decision**: Option 1.
+**Rationale**: `extra_kwargs` is the idiomatic DRF mechanism for overriding
+auto-derived validators. Minimal diff, no new field class needed.
+
+### D-2: Field-level (`validate_email`) vs. object-level (`validate`) check
+
+**Options Considered**:
+1. `validate_email(value)` — DRF maps the error to `{"email": [...]}` automatically.
+2. `validate(attrs)` — must build the `{"email": [...]}` dict manually.
+
+**Decision**: Option 1.
+**Rationale**: Field-level placement gives the correct `details.email` error
+shape for free, which is exactly what `form.setFields()` on the frontend needs.
+
+### D-3: Deep-link to existing user's edit page on same-workspace error
+
+**Decision**: No deep-link.
+**Rationale**: Out of scope for this issue. The message directs the admin to
+edit the existing user; finding that user via the existing users list is
+sufficient.
+
+### D-4: Inline only vs. toast + inline for email collision errors
+
+**Decision**: Both inline field error **and** an error toast.
+**Rationale**: Inline error anchors the problem to the field. The additional
+toast ensures the message is visible even if the email field is scrolled off
+screen, and aids assistive-technology users who may not be notified of DOM-only
+validation state changes.
+
+### D-5: Information disclosure
+
+**Decision**: Accept that the error reveals "someone holds this email".
+**Rationale**: Any response to an invite attempt reveals at least "this address
+is taken". The alternative (silently ignoring the request) is even more
+confusing. Policy language is a deliberate improvement over leaked ORM internals.
+
+---
+
+## 12. References
+
+- Related specs:
+  - [MT-002](./MT-002-tenant-scoping-database.md) — tenant scoping database
+  - [MT-003](./MT-003-tenant-isolation-read-filtering.md) — tenant isolation read filtering
+  - [MT-004](./MT-004-tenant-write-path-enforcement.md) — tenant write-path enforcement
+- Key source files:
+  - `backend/api/v1/v1_users/serializers.py` — `AddEditUserSerializer` (lines 370–582)
+  - `backend/api/v1/v1_users/models.py` — `SystemUser` model (lines 64–96)
+  - `backend/utils/soft_deletes_model.py` — `SoftDeletesManager` / `for_user()`
+  - `backend/utils/tenant_scoped_model.py` — `acting_user()` helper
+  - `frontend/src/pages/add-user/AddUser.jsx` — `onFinish` catch block
+  - `docs/source/start.rst` — "Invite Users" bullet
+- Future direction: splitting `SystemUser` into identity + per-workspace
+  `Membership` (issue #295 "Out of scope").

--- a/docs/source/start.rst
+++ b/docs/source/start.rst
@@ -75,6 +75,10 @@ User access in Akvo MIS is managed through roles and permissions. Each user can 
 
 - **Invite Users**: Administrators can invite new users to join the system by sending them an invitation email. The invited user will need to set up their account by creating a password.
 
+  .. note::
+
+     **One account per workspace.** An email address can belong to only one workspace. If the address is already registered elsewhere — as an owner, a member, or a pending invitation — it cannot be invited into a second workspace. Ask the person to use a different email address, or contact support if you need help.
+
 
 .. _manage_roles:
 

--- a/frontend/src/pages/add-user/AddUser.jsx
+++ b/frontend/src/pages/add-user/AddUser.jsx
@@ -168,8 +168,8 @@ const AddUser = () => {
             inform_user: !id
               ? true
               : authUser?.email === res.data?.email
-                ? false
-                : true,
+              ? false
+              : true,
           });
           setLoading(false);
           fetchData(res.data.administration?.id, []);
@@ -409,8 +409,8 @@ const AddUser = () => {
                             !id
                               ? true
                               : authUser?.email === form.getFieldValue("email")
-                                ? true
-                                : false
+                              ? true
+                              : false
                           }
                         >
                           {text.informUser}

--- a/frontend/src/pages/add-user/AddUser.jsx
+++ b/frontend/src/pages/add-user/AddUser.jsx
@@ -104,12 +104,30 @@ const AddUser = () => {
           setIsModalVisible(true);
           setModalContent(err?.response?.data?.message);
         } else {
-          notify({
-            type: "error",
-            message:
-              err?.response?.data?.message ||
-              `User could not be ${id ? "updated" : "added"}`,
-          });
+          const details = err?.response?.data?.details || {};
+          if (details.email) {
+            form.setFields([
+              {
+                name: "email",
+                errors: Array.isArray(details.email)
+                  ? details.email
+                  : [details.email],
+              },
+            ]);
+            notify({
+              type: "error",
+              message:
+                err?.response?.data?.message ||
+                `User could not be ${id ? "updated" : "added"}`,
+            });
+          } else {
+            notify({
+              type: "error",
+              message:
+                err?.response?.data?.message ||
+                `User could not be ${id ? "updated" : "added"}`,
+            });
+          }
         }
         setSubmitting(false);
       });
@@ -150,8 +168,8 @@ const AddUser = () => {
             inform_user: !id
               ? true
               : authUser?.email === res.data?.email
-              ? false
-              : true,
+                ? false
+                : true,
           });
           setLoading(false);
           fetchData(res.data.administration?.id, []);
@@ -391,8 +409,8 @@ const AddUser = () => {
                             !id
                               ? true
                               : authUser?.email === form.getFieldValue("email")
-                              ? true
-                              : false
+                                ? true
+                                : false
                           }
                         >
                           {text.informUser}


### PR DESCRIPTION
## Summary & Context

Issue: [#295](https://github.com/akvo/akvo-mis/issues/295)
Design Specification: [`doc/design/MT-011-cross-workspace-invite-policy.md`](/doc/design/MT-011-cross-workspace-invite-policy.md)

Inviting a user whose email belongs to **another** workspace previously returned DRF's default raw `UniqueValidator` error (`{"email": ["system user with this email already exists."]}`). This raw ORM error leaked global account existence details and looked like a form validation bug. Additionally, the same code path had a cross-tenant restore leak: soft-deleted users in foreign tenants were silently restored when re-invited by an admin of a different workspace.

This PR establishes an explicit **One Account Per Workspace** product policy message and plugs the cross-tenant restore leak.

---

## What Changes Were Made

### 1. Backend (`AddEditUserSerializer`)
- **Suppressed auto-derived `UniqueValidator`**: Added `extra_kwargs = {'email': {'validators': []}}` to `AddEditUserSerializer.Meta`.
- **Tenant-aware `validate_email()`**: Checks `SystemUser.objects_with_deleted`:
  - **Same workspace duplicate**: Returns clear message: `"This email is already in your workspace. To make changes, edit the existing user."`
  - **Cross-workspace email**: Returns policy message: `"This email address is already registered to another workspace. An account can only belong to one workspace — ask them to use a different address, or contact support."`
  - **Same-workspace soft-deleted user**: Allowed through so `create()` can restore them.
- **Scoped Restore Lookup**: Scoped soft-delete lookup in `create()` with `.for_user(acting_user(self.context))` using `objects_deleted` to prevent foreign tenant accounts from being restored.

### 2. Frontend (`AddUser.jsx`)
- Updated `onFinish` catch handler to call `form.setFields([{ name: "email", errors: [...] }])` when `details.email` error is returned, placing the message directly under the Email field inline while keeping the error toast notification.

### 3. Documentation (`docs/source/start.rst`)
- Added Sphinx `.. note::` under **Invite Users** documenting the explicit policy: *An email address can belong to only one workspace*.

### 4. Tests (`tests_tenant_isolation.py` & `tests_add_user.py`)
- Added 5 new tenant isolation tests covering active, soft-deleted, pending cross-workspace invites, same-workspace duplicates, and same-workspace soft-delete restores.
- Updated existing `test_add_user_with_existing_email` test assertion.

---

## How to Test

### Automated Tests
```bash
./dc.sh exec backend python manage.py test api.v1.v1_users.tests.tests_tenant_isolation api.v1.v1_users.tests.tests_add_user
```

### Manual Verification
1. Log in as **Workspace B** Admin and go to **Control Center → Users → Add User**.
2. Try inviting an email address belonging to **Workspace A**.
   - **Expected**: Inline red error under Email field + Error Toast: *"This email address is already registered to another workspace..."*. No user created in Workspace B.
3. Try inviting an email address belonging to **Workspace B**.
   - **Expected**: Inline red error under Email field + Error Toast: *"This email is already in your workspace..."*.
4. Soft-delete a user in **Workspace B** and re-invite them.
   - **Expected**: Success toast and user is restored in Workspace B.
5. Soft-delete a user in **Workspace A**, log in as **Workspace B** Admin, and invite that email.
   - **Expected**: Rejected with 400 policy error. Soft-deleted user in Workspace A is **NOT** restored or transferred.


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1217386215728520