### PR TITLE
[#267] Add Monitoring Form View Mode to Manage Data Page

### DIFF
--- a/backend/api/v1/v1_data/serializers.py
+++ b/backend/api/v1/v1_data/serializers.py
@@ -45,9 +45,9 @@ class SubmitFormDataSerializer(serializers.ModelSerializer):
 
     def __init__(self, **kwargs):
         super().__init__(**kwargs)
-        self.fields.get(
-            "administration"
-        ).queryset = Administration.objects.all()
+        self.fields.get("administration").queryset = (
+            Administration.objects.all()
+        )
 
     class Meta:
         model = FormData
@@ -82,9 +82,7 @@ class SubmitFormDataAnswerSerializer(serializers.ModelSerializer):
             # but ensure that the question is provided and
             # value is correct type
             if not attrs.get("question"):
-                raise ValidationError(
-                    "Question is required for Answer"
-                )
+                raise ValidationError("Question is required for Answer")
             if attrs.get("value") is None:
                 attrs["value"] = ""
             question = attrs.get("question")
@@ -371,9 +369,9 @@ class ListFormDataRequestSerializer(serializers.Serializer):
 
     def __init__(self, **kwargs):
         super().__init__(**kwargs)
-        self.fields.get(
-            "administration"
-        ).queryset = Administration.objects.all()
+        self.fields.get("administration").queryset = (
+            Administration.objects.all()
+        )
 
     def validate(self, attrs):
         date_from = attrs.get("date_from")
@@ -395,6 +393,9 @@ class ListFormDataSerializer(serializers.ModelSerializer):
     administration = serializers.SerializerMethodField()
     pending_data = serializers.SerializerMethodField()
     total_children = serializers.SerializerMethodField()
+    parent_name = serializers.SerializerMethodField()
+    parent_id = serializers.SerializerMethodField()
+    parent_form_id = serializers.SerializerMethodField()
 
     @extend_schema_field(OpenApiTypes.STR)
     def get_created_by(self, instance: FormData):
@@ -454,6 +455,18 @@ class ListFormDataSerializer(serializers.ModelSerializer):
     def get_total_children(self, instance: FormData):
         return getattr(instance, "total_children", 0)
 
+    @extend_schema_field(OpenApiTypes.STR)
+    def get_parent_name(self, instance: FormData):
+        return instance.parent.name if instance.parent else None
+
+    @extend_schema_field(OpenApiTypes.INT)
+    def get_parent_id(self, instance: FormData):
+        return instance.parent.id if instance.parent else None
+
+    @extend_schema_field(OpenApiTypes.INT)
+    def get_parent_form_id(self, instance: FormData):
+        return instance.parent.form_id if instance.parent else None
+
     class Meta:
         model = FormData
         fields = [
@@ -472,6 +485,9 @@ class ListFormDataSerializer(serializers.ModelSerializer):
             "pending_data",
             "submitter",
             "total_children",
+            "parent_name",
+            "parent_id",
+            "parent_form_id",
         ]
 
 
@@ -510,10 +526,9 @@ class ListPendingDataAnswerSerializer(serializers.ModelSerializer):
             if instance.question.form.parent:
                 # If the question is from a parent form,
                 # get the parent question from the parent form
-                qg = instance.question.form.parent \
-                    .form_question_group.filter(
-                        name=instance.question.question_group.name
-                    ).first()
+                qg = instance.question.form.parent.form_question_group.filter(
+                    name=instance.question.question_group.name
+                ).first()
                 if qg:
                     parent_question = qg.question_group_question.filter(
                         name=instance.question.name
@@ -524,8 +539,8 @@ class ListPendingDataAnswerSerializer(serializers.ModelSerializer):
                     Q(
                         question=instance.question,
                         index=instance.index,
-                    ) |
-                    Q(
+                    )
+                    | Q(
                         question=parent_question,
                         index=instance.index,
                     )
@@ -576,9 +591,7 @@ class ListPendingFormDataSerializer(serializers.ModelSerializer):
     @extend_schema_field(OpenApiTypes.BOOL)
     def get_answer_history(self, instance: FormData):
         # Check for history in answer_history table
-        history = AnswerHistory.objects.filter(
-            data=instance
-        ).count()
+        history = AnswerHistory.objects.filter(data=instance).count()
         return True if history > 0 else False
 
     @extend_schema_field(ParentFormDataSerializer)
@@ -715,37 +728,45 @@ class SubmitPendingFormSerializer(serializers.Serializer):
                 ep = q_api.get("endpoint", "")
                 val = None
                 if "organisation" in ep:
-                    val = Organisation.objects.filter(pk=id).values_list(
-                        'name', flat=True).first()
+                    val = (
+                        Organisation.objects.filter(pk=id)
+                        .values_list("name", flat=True)
+                        .first()
+                    )
                 elif "entity-data" in ep or extra_type == "entity":
-                    val = EntityData.objects.filter(pk=id).values_list(
-                        'name', flat=True).first()
+                    val = (
+                        EntityData.objects.filter(pk=id)
+                        .values_list("name", flat=True)
+                        .first()
+                    )
                 else:
                     # administration cascade: store both name and integer value
-                    val = Administration.objects.filter(pk=id).values_list(
-                        'name', flat=True).first()
+                    val = (
+                        Administration.objects.filter(pk=id)
+                        .values_list("name", flat=True)
+                        .first()
+                    )
                     value = id
                 name = val
             else:
                 # for number question type
                 value = answer.get("value")
 
-            answers.append(Answers(
-                data=obj_data,
-                question=question,
-                name=name,
-                value=value,
-                options=option,
-                created_by=self.context.get("user"),
-                index=answer.get("index", 0)
-            ))
+            answers.append(
+                Answers(
+                    data=obj_data,
+                    question=question,
+                    name=name,
+                    value=value,
+                    options=option,
+                    created_by=self.context.get("user"),
+                    index=answer.get("index", 0),
+                )
+            )
 
         Answers.objects.bulk_create(answers)
 
-        if (
-            not is_draft and
-            not obj_data.is_pending
-        ):
+        if not is_draft and not obj_data.is_pending:
             # Refresh materialized view via async task
             async_task("api.v1.v1_data.tasks.seed_approved_data", obj_data)
 
@@ -830,30 +851,41 @@ class SubmitUpdateDraftFormSerializer(SubmitPendingFormSerializer):
                 ep = q_api.get("endpoint", "")
                 val = None
                 if "organisation" in ep:
-                    val = Organisation.objects.filter(pk=id).values_list(
-                        'name', flat=True).first()
+                    val = (
+                        Organisation.objects.filter(pk=id)
+                        .values_list("name", flat=True)
+                        .first()
+                    )
                 elif "entity-data" in ep or extra_type == "entity":
-                    val = EntityData.objects.filter(pk=id).values_list(
-                        'name', flat=True).first()
+                    val = (
+                        EntityData.objects.filter(pk=id)
+                        .values_list("name", flat=True)
+                        .first()
+                    )
                 else:
                     # administration cascade: store both name and integer value
-                    val = Administration.objects.filter(pk=id).values_list(
-                        'name', flat=True).first()
+                    val = (
+                        Administration.objects.filter(pk=id)
+                        .values_list("name", flat=True)
+                        .first()
+                    )
                     value = id
                 name = val
             else:
                 # for number question type
                 value = answer.get("value")
 
-            answers.append(Answers(
-                data=instance,
-                question=question,
-                name=name,
-                value=value,
-                options=option,
-                created_by=self.context.get("user"),
-                index=answer.get("index", 0)
-            ))
+            answers.append(
+                Answers(
+                    data=instance,
+                    question=question,
+                    name=name,
+                    value=value,
+                    options=option,
+                    created_by=self.context.get("user"),
+                    index=answer.get("index", 0),
+                )
+            )
 
         Answers.objects.bulk_create(answers)
         return instance
@@ -880,9 +912,9 @@ class FilterDraftFormDataSerializer(serializers.Serializer):
 
     def __init__(self, **kwargs):
         super().__init__(**kwargs)
-        self.fields.get(
-            "administration"
-        ).queryset = Administration.objects.all()
+        self.fields.get("administration").queryset = (
+            Administration.objects.all()
+        )
 
     class Meta:
         fields = ["administration", "page", "search"]
@@ -892,9 +924,7 @@ class DraftFormDataDetailSerializer(serializers.ModelSerializer):
     answers = serializers.SerializerMethodField()
     datapoint_name = CustomCharField(source="name")
     geolocation = CustomListField(
-        source="geo",
-        required=False,
-        allow_null=True
+        source="geo", required=False, allow_null=True
     )
 
     @extend_schema_field(OpenApiTypes.ANY)

--- a/backend/api/v1/v1_data/tests/tests_parent_fields.py
+++ b/backend/api/v1/v1_data/tests/tests_parent_fields.py
@@ -1,0 +1,96 @@
+from django.test import TestCase
+from django.test.utils import override_settings
+from django.core.management import call_command
+
+from api.v1.v1_forms.models import Forms
+from api.v1.v1_data.functions import add_fake_answers
+from api.v1.v1_profile.models import Administration
+from api.v1.v1_profile.tests.mixins import ProfileTestHelperMixin
+
+
+@override_settings(USE_TZ=False, TEST_ENV=True)
+class ParentFieldsTestCase(TestCase, ProfileTestHelperMixin):
+    """Test cases for parent fields in ListFormDataSerializer."""
+
+    def setUp(self):
+        super().setUp()
+        call_command("administration_seeder", "--test")
+        call_command("form_seeder", "--test")
+        call_command("default_roles_seeder", "--test", 1)
+
+        self.form = Forms.objects.get(pk=1)
+        self.child_form = self.form.children.first()
+        self.administration = Administration.objects.filter(
+            parent__isnull=False
+        ).first()
+
+        self.user = self.create_user(
+            email="super@akvo.org",
+            role_level=self.IS_SUPER_ADMIN,
+        )
+        self.user.set_password("test")
+        self.user.save()
+
+        self.token = self.get_auth_token(self.user.email, "test")
+
+        # Create parent registration data
+        self.parent_data = self.form.form_form_data.create(
+            name="Test Parent Registration Data",
+            administration=self.administration,
+            geo=[0.0, 0.0],
+            created_by=self.user,
+            updated_by=self.user,
+            is_pending=False,
+            is_draft=False,
+        )
+        add_fake_answers(self.parent_data)
+
+        # Create child monitoring data
+        self.child_data = self.child_form.form_form_data.create(
+            parent=self.parent_data,
+            name=f"Monitoring of {self.parent_data.name}",
+            administration=self.parent_data.administration,
+            geo=self.parent_data.geo,
+            created_by=self.user,
+            updated_by=self.user,
+            is_pending=False,
+            is_draft=False,
+        )
+        add_fake_answers(self.child_data)
+
+    def test_monitoring_data_includes_parent_fields(self):
+        """Test monitoring data includes parent_name, parent_id,
+        parent_form_id."""
+        response = self.client.get(
+            f"/api/v1/form-data/{self.child_form.id}",
+            HTTP_AUTHORIZATION=f"Bearer {self.token}",
+        )
+        self.assertEqual(response.status_code, 200)
+        data = response.data["data"]
+        self.assertTrue(len(data) > 0)
+
+        child_item = next(
+            (item for item in data if item["id"] == self.child_data.id), None
+        )
+        self.assertIsNotNone(child_item)
+        self.assertEqual(child_item["parent_name"], self.parent_data.name)
+        self.assertEqual(child_item["parent_id"], self.parent_data.id)
+        self.assertEqual(child_item["parent_form_id"], self.form.id)
+
+    def test_registration_data_has_null_parent_fields(self):
+        """Test that registration form data has null parent fields."""
+        response = self.client.get(
+            f"/api/v1/form-data/{self.form.id}",
+            HTTP_AUTHORIZATION=f"Bearer {self.token}",
+        )
+        self.assertEqual(response.status_code, 200)
+        data = response.data["data"]
+        self.assertTrue(len(data) > 0)
+
+        parent_item = next(
+            (item for item in data if item["id"] == self.parent_data.id), None
+        )
+        self.assertIsNotNone(parent_item)
+        self.assertIsNone(parent_item.get("parent_name"))
+        self.assertIsNone(parent_item.get("parent_id"))
+        self.assertIsNone(parent_item.get("parent_form_id"))

--- a/backend/api/v1/v1_data/tests/tests_parent_fields.py
+++ b/backend/api/v1/v1_data/tests/tests_parent_fields.py
@@ -20,9 +20,13 @@ class ParentFieldsTestCase(TestCase, ProfileTestHelperMixin):
 
         self.form = Forms.objects.get(pk=1)
         self.child_form = self.form.children.first()
-        self.administration = Administration.objects.filter(
-            parent__isnull=False
-        ).first()
+        root_adm = Administration.objects.filter(parent__isnull=True).first()
+        self.administration = (
+            Administration.objects.filter(
+                parent__isnull=False, path__startswith=f"{root_adm.id}."
+            ).first()
+            or root_adm
+        )
 
         self.user = self.create_user(
             email="super@akvo.org",
@@ -44,6 +48,8 @@ class ParentFieldsTestCase(TestCase, ProfileTestHelperMixin):
             is_draft=False,
         )
         add_fake_answers(self.parent_data)
+        self.parent_data.name = "Test Parent Registration Data"
+        self.parent_data.save()
 
         # Create child monitoring data
         self.child_data = self.child_form.form_form_data.create(
@@ -94,3 +100,20 @@ class ParentFieldsTestCase(TestCase, ProfileTestHelperMixin):
         self.assertIsNone(parent_item.get("parent_name"))
         self.assertIsNone(parent_item.get("parent_id"))
         self.assertIsNone(parent_item.get("parent_form_id"))
+
+    def test_monitoring_data_search_by_parent_name(self):
+        """Test searching monitoring data by parent registration name."""
+        response = self.client.get(
+            f"/api/v1/form-data/{self.child_form.id}",
+            {"search": "Test Parent Registration Data"},
+            HTTP_AUTHORIZATION=f"Bearer {self.token}",
+        )
+        self.assertEqual(response.status_code, 200)
+        data = response.data["data"]
+        self.assertTrue(len(data) > 0)
+
+        child_item = next(
+            (item for item in data if item["id"] == self.child_data.id), None
+        )
+        self.assertIsNotNone(child_item)
+        self.assertEqual(child_item["parent_name"], self.parent_data.name)

--- a/backend/api/v1/v1_data/views.py
+++ b/backend/api/v1/v1_data/views.py
@@ -217,7 +217,13 @@ class FormDataAddListView(APIView):
                 )
             )
             if search:
-                queryset = queryset.filter(name__icontains=search)
+                queryset = queryset.filter(
+                    Q(name__icontains=search)
+                    | Q(parent__name__icontains=search)
+                    | Q(created_by__first_name__icontains=search)
+                    | Q(created_by__last_name__icontains=search)
+                    | Q(created_by__email__icontains=search)
+                )
             if date_from:
                 start_datetime = datetime.combine(date_from, time.min)
                 if settings.USE_TZ:
@@ -323,7 +329,13 @@ class FormDataAddListView(APIView):
             )
         )
         if search:
-            queryset = queryset.filter(name__icontains=search)
+            queryset = queryset.filter(
+                Q(name__icontains=search)
+                | Q(parent__name__icontains=search)
+                | Q(created_by__first_name__icontains=search)
+                | Q(created_by__last_name__icontains=search)
+                | Q(created_by__email__icontains=search)
+            )
         # When sorting by latest_activity, filter on that annotation so
         # registrations with recent monitoring children are not excluded.
         date_filter_field = (

--- a/backend/api/v1/v1_data/views.py
+++ b/backend/api/v1/v1_data/views.py
@@ -46,9 +46,7 @@ from api.v1.v1_data.serializers import (
     FormDataSerializer,
     FilterDraftFormDataSerializer,
 )
-from api.v1.v1_forms.constants import (
-    QuestionTypes
-)
+from api.v1.v1_forms.constants import QuestionTypes
 from api.v1.v1_forms.models import Forms, Questions
 from api.v1.v1_profile.models import Administration
 from api.v1.v1_profile.constants import DataAccessTypes
@@ -126,8 +124,11 @@ class FormDataAddListView(APIView):
                     "total_children, latest_activity)"
                 ),
                 enum=[
-                    "created", "updated", "name",
-                    "total_children", "latest_activity"
+                    "created",
+                    "updated",
+                    "name",
+                    "total_children",
+                    "latest_activity",
                 ],
             ),
             OpenApiParameter(
@@ -198,14 +199,23 @@ class FormDataAddListView(APIView):
 
         if parent:
             # Only get the children data
-            queryset = form.form_form_data.filter(
-                uuid=parent,
-                is_pending=False,
-                is_draft=False,
-            ).annotate(total_children=Count(
-                'children',
-                filter=Q(children__is_pending=False, children__is_draft=False)
-            ))
+            queryset = (
+                form.form_form_data.select_related("parent__form")
+                .filter(
+                    uuid=parent,
+                    is_pending=False,
+                    is_draft=False,
+                )
+                .annotate(
+                    total_children=Count(
+                        "children",
+                        filter=Q(
+                            children__is_pending=False,
+                            children__is_draft=False,
+                        ),
+                    )
+                )
+            )
             if search:
                 queryset = queryset.filter(name__icontains=search)
             if date_from:
@@ -260,9 +270,13 @@ class FormDataAddListView(APIView):
             # Filter data by user administration path. The root is looked
             # up within the tenant: an unscoped first() could pick another
             # tenant's root and scope the whole list to it.
-            adm = Administration.objects.for_user(request.user).filter(
-                parent__isnull=True,
-            ).first()
+            adm = (
+                Administration.objects.for_user(request.user)
+                .filter(
+                    parent__isnull=True,
+                )
+                .first()
+            )
             if not request.user.is_superuser:
                 user_role = request.user.user_user_role.first()
                 if user_role:
@@ -273,29 +287,39 @@ class FormDataAddListView(APIView):
         # Subquery to get the form name of the child with latest activity.
         # Order by Coalesce(updated, created) so NULL updated records are
         # ranked by created instead of being sorted first by PostgreSQL.
-        latest_child_form_subquery = FormData.objects.filter(
-            parent=OuterRef('pk'),
-            is_pending=False,
-            is_draft=False
-        ).annotate(
-            child_activity=Coalesce('updated', 'created')
-        ).order_by('-child_activity').values('form__name')[:1]
+        latest_child_form_subquery = (
+            FormData.objects.filter(
+                parent=OuterRef("pk"), is_pending=False, is_draft=False
+            )
+            .annotate(child_activity=Coalesce("updated", "created"))
+            .order_by("-child_activity")
+            .values("form__name")[:1]
+        )
 
-        queryset = form.form_form_data.filter(**filter_data).annotate(
-            total_children=Count(
-                'children',
-                filter=Q(children__is_pending=False, children__is_draft=False)
-            ),
-            # Use Coalesce so flow-imported children with NULL updated
-            # fall back to their created date for activity calculation.
-            latest_child_activity=Max(
-                Coalesce('children__updated', 'children__created'),
-                filter=Q(children__is_pending=False, children__is_draft=False)
-            ),
-            latest_activity_source=Subquery(latest_child_form_subquery),
-        ).annotate(
-            latest_activity=Coalesce(
-                'latest_child_activity', 'updated', 'created'
+        queryset = (
+            form.form_form_data.select_related("parent__form")
+            .filter(**filter_data)
+            .annotate(
+                total_children=Count(
+                    "children",
+                    filter=Q(
+                        children__is_pending=False, children__is_draft=False
+                    ),
+                ),
+                # Use Coalesce so flow-imported children with NULL updated
+                # fall back to their created date for activity calculation.
+                latest_child_activity=Max(
+                    Coalesce("children__updated", "children__created"),
+                    filter=Q(
+                        children__is_pending=False, children__is_draft=False
+                    ),
+                ),
+                latest_activity_source=Subquery(latest_child_form_subquery),
+            )
+            .annotate(
+                latest_activity=Coalesce(
+                    "latest_child_activity", "updated", "created"
+                )
             )
         )
         if search:
@@ -403,9 +427,7 @@ class FormDataAddListView(APIView):
         for answer in answers:
             index = answer.get("index", 0)
             form_answer = Answers.objects.filter(
-                data=data,
-                index=index,
-                question=answer.get("question")
+                data=data, index=index, question=answer.get("question")
             ).first()
             if form_answer:
                 AnswerHistory.objects.create(
@@ -519,8 +541,11 @@ class PendingDataDetailDeleteView(APIView):
             is_pending=True,
         )
         # Get the last data from the last children
-        last_data = data.parent.children.filter(is_pending=False).last() if \
-            data.parent else None
+        last_data = (
+            data.parent.children.filter(is_pending=False).last()
+            if data.parent
+            else None
+        )
         # Find the original FormData if this is an update
         if not last_data:
             last_data = FormData.objects.filter(
@@ -589,9 +614,12 @@ class DataDetailDeleteView(APIView):
             pk=data_id,
             is_pending=False,
         )
-        if not request.user.is_superuser or request.user.user_role.filter(
-            role__role_role_access__data_access=DataAccessTypes.delete
-        ).exists():
+        if (
+            not request.user.is_superuser
+            or request.user.user_role.filter(
+                role__role_role_access__data_access=DataAccessTypes.delete
+            ).exists()
+        ):
             return Response(
                 {"message": "You are not allowed to perform this action"},
                 status=status.HTTP_400_BAD_REQUEST,
@@ -604,9 +632,7 @@ class DataDetailDeleteView(APIView):
 @api_view(["GET"])
 @permission_classes([IsAuthenticated])
 def export_form_data(request, version, form_id):
-    form = get_object_or_404(
-            Forms.objects.for_user(request.user), pk=form_id
-        )
+    form = get_object_or_404(Forms.objects.for_user(request.user), pk=form_id)
     form_name = form.name
     filename = f"{form.id}-{form_name}"
     directory = "tmp"
@@ -728,7 +754,7 @@ class PendingFormDataView(APIView):
         # Get all child form IDs including the parent form
         form_ids = [form.id]
         if form.children.exists():
-            child_form_ids = form.children.values_list('id', flat=True)
+            child_form_ids = form.children.values_list("id", flat=True)
             form_ids.extend(list(child_form_ids))
         # Query for pending form data across parent and child forms
         queryset = FormData.objects.filter(
@@ -761,14 +787,12 @@ class PendingFormDataView(APIView):
         selection_ids = request.GET.getlist("selection_ids")
         if selection_ids:
             # Return without pagination if selection_ids are provided
-            queryset = queryset.filter(
-                id__in=selection_ids
-            )
+            queryset = queryset.filter(id__in=selection_ids)
             return Response(
                 ListPendingFormDataSerializer(
                     instance=queryset, many=True
                 ).data,
-                status=status.HTTP_200_OK
+                status=status.HTTP_200_OK,
             )
 
         paginator = PageNumberPagination()
@@ -799,9 +823,7 @@ class PendingFormDataView(APIView):
         summary="Edit pending form data",
     )
     def put(self, request, form_id, version):
-        get_object_or_404(
-            Forms.objects.for_user(request.user), pk=form_id
-        )
+        get_object_or_404(Forms.objects.for_user(request.user), pk=form_id)
         pending_data_id = request.GET["pending_data_id"]
         user = request.user
         pending_data = get_object_or_404(
@@ -871,8 +893,10 @@ class PendingFormDataView(APIView):
         pending_data.updated = timezone.now()
         pending_data.updated_by = user
         pending_data.save()
-        if hasattr(pending_data, "data_batch_list") and \
-                not pending_data.data_batch_list.batch.approved:
+        if (
+            hasattr(pending_data, "data_batch_list")
+            and not pending_data.data_batch_list.batch.approved
+        ):
             # If this pending data is part of a batch,
             # update the batch approval status as pending
             approvals = pending_data.data_batch_list.batch.batch_approval.all()
@@ -949,13 +973,18 @@ class DraftFormDataListView(APIView):
         page = serializer.validated_data.get("page", 1)
 
         # Filter draft data for this form and user
-        queryset = FormData.objects_draft.filter(
-            form=form,
-            created_by=request.user
-        ).annotate(total_children=Count(
-            'children',
-            filter=Q(children__is_pending=False, children__is_draft=False)
-        )).order_by("-created")
+        queryset = (
+            FormData.objects_draft.filter(form=form, created_by=request.user)
+            .annotate(
+                total_children=Count(
+                    "children",
+                    filter=Q(
+                        children__is_pending=False, children__is_draft=False
+                    ),
+                )
+            )
+            .order_by("-created")
+        )
 
         # Apply search filter if provided
         search = serializer.validated_data.get("search", None)
@@ -968,8 +997,8 @@ class DraftFormDataListView(APIView):
             adm = serializer.validated_data.get("administration")
             adm_path = adm.path if adm.path else f"{adm.pk}."
             queryset = queryset.filter(
-                Q(administration__path__startswith=adm_path) |
-                Q(administration=adm)
+                Q(administration__path__startswith=adm_path)
+                | Q(administration=adm)
             )
 
         paginator = PageNumberPagination()
@@ -979,9 +1008,7 @@ class DraftFormDataListView(APIView):
             "current": int(page),
             "total": queryset.count(),
             "total_page": ceil(queryset.count() / page_size),
-            "data": ListFormDataSerializer(
-                instance=instance, many=True
-            ).data,
+            "data": ListFormDataSerializer(instance=instance, many=True).data,
         }
         return Response(data, status=status.HTTP_200_OK)
 
@@ -1000,8 +1027,8 @@ class DraftFormDataListView(APIView):
             context={
                 "user": request.user,
                 "form": form,
-                "is_draft": True  # Indicate this is a draft submission
-            }
+                "is_draft": True,  # Indicate this is a draft submission
+            },
         )
         if not serializer.is_valid():
             return Response(
@@ -1015,7 +1042,7 @@ class DraftFormDataListView(APIView):
         serializer.save()
         return Response(
             {"message": "Draft created successfully"},
-            status=status.HTTP_201_CREATED
+            status=status.HTTP_201_CREATED,
         )
 
 
@@ -1040,10 +1067,9 @@ class DraftFormDataDetailView(APIView):
             )
         return Response(
             FormDataSerializer(
-                instance=draft_data,
-                context={"webform": True}
+                instance=draft_data, context={"webform": True}
             ).data,
-            status=status.HTTP_200_OK
+            status=status.HTTP_200_OK,
         )
 
     @extend_schema(
@@ -1067,7 +1093,7 @@ class DraftFormDataDetailView(APIView):
         serializer = SubmitUpdateDraftFormSerializer(
             instance=draft_data,
             data=request.data,
-            context={"user": request.user, "form": draft_data.form}
+            context={"user": request.user, "form": draft_data.form},
         )
         if not serializer.is_valid():
             return Response(
@@ -1081,7 +1107,7 @@ class DraftFormDataDetailView(APIView):
         serializer.save()
         return Response(
             {"message": "Draft updated successfully"},
-            status=status.HTTP_200_OK
+            status=status.HTTP_200_OK,
         )
 
     @extend_schema(
@@ -1099,7 +1125,9 @@ class DraftFormDataDetailView(APIView):
         )
         if draft_data.created_by_id != request.user.id:
             return Response(
-                {"detail": "You do not have permission to perform this action."},  # noqa: E501
+                {
+                    "detail": "You do not have permission to perform this action."  # noqa: E501
+                },
                 status=status.HTTP_403_FORBIDDEN,
             )
 
@@ -1112,10 +1140,7 @@ class PublishDraftFormDataView(APIView):
     permission_classes = [IsAuthenticated, IsSubmitter]
 
     @extend_schema(
-        request=inline_serializer(
-            "PublishDraftRequestSerializer",
-            fields={}
-        ),
+        request=inline_serializer("PublishDraftRequestSerializer", fields={}),
         responses={200: DefaultResponseSerializer},
         tags=["Draft Data"],
         summary="Publish draft form data",
@@ -1128,7 +1153,9 @@ class PublishDraftFormDataView(APIView):
         )
         if draft_data.created_by_id != request.user.id:
             return Response(
-                {"detail": "You do not have permission to perform this action."},  # noqa: E501
+                {
+                    "detail": "You do not have permission to perform this action."  # noqa: E501
+                },
                 status=status.HTTP_403_FORBIDDEN,
             )
 
@@ -1149,5 +1176,5 @@ class PublishDraftFormDataView(APIView):
 
         return Response(
             {"message": "Draft published successfully"},
-            status=status.HTTP_200_OK
+            status=status.HTTP_200_OK,
         )

--- a/doc/design/MP-001-monitoring-data-view.md
+++ b/doc/design/MP-001-monitoring-data-view.md
@@ -1,0 +1,312 @@
+# Feature Design Document
+
+> **Purpose**: Use this template when planning new features that require data model changes, API design, or architectural decisions. Complete this document BEFORE implementation begins.
+
+---
+
+## Feature: MP-001 — Monitoring Data View
+
+**Task ID**: 267
+**Issue**: #267
+**Author**: Galih Pratama
+**Date**: 2026-08-13
+**Status**: Review
+**Branch**: `feature/267-add-monitoring-form-view-mode-to-manage-data-page`
+
+---
+
+## 1. Context & Problem Statement
+
+```
+Currently:
+- The manage data view is only registration-based.
+- When monitoring data collection is happening for a certain form, it is difficult to track progress.
+- Users are forced to click every Registration Datapoint to see monitoring submissions.
+
+Goal:
+- Add a "View Mode" dropdown next to the existing Form dropdown.
+- Allow users to switch between Registration view (current behavior) and Monitoring form views (one option per monitoring form).
+- See all monitoring submissions directly in the Manage Data table, with inline expansion for details.
+```
+
+## 2. Architecture Overview
+
+- **Backend**: Update `ListFormDataSerializer` to include `parent_name`, `parent_id`, and `parent_form_id` so monitoring form data can link back to its parent registration datapoint.
+- **Frontend**: Add `viewMode` state to `ManageData.jsx`. Pass it to `DataFilters` (new dropdown) and `ManageDataTable` (conditional columns + expandable rows).
+- **UX**: Hybrid approach — clicking a monitoring row expands inline (reusing `DataDetail`), with a "View Full Context" button to navigate to `MonitoringDetail`.
+
+```mermaid
+sequenceDiagram
+    participant User
+    participant ManageData
+    participant DataFilters
+    participant ManageDataTable
+    participant API
+
+    User->>DataFilters: Select Registration Form
+    DataFilters-->>ManageData: Updates selectedForm (store)
+    ManageData->>ManageDataTable: Renders with viewMode="registration"
+    ManageDataTable->>API: GET /form-data/{selectedForm}/
+    API-->>ManageDataTable: Registration data
+
+    User->>DataFilters: Select Monitoring Form from View Mode dropdown
+    DataFilters-->>ManageData: onViewModeChange(monitoringFormId)
+    ManageData->>ManageDataTable: Renders with viewMode={monitoringFormId}
+    ManageDataTable->>API: GET /form-data/{monitoringFormId}/
+    API-->>ManageDataTable: Monitoring data (with parent_name, parent_id, parent_form_id)
+    ManageDataTable-->>User: Monitoring columns + expandable rows
+```
+
+---
+
+## 3. Requirements
+
+### User Acceptance Criteria
+- [ ] View mode dropdown appears when a registration form with monitoring forms is selected
+- [ ] Dropdown is hidden when selected form has no monitoring forms
+- [ ] Selecting a monitoring form shows monitoring submissions in the table
+- [ ] Table columns adapt based on view mode (registration vs monitoring)
+- [ ] Registration view: Click row navigates to MonitoringDetail page (current behavior)
+- [ ] Monitoring view: Click row expands inline to show data details
+- [ ] Monitoring view: "View Full Context" button navigates to parent's MonitoringDetail
+- [ ] Existing filters (search, date range, administration) work with monitoring view
+- [ ] View mode resets to "Registration" when changing the form dropdown
+
+### Technical Acceptance Criteria
+- [ ] Backend returns `parent_name`, `parent_id`, `parent_form_id` for monitoring data via `ListFormDataSerializer`
+- [ ] Registration data returns `null` for these fields
+- [ ] Backend tests pass for new serializer fields
+- [ ] Frontend linting passes
+- [ ] All existing tests continue to pass
+
+---
+
+## 4. Backend Implementation
+
+### Data Model Changes
+
+No model changes. Serializer-only additions.
+
+### Modified Serializer
+
+**File**: [`serializers.py`](/backend/api/v1/v1_data/serializers.py#L388-L475)
+
+| Serializer | Change | Reason |
+|------------|--------|--------|
+| `ListFormDataSerializer` | Add `parent_name`, `parent_id`, `parent_form_id` SerializerMethodFields | Link monitoring data to parent registration datapoint |
+
+```python
+# New fields to add after total_children (line ~397)
+parent_name = serializers.SerializerMethodField()
+parent_id = serializers.SerializerMethodField()
+parent_form_id = serializers.SerializerMethodField()
+
+def get_parent_name(self, instance: FormData):
+    return instance.parent.name if instance.parent else None
+
+def get_parent_id(self, instance: FormData):
+    return instance.parent.id if instance.parent else None
+
+def get_parent_form_id(self, instance: FormData):
+    return instance.parent.form_id if instance.parent else None
+```
+
+Add to `Meta.fields`: `"parent_name"`, `"parent_id"`, `"parent_form_id"`
+
+### API Response (monitoring form data)
+
+```json
+{
+  "id": 42,
+  "name": "Monitoring Record 1",
+  "form": 5,
+  "administration": "Province - District",
+  "created_by": "Jane Doe",
+  "created": "20 Jun 2024",
+  "submitter": "device-123",
+  "parent_name": "School Alpha",
+  "parent_id": 10,
+  "parent_form_id": 3
+}
+```
+
+For registration data: `parent_name`, `parent_id`, `parent_form_id` will all be `null`.
+
+### N+1 Query Note
+
+`FormData.parent` is a FK. Django will auto-query each parent unless `select_related("parent")` is applied in the queryset. Check the view's queryset — if it already uses `select_related`, no change needed; otherwise add `select_related("parent")` to avoid N+1 queries.
+
+---
+
+## 5. Frontend Implementation
+
+### State Management
+
+**File**: [`ManageData.jsx`](/frontend/src/pages/manage-data/ManageData.jsx)
+
+- Add `viewMode` state (default: `"registration"`).
+- Add `handleViewModeChange` handler that sets `viewMode` and clears `selectedRowKeys`.
+- Pass `viewMode` + `onViewModeChange` to `DataFilters`.
+- Pass `viewMode` to `ManageDataTable`.
+
+### DataFilters — View Mode Dropdown
+
+**File**: [`DataFilters.js`](/frontend/src/components/filters/DataFilters.js)
+
+Key insight: **`childForms` is already computed** at line 70-72 via `allForms.filter(f => f?.content?.parent === selectedForm)`. This is exactly the monitoring forms list.
+
+Changes:
+- Accept new props: `viewMode`, `onViewModeChange`.
+- Build `viewModeOptions` from `childForms`: `[{value: "registration", label: "Registration"}, ...childForms mapped]`.
+- Render a `<Select>` next to `<FormDropdown>` when `childForms.length > 0`.
+- Add `useEffect` to reset `viewMode` to `"registration"` when `selectedForm` changes.
+
+### ManageDataTable — Conditional Rendering
+
+**File**: [`ManageDataTable.jsx`](/frontend/src/pages/manage-data/components/ManageDataTable.jsx)
+
+Changes:
+- Accept `viewMode` prop.
+- Derive `isMonitoringView = viewMode !== "registration"`.
+- **Fetch logic**: Use `viewMode` as the `formId` when `isMonitoringView`, otherwise use existing `selectedForm`.
+- **Registration columns** (current behavior, extracted into `registrationColumns`).
+- **Monitoring columns**: Submission Date, Datapoint (`parent_name`), Channel (`submitter`), User, Region, Expand column — pattern copied from [`MonitoringDetail.jsx` columns](/frontend/src/pages/manage-data/MonitoringDetail.jsx#L135-L163).
+- **Expandable config**: Reuse exact pattern from [`MonitoringDetail.jsx` expandable](/frontend/src/pages/manage-data/MonitoringDetail.jsx#L382-L413) — `DataDetail` in expanded row, circle expand icons, `expandRowByClick`.
+- **Sort default**: `"created"` for monitoring view, `"latest_activity"` for registration.
+- Add `useEffect` to reset page/sort when `viewMode` changes.
+
+### DataDetail — "View Full Context" Button
+
+**File**: [`DataDetail.jsx`](/frontend/src/pages/manage-data/DataDetail.jsx)
+
+- Accept optional `goToParentContext` prop.
+- Render a "View Full Context" `<Button type="link">` in the action buttons area when the prop is provided.
+- Navigation target: `/control-center/data/{parent_form_id}/monitoring/{parent_id}?form_id={viewMode}`
+
+### UI Mockup
+
+```text
+┌──────────────────────────────────────────────────────────────────────────┐
+│ Form: [Household Survey ▼]   View: [Registration ▼]    [+ Add New]     │
+│                                    ├─ Registration                     │
+│                                    ├─ Monthly Check                    │
+│                                    └─ Quarterly Visit                  │
+├──────────────────────────────────────────────────────────────────────────┤
+│ When "Monthly Check" selected:                                         │
+│ Submission Date │ Datapoint      │ Channel │ User │ Region             │
+├──────────────────────────────────────────────────────────────────────────┤
+│ ▶ 2024-06-20    │ School Alpha   │ Mobile  │ John │ District A         │
+│ ▼ 2024-06-18    │ School Beta    │ Web     │ Jane │ District B         │
+│   ┌──────────────────────────────────────────────────────────────┐     │
+│   │ [View Full Context]  [Edit]  [Delete]                       │     │
+│   │ Question 1: Answer 1                                        │     │
+│   │ Question 2: Answer 2                                        │     │
+│   └──────────────────────────────────────────────────────────────┘     │
+│ ▶ 2024-06-15    │ School Gamma   │ Mobile  │ John │ District A         │
+└──────────────────────────────────────────────────────────────────────────┘
+```
+
+---
+
+## 6. UI Text / Translations
+
+**File**: [`ui-text.js`](/frontend/src/lib/ui-text.js)
+
+**Already existing keys** (no changes needed):
+- `channelCol`, `mobileAppText`, `webformText`, `lastUpdatedCol`, `nameCol`, `userCol`, `regionCol`
+
+**New keys to add**:
+
+| Key | English Value |
+|-----|---------------|
+| `registrationView` | `"Registration"` |
+| `selectViewMode` | `"Select View"` |
+| `submissionDateCol` | `"Submission Date"` |
+| `datapointCol` | `"Datapoint"` |
+| `viewFullContext` | `"View Full Context"` |
+
+---
+
+## 7. Compatibility & Migration
+
+### Backward Compatibility
+- [x] Existing API consumers unaffected (fields added, none removed)
+- [x] Existing data preserved
+- [x] No database migration needed
+
+### Mobile App Impact
+- [x] Sync endpoints unaffected
+- [x] No SQLite schema changes
+
+---
+
+## 8. Security Considerations
+
+- [x] No new attack vectors introduced
+- [x] Permissions remain identical — users can only access forms they have roles for
+- [x] The monitoring form data endpoint already enforces the same auth as registration
+
+---
+
+## 9. Testing & Verification
+
+### Automated Tests
+
+**Backend**: New test file `tests_parent_fields.py` in `backend/api/v1/v1_data/tests/`:
+- Test monitoring form data includes `parent_name`, `parent_id`, `parent_form_id`
+- Test registration form data returns `null` for parent fields
+
+Run: `./dc.sh exec backend python manage.py test api.v1.v1_data.tests`
+
+**Frontend**: `cd frontend && CI=true npx react-scripts test --watchAll=false`
+
+### Manual Verification
+1. Open Manage Data page
+2. Select a Registration Form that has monitoring forms
+3. Verify "View" dropdown appears with Registration + monitoring form options
+4. Switch to a monitoring form — verify columns change
+5. Expand a row — verify DataDetail renders inline
+6. Click "View Full Context" — verify navigation to MonitoringDetail
+7. Switch form dropdown — verify view mode resets to Registration
+8. Apply search/date/administration filters in monitoring view
+
+---
+
+## 10. Epic & Ballpark Estimation
+
+- Confidence Level: High
+- Dependencies: None
+
+| Task ID | Component & Description | Est. Hours (Min - Max) | Priority |
+|---------|-------------------------|------------------------|----------|
+| T-001 | Backend: Add parent fields to `ListFormDataSerializer` + `select_related` | 0.5h - 1h | Must Have |
+| T-002 | Backend: Add tests for parent serializer fields | 0.5h - 1h | Must Have |
+| T-003 | Frontend: `ManageData.jsx` — add `viewMode` state + pass props | 0.25h - 0.5h | Must Have |
+| T-004 | Frontend: `DataFilters.js` — add View Mode dropdown | 0.5h - 1h | Must Have |
+| T-005 | Frontend: `ManageDataTable.jsx` — conditional columns, fetch, expandable rows | 1h - 2h | Must Have |
+| T-006 | Frontend: `DataDetail.jsx` — add "View Full Context" button | 0.25h - 0.5h | Must Have |
+| T-007 | Frontend: `ui-text.js` — add 5 new translation keys | 0.15h - 0.25h | Must Have |
+| T-008 | Testing & verification (manual + lint) | 0.5h - 1h | Must Have |
+| **Total** | | **3.5h - 7h** | |
+
+---
+
+## 11. Decision Log
+
+### D-1: Row Click Behavior for Monitoring View
+**Options Considered**:
+1. Navigate directly to `MonitoringDetail` (like registration view)
+2. Expand inline with `DataDetail` + "View Full Context" button
+**Decision**: Option 2
+**Rationale**: Matches existing pattern in `MonitoringDetail.jsx` (line 382-413), enables quick scanning without page navigation, provides escape hatch via button.
+
+### D-2: Reuse Existing `childForms` Computation
+**Decision**: Leverage `DataFilters.js` line 70-72's existing `childForms` memo instead of duplicating form filtering logic.
+**Rationale**: DRY — the monitoring forms list is already correctly computed from `allForms.filter(f => f?.content?.parent === selectedForm)`.
+
+---
+
+## 12. Open Questions & References
+- [ ] Verify `select_related("parent")` is needed in the view queryset to prevent N+1 queries
+- [ ] Verify `DataDetail` edit/delete callbacks function properly in the inline expansion context
+- Related issue: #267

--- a/frontend/src/components/filters/DataFilters.js
+++ b/frontend/src/components/filters/DataFilters.js
@@ -1,4 +1,4 @@
-import React, { useState, useMemo, useCallback } from "react";
+import React, { useState, useEffect, useMemo, useCallback } from "react";
 import "./style.scss";
 import {
   Row,
@@ -12,6 +12,7 @@ import {
   Radio,
   Input,
   DatePicker,
+  Select,
 } from "antd";
 import { useLocation, useNavigate, Link } from "react-router-dom";
 import AdministrationDropdown from "./AdministrationDropdown";
@@ -42,6 +43,8 @@ const DataFilters = ({
   selectedRowKeys = [],
   search = "",
   onSearchChange = () => {},
+  viewMode = "registration",
+  onViewModeChange = () => {},
 }) => {
   const authUser = store.useState((s) => s.user);
   const selectedForm = store.useState((s) => s.selectedForm);
@@ -70,6 +73,28 @@ const DataFilters = ({
   const childForms = useMemo(() => {
     return allForms?.filter((f) => f?.content?.parent === selectedForm);
   }, [selectedForm, allForms]);
+
+  const viewModeOptions = useMemo(() => {
+    const options = [
+      {
+        value: "registration",
+        label: text.registrationView || "Registration",
+      },
+    ];
+    (childForms || []).forEach((f) => {
+      options.push({
+        value: f.id,
+        label: f.name || f.content?.name || `${f.id}`,
+      });
+    });
+    return options;
+  }, [childForms, text.registrationView]);
+
+  useEffect(() => {
+    if (viewMode !== "registration") {
+      onViewModeChange("registration");
+    }
+  }, [selectedForm]); // eslint-disable-line react-hooks/exhaustive-deps
 
   const selectedAdm = takeRight(administration, 1)[0];
 
@@ -341,6 +366,15 @@ const DataFilters = ({
               width="100%"
               style={{ minWidth: 300 }}
             />
+            {childForms?.length > 0 && (
+              <Select
+                value={viewMode}
+                onChange={onViewModeChange}
+                options={viewModeOptions}
+                style={{ minWidth: 200 }}
+                placeholder={text.selectViewMode || "Select View"}
+              />
+            )}
             {/* <AdvancedFiltersButton /> */}
           </Space>
         </Col>

--- a/frontend/src/lib/ui-text.js
+++ b/frontend/src/lib/ui-text.js
@@ -1043,6 +1043,11 @@ const uiText = {
     regionCol: "Region",
     mobileAppText: "Mobile App",
     webformText: "Webform",
+    registrationView: "Registration",
+    selectViewMode: "Select View",
+    submissionDateCol: "Submission Date",
+    datapointCol: "Datapoint",
+    viewFullContext: "View Full Context",
     manageRoles: "Manage Roles",
     manageRoleText: (
       <Fragment>

--- a/frontend/src/pages/manage-data/DataDetail.jsx
+++ b/frontend/src/pages/manage-data/DataDetail.jsx
@@ -45,9 +45,14 @@ const DataDetail = ({
   const { notify } = useNotification();
   const {
     language,
-    forms: allForms,
+    allForms: rawAllForms,
+    forms: rawForms,
     user: authUser,
   } = store.useState((s) => s);
+  const allForms = useMemo(
+    () => rawAllForms || rawForms || [],
+    [rawAllForms, rawForms]
+  );
   const { active: activeLang } = language;
   const text = useMemo(() => {
     return uiText[activeLang];
@@ -58,8 +63,14 @@ const DataDetail = ({
 
   const questionGroups = useMemo(() => {
     const formList = allForms || [];
-    return formList?.find((f) => f.id === record?.form)?.content
-      ?.question_group;
+    const targetFormId = record?.form?.id || record?.form;
+    const numericFormId =
+      typeof targetFormId === "number"
+        ? targetFormId
+        : parseInt(targetFormId, 10);
+    return formList?.find(
+      (f) => f.id === targetFormId || f.id === numericFormId
+    )?.content?.question_group;
   }, [record?.form, allForms]);
 
   const updateCell = (key, parentId, value) => {
@@ -287,7 +298,7 @@ const DataDetail = ({
     }
 
     // Show all questions from form definition, merging with existing answers
-    if (!questionGroups?.length || !dataset.length) {
+    if (!questionGroups?.length) {
       return dataset;
     }
 

--- a/frontend/src/pages/manage-data/DataDetail.jsx
+++ b/frontend/src/pages/manage-data/DataDetail.jsx
@@ -6,7 +6,11 @@ import React, {
   useState,
 } from "react";
 import { Table, Button, Space, Spin, Alert, Row, Col, Switch } from "antd";
-import { LoadingOutlined, HistoryOutlined } from "@ant-design/icons";
+import {
+  LoadingOutlined,
+  HistoryOutlined,
+  LinkOutlined,
+} from "@ant-design/icons";
 import { EditableCell } from "../../components";
 import {
   api,
@@ -30,6 +34,7 @@ const DataDetail = ({
   setEditedRecord,
   isPublic = false,
   isFullScreen = false,
+  goToParentContext = null,
 }) => {
   const [dataset, setDataset] = useState([]);
   const [loading, setLoading] = useState(false);
@@ -469,6 +474,15 @@ const DataDetail = ({
         <Row type="flex" justify="space-between" align="middle" gutter={16}>
           <Col>
             <Space>
+              {goToParentContext && (
+                <Button
+                  type="link"
+                  icon={<LinkOutlined />}
+                  onClick={goToParentContext}
+                >
+                  {text.viewFullContext}
+                </Button>
+              )}
               <Switch
                 checked={isAllQuestions}
                 onChange={(checked) => setIsAllQuestions(checked)}

--- a/frontend/src/pages/manage-data/ManageData.jsx
+++ b/frontend/src/pages/manage-data/ManageData.jsx
@@ -14,6 +14,7 @@ const ManageData = () => {
   const [selectedRowKeys, setSelectedRowKeys] = useState([]);
   const [activeTab, setActiveTab] = useState("data-list");
   const [search, setSearch] = useState("");
+  const [viewMode, setViewMode] = useState("registration");
 
   const { language } = store.useState((s) => s);
   const { active: activeLang } = language;
@@ -24,6 +25,11 @@ const ManageData = () => {
   const formIdFromUrl = new URLSearchParams(window.location.search).get(
     "form_id"
   );
+
+  const handleViewModeChange = (value) => {
+    setViewMode(value);
+    setSelectedRowKeys([]);
+  };
 
   return (
     <div id="manageData">
@@ -57,6 +63,8 @@ const ManageData = () => {
             selectedRowKeys={selectedRowKeys}
             search={search}
             onSearchChange={setSearch}
+            viewMode={viewMode}
+            onViewModeChange={handleViewModeChange}
           />
           <Divider style={{ marginBottom: 8 }} />
           <div
@@ -85,6 +93,7 @@ const ManageData = () => {
                     selectedRowKeys,
                     setSelectedRowKeys,
                     search,
+                    viewMode,
                   }}
                 />
               </TabPane>

--- a/frontend/src/pages/manage-data/components/ManageDataTable.jsx
+++ b/frontend/src/pages/manage-data/components/ManageDataTable.jsx
@@ -1,16 +1,30 @@
 import React, { useState, useEffect, useMemo, useCallback } from "react";
-import { Table, ConfigProvider, Empty } from "antd";
+import {
+  Table,
+  ConfigProvider,
+  Empty,
+  Modal,
+  Tag,
+  Tooltip,
+  Button,
+  Row,
+  Col,
+} from "antd";
 import { useNavigate } from "react-router-dom";
 import { isEmpty, union, xor, without } from "lodash";
+import { LeftCircleOutlined, DownCircleOutlined } from "@ant-design/icons";
 
 import { api, store, uiText } from "../../../lib";
 import { generateAdvanceFilterURL } from "../../../util/filter";
+import { useNotification } from "../../../util/hooks";
+import DataDetail from "../DataDetail";
 
 const ManageDataTable = ({
   selectedRowKeys,
   setSelectedRowKeys,
   formIdFromUrl = null,
   search = "",
+  viewMode = "registration",
 }) => {
   const [loading, setLoading] = useState(false);
   const [dataset, setDataset] = useState([]);
@@ -20,8 +34,14 @@ const ManageDataTable = ({
   const [activeFilter, setActiveFilter] = useState(null);
   const [sortBy, setSortBy] = useState("latest_activity");
   const [sortType, setSortType] = useState("descend");
+  const [editedRecord, setEditedRecord] = useState({});
+  const [deleteData, setDeleteData] = useState(null);
+  const [deleting, setDeleting] = useState(false);
 
   const navigate = useNavigate();
+  const { notify } = useNotification();
+
+  const isMonitoringView = viewMode !== "registration";
 
   const { administration, selectedForm, user } = store.useState(
     (state) => state
@@ -39,6 +59,44 @@ const ManageDataTable = ({
     navigate(`/control-center/data/${selectedForm}/monitoring/${record.id}`);
   };
 
+  const goToParentContext = useCallback(
+    (record) => {
+      if (record?.parent_form_id && record?.parent_id) {
+        navigate(
+          `/control-center/data/${record.parent_form_id}/monitoring/${record.parent_id}?form_id=${viewMode}`
+        );
+      }
+    },
+    [navigate, viewMode]
+  );
+
+  const handleDeleteData = () => {
+    if (deleteData?.id) {
+      setDeleting(true);
+      api
+        .delete(`data/${deleteData.id}`)
+        .then(() => {
+          notify({
+            type: "success",
+            message: `${deleteData.name} deleted`,
+          });
+          setDataset(dataset.filter((d) => d.id !== deleteData.id));
+          setDeleteData(null);
+          setTotalCount((prev) => Math.max(0, prev - 1));
+        })
+        .catch((err) => {
+          notify({
+            type: "error",
+            message: "Could not delete datapoint",
+          });
+          console.error(err?.response);
+        })
+        .finally(() => {
+          setDeleting(false);
+        });
+    }
+  };
+
   const selectedAdministration = useMemo(() => {
     return administration?.[administration.length - 1];
   }, [administration]);
@@ -52,7 +110,8 @@ const ManageDataTable = ({
 
   const handleChange = (e, _, sorter) => {
     const newPage = e.current;
-    const newSortBy = sorter?.field || "latest_activity";
+    const defaultSortField = isMonitoringView ? "created" : "latest_activity";
+    const newSortBy = sorter?.field || defaultSortField;
     const newSortType = sorter?.order || null;
 
     const sortChanged = sortBy !== newSortBy || sortType !== newSortType;
@@ -106,8 +165,8 @@ const ManageDataTable = ({
   ]);
 
   const fetchData = useCallback(() => {
-    const formId = formIdFromUrl || selectedForm;
-    if (formIdFromUrl) {
+    const formId = isMonitoringView ? viewMode : formIdFromUrl || selectedForm;
+    if (formIdFromUrl && !isMonitoringView) {
       store.update((s) => {
         s.selectedForm = parseInt(formIdFromUrl, 10);
       });
@@ -164,6 +223,8 @@ const ManageDataTable = ({
     search,
     sortBy,
     sortType,
+    isMonitoringView,
+    viewMode,
   ]);
 
   useEffect(() => {
@@ -198,6 +259,153 @@ const ManageDataTable = ({
     setUpdateRecord(true);
   }, [dateRange]);
 
+  useEffect(() => {
+    setCurrentPage(1);
+    setSortBy(isMonitoringView ? "created" : "latest_activity");
+    setSortType("descend");
+    setUpdateRecord(true);
+    setSelectedRowKeys([]);
+  }, [viewMode]); // eslint-disable-line react-hooks/exhaustive-deps
+
+  const registrationColumns = useMemo(
+    () => [
+      {
+        title: text.recentActivityCol,
+        dataIndex: "latest_activity",
+        key: "latest_activity",
+        width: 210,
+        sorter: true,
+        sortDirections: ["descend", "ascend"],
+        sortOrder: sortBy === "latest_activity" ? sortType : null,
+        render: (cell, row) => {
+          const displayDate = cell || row.updated || row.created;
+          const source = row.latest_activity_source || text.initialRegistration;
+          return (
+            <div>
+              <div>{displayDate}</div>
+              <div style={{ fontSize: 12, color: "#888" }}>{source}</div>
+            </div>
+          );
+        },
+        onCell: (record) => ({
+          onClick: () => goToMonitoring(record),
+        }),
+      },
+      {
+        title: text.nameCol,
+        dataIndex: "name",
+        key: "name",
+        filtered: true,
+        onFilter: (value, filters) =>
+          filters.name.toLowerCase().includes(value.toLowerCase()),
+        onCell: (record) => ({
+          onClick: () => goToMonitoring(record),
+        }),
+      },
+      {
+        title: text.userCol,
+        dataIndex: "created_by",
+        onCell: (record) => ({
+          onClick: () => goToMonitoring(record),
+        }),
+      },
+      {
+        title: text.regionCol,
+        dataIndex: "administration",
+        onCell: (record) => ({
+          onClick: () => goToMonitoring(record),
+        }),
+      },
+      {
+        title: text.totalMonitoring,
+        dataIndex: "total_children",
+        width: 120,
+        sorter: true,
+        sortDirections: ["descend", "ascend"],
+        sortOrder: sortBy === "total_children" ? sortType : null,
+        onCell: (record) => ({
+          onClick: () => goToMonitoring(record),
+        }),
+      },
+    ],
+    [text, sortBy, sortType, selectedForm] // eslint-disable-line react-hooks/exhaustive-deps
+  );
+
+  const monitoringColumns = useMemo(
+    () => [
+      {
+        title: text.submissionDateCol || "Submission Date",
+        dataIndex: "created",
+        key: "created",
+        sorter: true,
+        sortDirections: ["descend", "ascend"],
+        sortOrder: sortBy === "created" ? sortType : null,
+        render: (cell, row) => cell || row.updated,
+      },
+      {
+        title: text.datapointCol || "Datapoint",
+        dataIndex: "parent_name",
+        key: "parent_name",
+      },
+      {
+        title: text.channelCol || "Channel",
+        dataIndex: "submitter",
+        key: "submitter",
+        render: (submitter) =>
+          submitter ? (
+            <Tooltip title={submitter}>
+              <Tag color="green">{text.mobileAppText}</Tag>
+            </Tooltip>
+          ) : (
+            <Tag color="blue">{text.webformText}</Tag>
+          ),
+      },
+      {
+        title: text.userCol || "User",
+        dataIndex: "created_by",
+        key: "created_by",
+      },
+      {
+        title: text.regionCol || "Region",
+        dataIndex: "administration",
+        key: "administration",
+      },
+      Table.EXPAND_COLUMN,
+    ],
+    [text, sortBy, sortType]
+  );
+
+  const columns = isMonitoringView ? monitoringColumns : registrationColumns;
+
+  const expandableConfig = isMonitoringView
+    ? {
+        expandedRowRender: (record) => (
+          <DataDetail
+            record={record}
+            updater={() => setUpdateRecord(true)}
+            updateRecord={updateRecord}
+            setDeleteData={setDeleteData}
+            editedRecord={editedRecord}
+            setEditedRecord={setEditedRecord}
+            goToParentContext={() => goToParentContext(record)}
+          />
+        ),
+        expandIcon: ({ expanded, onExpand, record }) =>
+          expanded ? (
+            <DownCircleOutlined
+              onClick={(e) => onExpand(record, e)}
+              style={{ color: "#1651B6", fontSize: "19px" }}
+            />
+          ) : (
+            <LeftCircleOutlined
+              onClick={(e) => onExpand(record, e)}
+              style={{ color: "#1651B6", fontSize: "19px" }}
+            />
+          ),
+        expandRowByClick: true,
+      }
+    : null;
+
   return (
     <div>
       <ConfigProvider
@@ -210,67 +418,7 @@ const ManageDataTable = ({
         )}
       >
         <Table
-          columns={[
-            {
-              title: text.recentActivityCol,
-              dataIndex: "latest_activity",
-              key: "latest_activity",
-              width: 210,
-              sorter: true,
-              sortDirections: ["descend", "ascend"],
-              sortOrder: sortBy === "latest_activity" ? sortType : null,
-              render: (cell, row) => {
-                const displayDate = cell || row.updated || row.created;
-                const source =
-                  row.latest_activity_source || text.initialRegistration;
-                return (
-                  <div>
-                    <div>{displayDate}</div>
-                    <div style={{ fontSize: 12, color: "#888" }}>{source}</div>
-                  </div>
-                );
-              },
-              onCell: (record) => ({
-                onClick: () => goToMonitoring(record),
-              }),
-            },
-            {
-              title: text.nameCol,
-              dataIndex: "name",
-              key: "name",
-              filtered: true,
-              onFilter: (value, filters) =>
-                filters.name.toLowerCase().includes(value.toLowerCase()),
-              onCell: (record) => ({
-                onClick: () => goToMonitoring(record),
-              }),
-            },
-            {
-              title: text.userCol,
-              dataIndex: "created_by",
-              onCell: (record) => ({
-                onClick: () => goToMonitoring(record),
-              }),
-            },
-            {
-              title: text.regionCol,
-              dataIndex: "administration",
-              onCell: (record) => ({
-                onClick: () => goToMonitoring(record),
-              }),
-            },
-            {
-              title: text.totalMonitoring,
-              dataIndex: "total_children",
-              width: 120,
-              sorter: true,
-              sortDirections: ["descend", "ascend"],
-              sortOrder: sortBy === "total_children" ? sortType : null,
-              onCell: (record) => ({
-                onClick: () => goToMonitoring(record),
-              }),
-            },
-          ]}
+          columns={columns}
           dataSource={dataset}
           loading={loading}
           onChange={handleChange}
@@ -282,15 +430,61 @@ const ManageDataTable = ({
             showTotal: (total, range) =>
               `Results: ${range[0]} - ${range[1]} of ${total} data`,
           }}
-          rowClassName="row-normal sticky"
+          rowClassName={(record) => {
+            if (!isMonitoringView) {
+              return "row-normal sticky";
+            }
+            const rowEdited = editedRecord[record.id]
+              ? "row-edited"
+              : "row-normal sticky";
+            return `expandable-row ${rowEdited}`;
+          }}
           rowKey="id"
           rowSelection={{
             selectedRowKeys: selectedRowKeys,
             onSelect: onSelectTableRow,
             onSelectAll: onSelectAllTableRow,
           }}
+          expandable={expandableConfig}
         />
       </ConfigProvider>
+      <Modal
+        open={Boolean(deleteData)}
+        onCancel={() => setDeleteData(null)}
+        centered
+        width="575px"
+        footer={
+          <Row justify="center" align="middle">
+            <Col span={14}>&nbsp;</Col>
+            <Col span={10}>
+              <Button
+                className="light"
+                disabled={deleting}
+                onClick={() => {
+                  setDeleteData(null);
+                }}
+              >
+                {text.cancelButton}
+              </Button>
+              <Button
+                type="primary"
+                danger
+                loading={deleting}
+                onClick={handleDeleteData}
+              >
+                {text.deleteText}
+              </Button>
+            </Col>
+          </Row>
+        }
+      >
+        <div style={{ textAlign: "center", padding: "20px" }}>
+          <h2>Delete Datapoint?</h2>
+          <p>
+            Are you sure you want to delete <b>{deleteData?.name}</b>?
+          </p>
+        </div>
+      </Modal>
     </div>
   );
 };

--- a/frontend/src/pages/manage-data/style.scss
+++ b/frontend/src/pages/manage-data/style.scss
@@ -4,7 +4,14 @@
   #manageData {
     tr.ant-table-expanded-row:hover > td,
     tr.ant-table-expanded-row > td {
-      padding: 48px 16px 16px;
+      padding: 16px;
+      .button-save {
+        position: relative;
+        top: 0;
+        right: 0;
+        margin-top: 16px;
+        width: 100%;
+      }
     }
     .data-detail {
       height: 450px;


### PR DESCRIPTION
## Summary of Changes
This PR implements **Monitoring Form View Mode** on the Manage Data page (`/control-center/data`), allowing users to toggle between **Registration View** and individual **Monitoring Form Views**, view dedicated monitoring table columns, expand monitoring rows inline, search across parent datapoints and submitters, and jump directly to parent context.

### 🔑 Key Features & Enhancements
1. **View Mode Selection (`DataFilters.js`, `ManageData.jsx`)**:
   - Added a **View Mode** dropdown next to the main Form dropdown.
   - Populates `Registration` view alongside all child monitoring forms associated with the selected registration form.
   - Dynamically hides when a registration form has no child monitoring forms.
2. **Monitoring Table & Inline Expansion (`ManageDataTable.jsx`)**:
   - Custom column layout for monitoring view: **Submission Date** (default DESC), **Datapoint** (parent registration name), **Channel** (`Mobile App` / `Webform`), **User** (submitter), **Region**, and Expand Action (`▶`).
   - Clicking a row expands `DataDetail` inline.
   - Action bar rendered at the bottom of expanded rows featuring a **"View Full Context"** link button navigating to the parent registration datapoint.
3. **Backend API & Search Optimization (`views.py`, `serializers.py`)**:
   - `ListFormDataSerializer` includes `parent_name`, `parent_id`, and `parent_form_id`.
   - Querysets optimized with `select_related("parent__form")` to eliminate N+1 query overhead.
   - `FormDataAddListView` search expanded using `Q` filter to match parent datapoint name (`parent__name`), submission name (`name`), and submitter details (`created_by`).
4. **Automated & QA Testing (`tests_parent_fields.py`, `qa-guide-issue-267.md`)**:
   - 3/3 backend unit tests passing including search by parent registration name.
   - Verified 14 comprehensive QA test cases (TC-001 through TC-014).

---

## 🧪 Verification & Testing Completed
- **Backend Unit Tests**: `./dc.sh exec backend python manage.py test api.v1.v1_data.tests.tests_parent_fields` — **3/3 PASS**
- **Linting & Code Quality**:
  - Backend `flake8 api/v1/v1_data` — **0 errors**
  - Frontend `npx prettier --write src` — **Formatted cleanly**
  - Frontend `npm run lint` — **0 errors**

---

## 🔗 Related References
- **Issue**: `#267`
- **Feature Spec**: `doc/design/MP-001-monitoring-data-view.md`

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1216935273671296